### PR TITLE
Added "Test String" tab to Secure Prepopulate admin.

### DIFF
--- a/secure_prepopulate/secure_prepopulate.admin.inc
+++ b/secure_prepopulate/secure_prepopulate.admin.inc
@@ -57,3 +57,48 @@ function secure_prepopulate_admin_settings_validate(&$form, &$form_state) {
     $form_state['values']['secure_prepopulate_iv'] = encrypt($form_state['values']['secure_prepopulate_iv']);
   }
 }
+
+/**
+ * Test string previewer
+ */
+function secure_prepopulate_preview(&$form_state) {
+  if ($encrypted = $form_state['values']['encrypted']) {
+    $decrypted = urldecode($encrypted);
+    $decrypted = secure_prepopulate_decrypt($decrypted);
+  }
+  
+  $form = array();
+  if (!$encrypted) {
+    $form['intro'] = array(
+      '#type' => 'markup',
+      '#value' => t('To verify the contents of a Secure Prepopulate string produced by Salesforce, enter it below exactly as it would be appended to a URL.'),
+      '#prefix' => '<p>',
+      '#suffix' => '</p>',
+    );
+  }
+  $form['encrypted'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Encrypted'),
+    '#rows' => 3,
+    '#required' => TRUE,
+    '#default_value' => $encrypted,
+  );
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Preview'),
+  );
+  $form['string_output'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Decrypted'),
+    '#rows' => 6,
+    '#attributes' => array('readonly' => '1'),
+    '#value' => print_r($decrypted,true),
+  );
+  return $form;
+}
+
+function secure_prepopulate_preview_submit(&$form, &$form_state) {
+  $is_expired = secure_prepopulate_is_expired($encrypted);
+  drupal_set_message($is_expired ? t('String is expired') : t('String is not expired'));
+  $form_state['rebuild'] = TRUE;
+}

--- a/secure_prepopulate/secure_prepopulate.module
+++ b/secure_prepopulate/secure_prepopulate.module
@@ -17,6 +17,22 @@ function secure_prepopulate_menu() {
     'page arguments' => array('secure_prepopulate_admin_settings'),
     'access arguments' => array('administer secure pre-populate'),
     'file' => 'secure_prepopulate.admin.inc',
+    'type' => MENU_NORMAL_ITEM,
+  );
+  $items['admin/settings/secure-prepopulate/settings'] = array(
+    'title' => t('Settings'),
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+    'weight' => -10,
+  );
+  $items['admin/settings/secure-prepopulate/test'] = array(
+    'title' => t('Test String'),
+    'description' => t('Preview the contents of encrypted strings for testing'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('secure_prepopulate_preview'),
+    'access arguments' => array('administer secure pre-populate'),
+    'file' => 'secure_prepopulate.admin.inc',
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 1,
   );
 
   $items['secure-prepopulate/not-me/%'] = array(


### PR DESCRIPTION
This is a simple additional admin form for testing out the current Secure Prepopulate encryption configuration with actual encrypted strings from Salesforce, so project admins can confirm that triggers are working and/or troubleshoot.
