### PR TITLE
Fixes a jQuery error when % is in the query string. This 'encodes' the s...

### DIFF
--- a/market_source/market_source.js
+++ b/market_source/market_source.js
@@ -17,6 +17,7 @@ Drupal.behaviors.marketSourceInit = function (context) {
       var parsed,
           regex = /([^&=]+)=?([^&]*)/g,
           decode = function (value) {
+            value = encodeURI(value);
             // Regex for replacing addition symbol with a space
             return decodeURIComponent(value.replace(/\+/g, " "));
           },


### PR DESCRIPTION
...tring first to convert the % to %25 so it doesn't break the decodeURI() function.

In reference to jr-ifaw ticket #1190.

We occasionally get a query string for pre-populating donation forms where the mailing id doesn't parse correctly and it output by the token: mailid=%%MAILING_ID%%
SilverPop is unable to fix.

The problem is that when we parse the string with jQuery to pull out the market source, we are using decodeURIComponent() which dies when it hits the %%. My proposed solution is to first use encode URI() on the variable (which converts % to %25), and then decode it. 

This works on my tests and is on the staging site above. I don't think it will create any other problems, or at least I am not seeing any, and its a pretty simple fix.
