### PR TITLE
Add choice to produce static confirmation page so it is cacheable.

### DIFF
--- a/springboard_social/includes/sb_social.admin.inc
+++ b/springboard_social/includes/sb_social.admin.inc
@@ -373,6 +373,18 @@ function sb_social_node_settings($form, $edit, $node) {
     _sb_social_settings_market_source($form, $settings);
   }
 
+  // Whether or not this page should be static so it can be cached.
+  $cached_enabled = variable_get('sb_social_cached_enabled_pages', array());
+  $form['sb_social_cached_enabled'] = array(
+    '#type' => 'checkbox',
+    '#name' => 'sb_social_cached_enabled',
+    '#title' => t('Enable ability to cache confirmation page'),
+    '#default_value' => isset($cached_enabled[$node->nid]) ? $cached_enabled[$node->nid] : FALSE,
+    '#description' => t('Should all users receive the same exact page so it can
+      be cached?  If this happens, Springboard Social will not be able to track
+      a specific user\'s social influence.'),
+  );
+
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save'),
@@ -412,6 +424,9 @@ function sb_social_settings_submit($form, $form_state) {
         'data' => $data,
     );
     sb_social_settings_save($record, $form_state['values']);
+    $cached_pages = variable_get('sb_social_cached_enabled_pages', array());
+    $cached_pages[$form_state['values']['id']] = $form_state['values']['sb_social_cached_enabled'];
+    variable_set('sb_social_cached_enabled_pages', $cached_pages);
   }
 }
 

--- a/springboard_social/sb_social.module
+++ b/springboard_social/sb_social.module
@@ -268,9 +268,10 @@ function sb_social_init() {
 
     }
   }
-  // stash cookie payload in js
+  // Stash cookie payload in js, except when pages is cached enabled.
   // TODO: this should probably live somewhere else.
-   if (!empty($_COOKIE['sb_social_event_submission'])) {
+  $cached_pages = variable_get('sb_social_cached_enabled_pages', array());
+   if (!empty($_COOKIE['sb_social_event_submission']) && (empty($id) || !isset($cached_pages[$id]) || !$cached_pages[$id]))) {
      $data = explode("::", $_COOKIE['sb_social_event_submission']);
      drupal_add_js(array('sb_social' => array(
        'uid' => $data[0],
@@ -390,6 +391,30 @@ function sb_social_webform_submission_insert($node, $submission) {
       $mail = $submission->data[$component->cid]['value'][0];
       _sb_social_set_tracking_cookie($submission->uid, $mail, $submission->sid);
     }
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function sb_social_form_alter(&$form, &$form_state, $form_id) {
+  if (strstr($form_id, 'webform_client_form_')) {
+    // Add our own custom submit callback.
+    $form['#submit'][] = 'sb_social_webform_client_form_submit';
+  }
+}
+
+/**
+ * Submit callback for webform client forms
+ */
+function sb_social_webform_client_form_submit($form, &$form_state) {
+  // Modify the redirect to remove the sid as a unique identifier when the
+  // webform requests this particular form should have cachable confirmation
+  // pages.
+  $cached_pages = variable_get('sb_social_cached_enabled_pages', array());
+  $webform_id = isset($form_state['complete form']['#node']) ? $form_state['complete form']['#node']->nid : 0;
+  if (isset($cached_pages[$webform_id]) && $cached_pages[$webform_id]) {
+    unset($form_state['redirect'][1]['query']['sid']);
   }
 }
 

--- a/springboard_social/tests/sb_social.test
+++ b/springboard_social/tests/sb_social.test
@@ -120,6 +120,7 @@ class SpringboardSocialFunctionalTest extends FundraiserSetup {
     $this->assertFieldByName('fb_title', '%title', t('Facebook Title field present with correct default'));
     $this->assertFieldByName('fb_description', '%teaser', t('Facebook Description field present with correct default'));
     $this->assertFieldByName('twitter_message', '%title', t('Twitter message field present with correct default'));
+    $this->assertFieldByName('sb_social_cached_enabled', '', t('Cache confirmation page toggle exists.'));
 
     // Confirm form elements present for all expected MS fields
     $this->assertFieldByName('ms', '', t('Default Market Source ms field available'));
@@ -156,6 +157,14 @@ class SpringboardSocialFunctionalTest extends FundraiserSetup {
       'submitted[billing_information][city]' => 'Greensboro',
     );
     $this->submitDonation($node->nid, $donation_settings);
+    $this->assertTrue(strstr($this->getUrl(), 'sid='));
+
+    // Check confirmation page cache.
+    $this->drupalGet('node/' . $node->nid . '/share_settings');
+    $this->drupalPost(NULL, array('sb_social_cached_enabled' => TRUE), 'Save');
+    $donation_settings['submitted[donor_information][mail]'] = 'example2@example.com';
+    $this->submitDonation($node->nid, $donation_settings);
+    $this->assertFalse(strstr($this->getUrl(), 'sid='));
 
       // node tokens
 


### PR DESCRIPTION
This injects itself during form building to format the redirect URL so each submission will be unique.  It adds an option when setting up social for that form to make the page "cacheable".  The help text warns that doing so will prevent the ability to track an individual's social influence.
