### PR TITLE
Fixing the output of the fundraiser_submit_message text and padlock icon

### DIFF
--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1186,7 +1186,7 @@ function fundraiser_form_alter(&$form, $form_state, $form_id) {
       $form['#validate'][] = 'fundraiser_webform_validate';
       $form['#submit'][] = 'fundraiser_webform_submit';
       $form['#submit'][] = 'fundraiser_confirmation';
-      $form['submit']['#suffix'] = '<div class="fundraiser_submit_message">' . theme('image', drupal_get_path('module', 'fundraiser') . '/padlock.gif') . t('By clicking SUBMIT DONATION your credit card will be securely processed.') . '</div>';
+      $form['actions']['submit']['#suffix'] = '<div class="fundraiser_submit_message">' . theme('image', drupal_get_path('module', 'fundraiser') . '/padlock.gif') . t('By clicking SUBMIT DONATION your credit card will be securely processed.') . '</div>';
     }
   }
 


### PR DESCRIPTION
Fixing the output of the fundraiser_submit_message text and padlock icon in `fundraiser_form_alter()`.

Webform 6.x-3.0-beta2 changed how the `submit` form element is added to `$form` array. It is now inside `$form['actions']` instead of being set directly on `$form`. Previously, in `fundraiser_form_alter()`, the code attempted to add it to a (nonexistent) `$form['submit']` form element.
