### PR TITLE
add hook to alter confirmation redirect url on donation forms

### DIFF
--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -2112,6 +2112,15 @@ function fundraiser_confirmation($form, &$form_state) {
     $query = $parts['query'] ? ($parts['query'] . '&sid=' . $sid) : ('sid=' . $sid);
     $redirect = array($parts['path'], $query, $parts['fragment']);
   }
+  // perform any last minute alterations to redirect urls required by other modules.
+  // note we're avoiding module_invoke and module_invoke_all() so we can pass
+  // $redirect by reference.
+  foreach (module_implements('fundraiser_confirmation_redirect') as $module) {
+    $function = $module . '_fundraiser_confirmation_redirect';
+    if (function_exists($function)) {
+      $function($redirect, $form, $form_state);
+    }
+  }
 
   $form_state['redirect'] = $redirect;
 }


### PR DESCRIPTION
added hook to fundraiser_confirmation() to permit other modules to modify the confirmation redirect url. This permits 3rd party modules to alter or replace the confirmation page url. Example use case: if a site's confirmation pages are being cached we want to prevent ?sid=<submission id> getting added to the redirect url as this breaks caching.
