### PR TITLE
Add hooks to fundraiser and webform_user to alter profile data before saving

### DIFF
--- a/fundraiser/fundraiser.api.inc
+++ b/fundraiser/fundraiser.api.inc
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * API documentation for fundraiser.
+ */
+
+/**
+ * @param array $updates
+ *   An array of profile fields that will be updated to the database. Fundraiser
+ *   will first delete any existing values, and then write the new ones back. This
+ *   sidesteps the user_save() function and writes directly to the profile_values table
+ * @param string $category
+ *   The profile category that the fields are in
+ */
+function hook_fundraiser_save_profile_alter(&$updates, $category) {
+  // Remove extra white space on profile fields
+  foreach ($updates as $id => $field) {
+    if (is_string($field['data'])) {
+      $updates[$id]['data'] = trim($field['data']);
+    }
+  }
+}

--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1095,7 +1095,7 @@ function fundraiser_form_alter(&$form, $form_state, $form_id) {
       $state_field['#prefix'] = '<div id="zone-select-wrapper">';
       $state_field['#suffix'] = '</div>';
 
-      // preload any fields if the user is logged in and if offline exists, when not in offline mode 
+      // preload any fields if the user is logged in and if offline exists, when not in offline mode
       if (user_is_logged_in() &&
         ( !function_exists('_fundraiser_offline_is_offline') || (function_exists('_fundraiser_offline_is_offline') && !_fundraiser_offline_is_offline()) )
         ) {
@@ -2158,6 +2158,8 @@ function fundraiser_update_user_profile($uid, $nid, $sid) {
           $updates[$row['name']] = $map[$row['name']];
         }
       }
+      // Give us the chance to alter the data before its saved
+      drupal_alter('fundraiser_save_profile', $updates, $cat['name']);
       // save profile
       _fundraiser_profile_save_profile($updates, $update_user, $cat['name']);
     }

--- a/webform_user/webform_user.api.inc
+++ b/webform_user/webform_user.api.inc
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * API documentation for webform_user.
+ */
+
+/**
+ * @param array $updates
+ *   An array of profile fields that will be updated to the database. Webform_user
+ *   will first delete any existing values, and then write the new ones back. This
+ *   sidesteps the user_save() function and writes directly to the profile_values table
+ *
+ *   Array data is in this format:
+ *     $updates[] = array(
+ *       'fid' => $fid,
+ *       'name' => $field_name,
+ *       'type' => $field_type,
+ *       'data' => $data,
+ *      );
+ */
+function hook_webform_user_save_profile_alter(&$updates) {
+  // Remove extra white space on profile fields
+  foreach ($updates as $id => $field) {
+    if (is_string($field['data'])) {
+      $updates[$id]['data'] = trim($field['data']);
+    }
+  }
+}

--- a/webform_user/webform_user.module
+++ b/webform_user/webform_user.module
@@ -458,7 +458,7 @@ function webform_user_mapping_form($form_state, $node) {
         '#type' => 'item',
         '#description' => t($component['name'] . " - (" . $component['type'] . ")"),
       );
-      
+
       $form['mapping']['mandatory'][$cid] = array(
         '#type' => 'item',
         '#description' => $component['mandatory'] ? '<span class="form-required">*</span>' . t('required') :'',
@@ -862,6 +862,8 @@ function _webform_user_save_profile_map($uid, &$map) {
             }
           }
         }
+        // Give us the chance to alter the data before its saved
+        drupal_alter('webform_user_save_profile', $updates);
         // save profile
         _webform_user_profile_save_profile($updates, $user_to_update->uid);
       }


### PR DESCRIPTION
Adding a hook_save_profile to both fundraiser and webform_user just before the user profile values are saved to the DB. Because they are saved directly, there is no way to change or alter them with hook_user. We are using this on IFAW to clean up bad characters in form entries before they are saved to the user profile.
