### PR TITLE
Fundraiser Tickets donation amount reporting

### DIFF
--- a/fundraiser/modules/fundraiser_tickets/fundraiser_tickets.module
+++ b/fundraiser/modules/fundraiser_tickets/fundraiser_tickets.module
@@ -326,9 +326,10 @@ function fundraiser_tickets_fundraiser_commerce_generate_line_items($donation, $
  * Implements hook_fundraiser_donation_success().
  */
 function fundraiser_tickets_fundraiser_donation_success($donation) {
-  // If this donation contains a ticketed donation handle the add-on donation value
+  // If this donation contains a ticketed donation handle the multiplied ticket(s) and add-on donation values
   if (isset($donation->donation['ticket_box']) && is_array($donation->donation['ticket_box']) && count($donation->donation['ticket_box'])){
     $node_wrapper = entity_metadata_wrapper('node', $donation->node);
+    $extra_amount = 0;
 
     // Loop through each of the ticket options looking for the extra donation key
     foreach ($donation->donation['ticket_box'] as $offset => $serialized_value){
@@ -338,13 +339,13 @@ function fundraiser_tickets_fundraiser_donation_success($donation) {
 
       if ($key == 'fundraiser-tickets-extra-donation'){
         // The extra donation amount is stored in the quantity field
-        $amount = $quantity;
-        if ($amount > 0) {
+        $extra_amount = $quantity;
+        if ($extra_amount > 0) {
           // Clone the original donation, only a few values will change
           $extra_donation = clone $donation;
 
           // Set the amount
-          $extra_donation->donation['amount'] = $amount;
+          $extra_donation->donation['amount'] = $extra_amount;
 
           // Important to remove this
           unset($extra_donation->donation['ticket_box']);
@@ -357,6 +358,15 @@ function fundraiser_tickets_fundraiser_donation_success($donation) {
         }
       }
     }
+    
+    // Save only the ticket(s) amount to the main donation object.
+    // At this point, the main donation's order has that amount.
+    $order = commerce_order_load($donation->did);
+    $order_total = commerce_currency_amount_to_decimal(
+      $order->commerce_order_total[LANGUAGE_NONE][0]['amount'],
+      $order->commerce_order_total[LANGUAGE_NONE][0]['currency_code']
+    );
+    $donation->amount = $order_total;
   }
 }
 


### PR DESCRIPTION
t991: Updated fundraiser_tickets_fundraiser_donation_success() logic to ensure the amounts in {fundraiser_donation} total up correctly. If a ticket purchase includes an additional donation, there should be two donation records, one with the ticket(s) amount and one with the extra amount.
