### PR TITLE
6.x 3.x gateway alter

### DIFF
--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1957,7 +1957,7 @@ function fundraiser_order_accept($order_id, $transaction_id, $message = NULL, $a
       auth_code = '%s'
     WHERE
       order_id = %d",
-    $node->gateway, $transaction_id, $auth_code, $order_id);
+    $order->data['gateway'], $transaction_id, $auth_code, $order_id);
 
   // update the uid on the webform submission
   db_query("UPDATE {webform_submissions} SET uid = %d WHERE sid = %d", $order->uid, $webform->sid);

--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1844,6 +1844,7 @@ function fundraiser_webform_submit($form, &$form_state) {
   }
 
   // Store the gateway that was used to make the payment
+  drupal_alter('fundraiser_gateway', $node, $recurs);
   $order->data['gateway'] = $node->gateway;
 
   // cache the cc details stored by the handler.

--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1844,7 +1844,7 @@ function fundraiser_webform_submit($form, &$form_state) {
   }
 
   // Store the gateway that was used to make the payment
-  drupal_alter('fundraiser_gateway', $node, $recurs);
+  drupal_alter('fundraiser_gateway', $node, $form_state, $recurs);
   $order->data['gateway'] = $node->gateway;
 
   // cache the cc details stored by the handler.


### PR DESCRIPTION
Added drupal_alter() to allow changing of the node's gateway at webform submission.

In addition, changed the way the fundraiser_order_accept() function finds the gateway when saving to the fundraiser_webform_order table. It has been loading the webform node, but this is problematic for a multi-gateway setup. Since the gateway has been set on the $order object (in $order->data['gateway']), let's look there instead of looking in the node again. Looking at the node is not a reliable way of finding this, since drupal_alter() only temporarily resets the Gateway ID, and $recurs is not reliable at this point in the code.
