### PR TITLE
SB3 Dashboard SF credentials form encryption bugfix.

### DIFF
--- a/springboard/springboard.module
+++ b/springboard/springboard.module
@@ -396,7 +396,7 @@ function springboard_welcome() {
 /**
  * Validation handler for salesforce configuration form.
  */
-function springboard_welcome_salesforce_validate(&$form, $form_state) {
+function springboard_welcome_salesforce_validate(&$form, &$form_state) {
   // encrypt credentials
   $form_state['values']['salesforce_username'] = encrypt($form_state['values']['salesforce_username']);
   $form_state['values']['salesforce_password'] = encrypt($form_state['values']['salesforce_password']);


### PR DESCRIPTION
When SF creds are entered into the Springboard dashboard, they are saved unencrypted, due to $form_state not being passed in by reference.
