### PR TITLE
update fundraiser_update_amount_webform_component to not overwrite custom ask amounts

### DIFF
--- a/fundraiser/fundraiser.fields.inc
+++ b/fundraiser/fundraiser.fields.inc
@@ -551,7 +551,7 @@ function _fundraiser_update_amount_webform_component($node, $donation_amounts = 
       // if the original default value of the webform component is numeric and isn't a valid option we want to update it with defaults.
       // Otherwise ignore it since clients may customize this. A common example is setting it to 0 or NULL for no default or %get[amount]
       // to set the default from the query string.
-      if (is_numeric($old_value) && !in_array($old_value, $donation_amounts)) {
+      if (is_numeric($old_value) && !array_key_exists($old_value, $donation_amounts)) {
         db_query("UPDATE {webform_component} SET extra = '%s', value = %d WHERE nid = %d AND form_key = 'amount'", $data, $value, $node->nid);
       }
       else {


### PR DESCRIPTION
Because $donation_amounts is a multidimensional array and in_array doesn't work on multidimensional arrays, this hook always overwrites any custom ask amount. This PR uses array_key_exists instead of in_array.
