### PR TITLE
6.x 3.0 dev gs multi currency

### DIFF
--- a/secure_prepopulate/dynamic_gift_strings/dynamic_gift_strings.module
+++ b/secure_prepopulate/dynamic_gift_strings/dynamic_gift_strings.module
@@ -166,8 +166,10 @@ function dynamic_gift_strings_mail($key, &$message, $params) {
  *   An unformatted array of ask amounts.
  * @param $show_other
  *   Flag to indicate whether or not the 'other' amount should be added.
+ * @param $prefix
+ *   Currency prefix.
  */
-function _dynamic_gift_strings_parse_amounts($amounts, $show_other, $nid) {
+function _dynamic_gift_strings_parse_amounts($amounts, $show_other, $nid, $prefix = '$') {
   $amounts = explode('|', $amounts);
   $formatted_amounts = array();
   $all_valid = TRUE;
@@ -180,10 +182,10 @@ function _dynamic_gift_strings_parse_amounts($amounts, $show_other, $nid) {
     }
     // if the number has a decimal, retain it. otherwise format without decimals
     if (is_float($amount + 1)) { // implicit cast hack
-      $formatted_amounts[$amount] = '$' . number_format($amount, 2, '.', ',');
+      $formatted_amounts[$amount] = $prefix . number_format($amount, 2, '.', ',');
     }
     elseif (is_integer($amount + 1)) {
-      $formatted_amounts[$amount] = '$' . number_format($amount, 0, '', ',');
+      $formatted_amounts[$amount] = $prefix . number_format($amount, 0, '', ',');
     }
   }
 

--- a/secure_prepopulate/dynamic_gift_strings/dynamic_gift_strings.module
+++ b/secure_prepopulate/dynamic_gift_strings/dynamic_gift_strings.module
@@ -41,15 +41,30 @@ function dynamic_gift_strings_form_alter(&$form, $form_state, $form_id) {
       if (is_array($_SESSION['dynamic_gift_string_values'][$node->nid])) {
         $gs = $_SESSION['dynamic_gift_string_values'][$node->nid];
 
-        // create an array of amounts to replace the defaults
-        $amounts = _dynamic_gift_strings_parse_amounts($gs['amounts'], $node->show_other_amount, $node->nid);
+        // parse out the form components so we can find the 'amount' field
+        $component_hierarchy = fundraiser_parse_components($node->nid, $node->webform['components']);
+
+        if (module_exists('fundraiser_multi_currency')) {
+          // Get currency field, if it exists.
+          $currency_field =& fundraiser_find_field($form, $component_hierarchy['currency']);
+          $currencies = fundraiser_multi_currency_get_default_currencies();
+
+          if ($currency_field && $currencies) {
+            $prefix = $currencies[$currency_field['#default_value']]['symbol'];
+          }
+
+          // create an array of amounts to replace the defaults
+          $amounts = _dynamic_gift_strings_parse_amounts($gs['amounts'], $node->show_other_amount, $node->nid, $prefix);
+        }
+        else {
+          // create an array of amounts to replace the defaults
+          $amounts = _dynamic_gift_strings_parse_amounts($gs['amounts'], $node->show_other_amount, $node->nid);
+        }
 
         // grab the default
         $default = $gs['default'];
 
-        // parse out the form components so we can find the 'amount' field
-        $component_hierarchy = fundraiser_parse_components($node->nid, $node->webform['components']);
-        $amount_field = & fundraiser_find_field($form, $component_hierarchy['amount']);
+        $amount_field =& fundraiser_find_field($form, $component_hierarchy['amount']);
 
         // make sure we have the field and a good array of amounts
         if ($amount_field && $amounts) {


### PR DESCRIPTION
The dynamic gift string module adds the dollar sign to the gift amounts from the string. This is bad when a site uses multiple currencies. This fix checks for the presence of a currency component on the webform and if fundraiser multi currency is enabled, appends a prefix for the currency.
