### PR TITLE
P2P donations not counting towards personal campaign progress when using Paypal IPN

### DIFF
--- a/salesforce/salesforce_p2p/salesforce_p2p.module
+++ b/salesforce/salesforce_p2p/salesforce_p2p.module
@@ -53,10 +53,7 @@ function salesforce_p2p_salesforce_queue_create_item_alter(&$item) {
   if ($item['module'] == 'salesforce_donation' && $item['delta'] == 'donation') {
 
     $action = db_query("
-      SELECT
-        sa.personal_campaign_nid,
-        sa.campaign_nid,
-        sa.category_nid
+      SELECT sa.personal_campaign_nid
       FROM {fundraiser_donation} fd
       INNER JOIN {springboard_p2p_personal_campaign_action} sa
       ON sa.sid = fd.sid

--- a/springboard_p2p/springboard_p2p.install
+++ b/springboard_p2p/springboard_p2p.install
@@ -141,19 +141,7 @@ function springboard_p2p_schema() {
     ),
   );
 
-  $schema['springboard_p2p_personal_campaign_action'] = springboard_p2p_personal_campaign_action_schema();
-
-  return $schema;
-}
-
-/**
- * The schema definition for the personal campaign action table.
- *
- * @return array
- *   Schema definition.
- */
-function springboard_p2p_personal_campaign_action_schema() {
-  return array(
+  $schema['springboard_p2p_personal_campaign_action'] = array(
     'description' => 'Stores data about a user completing a form for a personal campaign.',
     'fields' => array(
       'category_nid' => array(
@@ -276,6 +264,8 @@ function springboard_p2p_personal_campaign_action_schema() {
       ),
     ),
   );
+
+  return $schema;
 }
 
 /**

--- a/springboard_p2p/springboard_p2p.install
+++ b/springboard_p2p/springboard_p2p.install
@@ -238,6 +238,12 @@ function springboard_p2p_personal_campaign_action_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'status' => array(
+        'description' => 'Boolean indicating whether the action is visible.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
     ),
     'indexes' => array(
       'personal_campaign_nid' => array('personal_campaign_nid'),
@@ -621,4 +627,19 @@ function springboard_p2p_update_7006() {
  */
 function springboard_p2p_update_7007() {
   variable_del('springboard_p2p_base_path');
+}
+
+/**
+ * Adds the status field to personal campaign actions.
+ */
+function springboard_p2p_update_7008() {
+  $status = array(
+    'description' => 'Boolean indicating whether the action is visible.',
+    'type' => 'int',
+    'not null' => TRUE,
+    'default' => 0,
+    'initial' => 1,
+  );
+
+  db_add_field('springboard_p2p_personal_campaign_action', 'status', $status);
 }

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -1957,6 +1957,11 @@ function springboard_p2p_webform_client_form_submit($form, &$form_state) {
       springboard_p2p_update_personal_campaign_submissions_progress($action['personal_campaign_nid']);
     }
 
+    // If this is a webform user action, then it should be marked as visible.
+    // If it's a fundraiser action, it will be marked as visible when
+    // the donation is a success.
+    $action['status'] = ($action['action_type'] == 'fundraiser') ? 0 : 1;
+
     springboard_p2p_save_personal_campaign_action($action);
 
     $form_state['redirect'][1]['query']['p2p_pcid'] = $form_state['values']['springboard_p2p_personal_campaign_action']['personal_campaign_nid'];
@@ -2104,6 +2109,8 @@ function springboard_p2p_fundraiser_donation_success($donation) {
 
     $action['amount'] = $amount * 100;
 
+    // Now that the donation is successful, mark the action as visible.
+    $action['status'] = 1;
     springboard_p2p_save_personal_campaign_action($action, array('sid'));
   }
 }
@@ -2167,7 +2174,7 @@ function springboard_p2p_save_personal_campaign_action($record, $key = NULL) {
  *   An associative array, or FALSE.
  */
 function springboard_p2p_get_personal_campaign_action_by_sid($sid) {
-  $query = "SELECT category_nid, campaign_nid, personal_campaign_nid, personal_campaign_uid, form_nid, action_type, uid, show_name, comment, amount, created, sid FROM {springboard_p2p_personal_campaign_action} WHERE sid = :sid";
+  $query = "SELECT category_nid, campaign_nid, personal_campaign_nid, personal_campaign_uid, form_nid, action_type, uid, show_name, comment, amount, created, sid, status FROM {springboard_p2p_personal_campaign_action} WHERE sid = :sid";
 
   return db_query($query, array(':sid' => $sid))->fetchAssoc();
 }
@@ -2465,7 +2472,7 @@ function springboard_p2p_preprocess_html(&$vars) {
  *   An array of personal campaign actions, keyed by column name.
  */
 function springboard_p2p_get_personal_campaign_comments($nid, $exclude_empty_comments = FALSE) {
-  $query = "SELECT action_type, uid, show_name, amount, comment, created FROM {springboard_p2p_personal_campaign_action} WHERE personal_campaign_nid = :nid";
+  $query = "SELECT action_type, uid, show_name, amount, comment, created FROM {springboard_p2p_personal_campaign_action} WHERE personal_campaign_nid = :nid AND status = :status";
 
   if ($exclude_empty_comments) {
     $query .= " AND comment != ''";
@@ -2473,7 +2480,9 @@ function springboard_p2p_get_personal_campaign_comments($nid, $exclude_empty_com
 
   $query .= " ORDER BY created DESC";
 
-  return db_query($query, array(':nid' => $nid))->fetchAll(PDO::FETCH_ASSOC);
+  $replacements = array(':nid' => $nid, ':status' => 1);
+
+  return db_query($query, $replacements)->fetchAll(PDO::FETCH_ASSOC);
 }
 
 /**

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -165,7 +165,7 @@ function springboard_p2p_springboard_admin_admin_menu_items_alter(&$items) {
     'weight' => 0,
   );
 }
- 
+
 /**
  * Implements hook_theme().
  */
@@ -1641,10 +1641,7 @@ function springboard_p2p_validate_email_as_username($mail) {
 /**
  * Implements hook_fundraiser_donation_post_create().
  *
- * At this point in the process there is enough information
- * to determine if the donation is being made to a personal
- * campaign. Let's go ahead and record that fact here because
- * downstream processing might need it.
+ * Adds p2p_pcid to $donation.
  */
 function springboard_p2p_fundraiser_donation_post_create($donation) {
   // Check to see if donation is being made to a personal campaign.
@@ -1653,16 +1650,6 @@ function springboard_p2p_fundraiser_donation_post_create($donation) {
     // Add the peer to peer personal campaign id to the donation
     // object so that it can be utilized downstream.
     $donation->p2p_pcid = $_GET['p2p_pcid'];
-
-    // Create a minimum action record. This record be completed in
-    // springboard_p2p_fundraiser_donation_post_submit.
-    $record['sid'] = $donation->sid;
-    $record['form_nid'] = $donation->nid;
-    $record['personal_campaign_nid'] = $_GET['p2p_pcid'];
-    $record['action_type'] = 'fundraiser';
-    $record['comment'] = '';
-
-    springboard_p2p_save_personal_campaign_action($record);
   }
 }
 
@@ -1949,27 +1936,31 @@ function springboard_p2p_webform_submission_update($node, $submission) {
  * Increments the submissions counter for the personal campaign. We do this here
  * instead of in the post_submit below so we can count submissions on
  * non-fundraiser forms.
+ *
+ * Also saves the personal campaign action.
  */
 function springboard_p2p_webform_client_form_submit($form, &$form_state) {
   if (!empty($form_state['values']['springboard_p2p_personal_campaign_action'])) {
     $action = $form_state['values']['springboard_p2p_personal_campaign_action'];
-
-    if ($action['action_type'] == 'webform_user') {
-      $action['sid'] = $form_state['values']['details']['sid'];
-      // If a user is logged in, add that to the action record.
-      // Otherwise webform_user will update the submission with the uid and
-      // we'll add the new uid in our hook_webform_submission_update
-      // implementation.
-      global $user;
-      if ($user->uid) {
-        $action['uid'] = $user->uid;
-      }
-      springboard_p2p_submit_personal_campaign_action($action);
+    $action['sid'] = $form_state['values']['details']['sid'];
+    // If a user is logged in, add that to the action record.
+    // Otherwise webform_user will update the submission with the uid and
+    // we'll add the new uid in our hook_webform_submission_update
+    // implementation.
+    global $user;
+    if ($user->uid) {
+      $action['uid'] = $user->uid;
     }
 
-    $form_state['redirect'][1]['query']['p2p_pcid'] = $form_state['values']['springboard_p2p_personal_campaign_action']['personal_campaign_nid'];
+    if (!empty($action['personal_campaign_nid'])) {
+      springboard_p2p_update_personal_campaign_submissions_progress($action['personal_campaign_nid']);
+    }
 
+    springboard_p2p_save_personal_campaign_action($action);
+
+    $form_state['redirect'][1]['query']['p2p_pcid'] = $form_state['values']['springboard_p2p_personal_campaign_action']['personal_campaign_nid'];
   }
+
   // Pass personal campaign id to Social for use when constructing share URLs.
   if (module_exists('sb_social') && !empty($form_state['values']['personal_campaign_id'])) {
     $url_context = array(
@@ -2068,30 +2059,6 @@ function springboard_p2p_sb_social_tokens_data_alter(&$node) {
 }
 
 /**
- * Implements hook_fundraiser_donation_post_submit().
- *
- * Adds the initial donation amount to the personal campaign progress.
- */
-function springboard_p2p_fundraiser_donation_post_submit($form, $form_state, $donation) {
-
-  if (!empty($donation->recurring) && ($donation->recurring->master_did != $donation->did)) {
-    return;
-  }
-
-  if (!$donation->result['success']) {
-    return;
-  }
-
-  if (!empty($form_state['values']['springboard_p2p_personal_campaign_action'])) {
-    $action = $form_state['values']['springboard_p2p_personal_campaign_action'];
-    if ($action['action_type'] == 'fundraiser') {
-      springboard_p2p_submit_personal_campaign_action($action, $donation);
-    }
-  }
-
-}
-
-/**
  * Formats a user's full name using the first name and last name fields.
  *
  * @param object $account
@@ -2113,42 +2080,57 @@ function springboard_p2p_format_user_full_name($account) {
 }
 
 /**
- * Increment the personal campaign progress and save the action.
+ * Implements hook_fundraiser_donation_success().
  *
- * @param array $action
- *   The action array as it came from form_state.
- * @param object|null $donation
- *   If this is a fundraiser action, pass in the donation.
+ * Updates the personal campaign node with new amount progress and saves the
+ * amount to the personal campaign action.
  */
-function springboard_p2p_submit_personal_campaign_action($action, $donation = NULL) {
-  $key = NULL;
-  if (!empty($action['personal_campaign_nid'])) {
-    $personal_campaign = node_load($action['personal_campaign_nid']);
+function springboard_p2p_fundraiser_donation_success($donation) {
 
-    // Incremenet the submissions progress.
-    ++$personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['submissions'];
-
-    // If a donation was passed in then we have a fundraiser action
-    // and should increment the amount progress.
-    if (!is_null(($donation))) {
-      // In the case of a donation, an action record will have been
-      // created in springboard_p2p_fundraiser_donation_post_create.
-      // Set the $key to sid so the record will get updated with the
-      // remaining information.
-      $key = array('sid');
-      $action['uid'] = $donation->uid;
-      $action['sid'] = $donation->sid;
-      $amount = $donation->donation['amount'];
-      if (!empty($donation->donation['quantity'])) {
-        $amount = $amount * $donation->donation['quantity'];
-      }
-      $personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['amount'] += $amount;
-      $action['amount'] = $amount * 100;
-    }
-    node_save($personal_campaign);
+  // We don't care about counting recurring donations.
+  if (!empty($donation->recurring) && ($donation->recurring->master_did != $donation->did)) {
+    return;
   }
 
-  springboard_p2p_save_personal_campaign_action($action, $key);
+  $action = springboard_p2p_get_personal_campaign_action_by_sid($donation->sid);
+  if ($action) {
+    $amount = $donation->donation['amount'];
+    if (!empty($donation->donation['quantity'])) {
+      $amount = $amount * $donation->donation['quantity'];
+    }
+
+    springboard_p2p_update_personal_campaign_amount_progress($action['personal_campaign_nid'], $amount);
+
+    $action['amount'] = $amount * 100;
+
+    springboard_p2p_save_personal_campaign_action($action, array('sid'));
+  }
+}
+
+/**
+ * Update the personal campaign amount progress.
+ *
+ * @param int $nid
+ *   The node ID of the personal campaign.
+ * @param float $amount
+ *   The amount in USD to add to the amount progress.
+ */
+function springboard_p2p_update_personal_campaign_amount_progress($nid, $amount) {
+  $personal_campaign = node_load($nid);
+  $personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['amount'] += $amount;
+  node_save($personal_campaign);
+}
+
+/**
+ * Update the personal campaign submissions progress.
+ *
+ * @param int $nid
+ *   The node ID of the personal campaign.
+ */
+function springboard_p2p_update_personal_campaign_submissions_progress($nid) {
+  $personal_campaign = node_load($nid);
+  ++$personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['submissions'];
+  node_save($personal_campaign);
 }
 
 /**

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -594,7 +594,8 @@ function _filter_tips_p2p_campaign_intro(&$form) {
   // Unset / remove the filter tips area for campaign intros.
   $form[LANGUAGE_NONE][0]['format']['guidelines']['#access'] = FALSE;
   $form[LANGUAGE_NONE][0]['format']['help']['#access'] = FALSE;
-  // We use js here as it can't be done with form alter for just the filters select list.
+  // We use js here as it can't be done with form alter for just the filters
+  // select list.
   // We also get rid of the disable rich text for wysiwyg.
   $filterjs = 'jQuery(document).ready(function($) {
   $("fieldset.filter-wrapper, .wysiwyg-toggle-wrapper").remove();
@@ -657,7 +658,7 @@ function springboard_p2p_personal_campaign_ajax(&$form, &$form_state) {
 /**
  * Determines if a path for personal campaign already exists in the system.
  *
- * @param $alias
+ * @param string $alias
  *   The user-entered alias to check.
  */
 function springboard_p2p_personal_campaign_alias_exists($alias, $language, $nid = NULL) {
@@ -2251,7 +2252,8 @@ function springboard_p2p_page_alter(&$page, $form) {
     // Define the module path for use below.
     $mod_path = drupal_get_path('module', 'springboard_p2p');
 
-    // Query the url string to see if it's a p2p donation form or p2p webform_user form.
+    // Query the url string to see if it's a p2p donation form or p2p
+    // webform_user form.
     if ($is_fundraiser_type || $is_webform_user_type) {
       // Query the url string to see if it belongs to P2P.
       if (!empty($_GET['p2p_pcid'])) {

--- a/springboard_p2p/springboard_p2p.views.inc
+++ b/springboard_p2p/springboard_p2p.views.inc
@@ -281,6 +281,26 @@ function springboard_p2p_views_data() {
         'handler' => 'views_handler_filter_date',
       ),
     ),
+    'status' => array(
+      'title' => t('Status'),
+      'help' => t('Whether the personal campaign action is visible.'),
+      'field' => array(
+        'handler' => 'views_handler_field_boolean',
+        'click sortable' => TRUE,
+        'output formats' => array(
+          'visible-notvisible' => array(t('Visible'), t('Not Visible')),
+        ),
+      ),
+      'filter' => array(
+        'handler' => 'views_handler_filter_boolean_operator',
+        'label' => t('Visible'),
+        'type' => 'yes-no',
+        'use equal' => TRUE,
+      ),
+      'sort' => array(
+        'handler' => 'views_handler_sort',
+      ),
+    ),
   );
 
   return $data;


### PR DESCRIPTION
This moves around the saving of the personal campaign action to accommodate some gateways not invoking the donation post submit hook with enough context.

 - The personal campaign action is now saved in the submit callback regardless of its type, which makes the donation post create save no longer needed.
 - The donation success hook is used instead of donation post submit. It looks up the previously saved record and adds the donation amount to that and to the personal campaign progress.
 - Removed unused fields from a db query in salesforce_p2p.
 - Added a status column to the personal campaign actions table so that actions won't be visible until the donation is successful. For webform_user actions, the action is immediately visible.
