### PR TITLE
Litle SDK version 8.27.1

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.admin.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.admin.inc
@@ -317,16 +317,20 @@ function commerce_litle_credit_request($payment_method, $transaction, $order, $a
     watchdog('commerce_litle', 'Litle Credit request: !param', array('!param' => '<pre>' . check_plain(print_r($nvp, TRUE)) . '</pre>'), WATCHDOG_DEBUG);
   }
 
+  $litle = _commerce_litle_get_litle();
+  $nvp = array_merge($nvp, _commerce_litle_get_litle_config($payment_method));
+  $nvp['id'] = $nvp['litleTxnId'];
+
   // Submit the request to Litle.
   if ($payment_method['method_id'] == 'commerce_litle_cc') {
-    $response = _commerce_litle_request_credit($payment_method, $nvp);
+    $response = $litle->creditRequest($nvp);
   }
   else {
-    $response = _commerce_litle_request_echeck_credit($payment_method, $nvp);
+    $response = $litle->echeckCreditRequest($nvp);
   }
 
-  $response_string = XmlParser::getDomDocumentAsString($response);
-  $response_code = XmlParser::getNode($response, 'response');
+  $response_string = $litle->getDomDocumentAsString($response);
+  $response_code = $litle->getNode($response, 'response');
 
   // Log the response if specified.
   if ($payment_method['settings']['log']['response'] === 'response') {
@@ -339,7 +343,7 @@ function commerce_litle_credit_request($payment_method, $transaction, $order, $a
     // Create a new transaction to record the credit.
     $credit_transaction = commerce_payment_transaction_new('commerce_litle_cc', $order->order_id);
     $credit_transaction->instance_id = $payment_method['instance_id'];
-    $credit_transaction->remote_id = XmlParser::getNode($response, 'litleTxnId');
+    $credit_transaction->remote_id = $litle->getNode($response, 'litleTxnId');
     $credit_transaction->amount = $credit_amount * -1;
     $credit_transaction->currency_code = $transaction->currency_code;
     $credit_transaction->payload[REQUEST_TIME] = $response_string;
@@ -349,6 +353,7 @@ function commerce_litle_credit_request($payment_method, $transaction, $order, $a
 
     // Save the credit transaction.
     commerce_payment_transaction_save($credit_transaction);
+
     return TRUE;
   }
   else {
@@ -356,7 +361,7 @@ function commerce_litle_credit_request($payment_method, $transaction, $order, $a
     $transaction->payload[REQUEST_TIME] = $response_string;
 
     // Display a failure message and response reason from Litle .
-    $message = XmlParser::getNode($response, 'message');
+    $message = $litle->getNode($response, 'message');
     drupal_set_message(t('Credit failed: @reason', array('@reason' => check_plain($message))), 'error');
 
     commerce_payment_transaction_save($transaction);

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.info
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.info
@@ -1,9 +1,13 @@
 name = Litle & Co. Payment Gateway
 description = Implements Litle payment services for use with Drupal Commerce.
 package = Commerce (contrib)
+
 dependencies[] = commerce
 dependencies[] = commerce_ui
 dependencies[] = commerce_payment
 dependencies[] = commerce_order
+dependencies[] = libraries
 
 core = 7.x
+
+php = 5.3

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.info
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.info
@@ -11,3 +11,5 @@ dependencies[] = libraries
 core = 7.x
 
 php = 5.3
+
+files[] = includes/LitleSDK.php

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.install
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.install
@@ -159,4 +159,6 @@ function commerce_litle_update_7002() {
 function commerce_litle_update_7003() {
   variable_del('commerce_litle_sdk_path');
   variable_del('commerce_litle_sdk_mode');
+
+  registry_rebuild();
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.install
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.install
@@ -9,12 +9,37 @@
  * Implements hook_requirements().
  */
 function commerce_litle_requirements($phase) {
+
+  $requirements = array();
+  // Ensure translations don't break at install time.
+  $t = get_t();
+
+  if ($phase == 'runtime') {
+    $requirements['commerce_litle_sdk'] = array(
+      'title' => $t('Litle SDK for PHP'),
+      'description' => $t('The Commerce Litle module requires the Litle SDK for PHP.'),
+      'value' => $t('Present'),
+      'severtiy' => REQUIREMENT_OK,
+    );
+
+    if (!libraries_get_path('litle')) {
+      $requirements['commerce_litle_sdk']['description'] = $t(
+          'The Commerce Litle module requires the !sdk in a valid library location. Consider installing it using the included make file.',
+          array(
+            '!sdk' => l($t('Litle SDK for PHP'), 'https://github.com/LitleCo/litle-sdk-for-php'),
+          ));
+      $requirements['commerce_litle_sdk']['value'] = 'Missing';
+      $requirements['commerce_litle_sdk']['severity'] = REQUIREMENT_ERROR;
+
+    }
+  }
+
   // Skip the requirements check if SimpleTest is installed to avoid multiple
   // cURL rows.
   if (module_exists('simpletest')) {
-    return;
+    return $requirements;
   }
-  $t = get_t();
+
   $has_curl = function_exists('curl_init');
   $requirements['commerce_litle_curl'] = array(
     'title' => $t('cURL'),
@@ -126,4 +151,12 @@ function commerce_litle_update_7002() {
     'description' => 'Approve, decline status',
     )
   );
+}
+
+/**
+ * Remove unused variables now that Commerce Litle uses the libraries module.
+ */
+function commerce_litle_update_7003() {
+  variable_del('commerce_litle_sdk_path');
+  variable_del('commerce_litle_sdk_mode');
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.make.example
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.make.example
@@ -1,0 +1,9 @@
+api = 2
+core = 7.x
+projects[libraries] = 2
+
+libraries[litle][directory_name] = litle
+libraries[litle][destination] = libraries
+libraries[litle][download][type] = git
+libraries[litle][download][url] = git://github.com/JacksonRiver/litle-sdk-for-php.git
+libraries[litle][download][branch] = jacksonriver-8.27

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.module
@@ -482,7 +482,7 @@ function _commerce_litle_fraud_session_id() {
  * Add the pseudo-session ID to the litle xml request.
  */
 function _commerce_litle_fraud_sale_request_item($nvp, $session_id) {
-  $nvp['advancedFraudChecks']  = array(
+  $nvp['advancedFraudChecks'] = array(
     'threatMetrixSessionId' => $session_id,
   );
 

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.module
@@ -470,7 +470,7 @@ function _commerce_litle_fraud_session_id() {
     $prefix = variable_get('commerce_litle_fraud_id_prefix');
     $session_id = $prefix . '-' . hash('sha256', time() . drupal_random_key() . mt_rand());
   }
-  elseif(!$session_id) {
+  elseif (!$session_id) {
     drupal_set_message('Please note: commerce Litle Advanced Fraud Protection is running in development mode.', 'warning', TRUE);
     $prefix = variable_get('commerce_litle_fraud_id_prefix');
     $session_id = $prefix . '-' . variable_get('commerce_litle_fraud_dev_mode_id', '');
@@ -482,12 +482,12 @@ function _commerce_litle_fraud_session_id() {
  * Add the pseudo-session ID to the litle xml request.
  */
 function _commerce_litle_fraud_sale_request_item($nvp, $session_id) {
- $nvp['advancedFraudChecks']  = array(
-   'threatMetrixSessionId' => $session_id,
- );
- return $nvp;
-}
+  $nvp['advancedFraudChecks']  = array(
+    'threatMetrixSessionId' => $session_id,
+  );
 
+  return $nvp;
+}
 
 /**
  * Payment method callback: checkout form.
@@ -637,7 +637,7 @@ function commerce_litle_cc_submit_form_submit($payment_method, $pane_form, $pane
   commerce_payment_transaction_save($transaction);
   $nvp['id'] = substr($transaction->transaction_id, 0, 20);
 
-  // Allow modules to alter the values sent to Litle
+  // Allow modules to alter the values sent to Litle.
   $context = array(
     'payment_method' => $payment_method,
     'type' => 'cc',
@@ -652,21 +652,21 @@ function commerce_litle_cc_submit_form_submit($payment_method, $pane_form, $pane
   $sale_response = $init->saleRequest($nvp);
   if (variable_get('commerce_litle_fraud', 0)) {
 
-    $order_id = XmlParser::getNode($sale_response, 'orderId');
-    $litle_txn_id = XmlParser::getNode($sale_response, 'litleTxnId');
-    $response_time = strtotime(XmlParser::getNode($sale_response, 'responseTime'));
-    $message = XmlParser::getNode($sale_response, 'message');
-    $avs_result = XmlParser::getNode($sale_response, 'avsResult');
-    $device_review_status = XmlParser::getNode($sale_response, 'deviceReviewStatus');
-    $device_reputation_score = XmlParser::getNode($sale_response, 'deviceReputationScore');
+    $order_id = $init->getNode($sale_response, 'orderId');
+    $litle_txn_id = $init->getNode($sale_response, 'litleTxnId');
+    $response_time = strtotime($init->getNode($sale_response, 'responseTime'));
+    $message = $init->getNode($sale_response, 'message');
+    $avs_result = $init->getNode($sale_response, 'avsResult');
+    $device_review_status = $init->getNode($sale_response, 'deviceReviewStatus');
+    $device_reputation_score = $init->getNode($sale_response, 'deviceReputationScore');
 
     $data = array(
       'order_id' => !empty($order_id) ? $order_id : NULL,
       'litle_txn_id' => !empty($litle_txn_id) ? $litle_txn_id : NULL,
       'response_time' => $response_time,
-      'message' => XmlParser::getNode($sale_response, 'message'),
+      'message' => $message,
       'avs_result' => !empty($avs_result) ? $avs_result : NULL,
-      'device_review_status' => XmlParser::getNode($sale_response, 'deviceReviewStatus'),
+      'device_review_status' => $device_review_status,
       'device_reputation_score' => !empty($device_reputation_score) ? $device_reputation_score : NULL,
     );
     drupal_write_record('commerce_litle_fraud', $data);
@@ -677,7 +677,7 @@ function commerce_litle_cc_submit_form_submit($payment_method, $pane_form, $pane
   }
 
   // If we didn't get an approval response code...
-  if (XmlParser::getNode($sale_response, 'response') != '000') {
+  if ($init->getNode($sale_response, 'response') != '000') {
     // Create a failed transaction with the error message.
     $transaction->status = COMMERCE_PAYMENT_STATUS_FAILURE;
   }
@@ -700,11 +700,11 @@ function commerce_litle_cc_submit_form_submit($payment_method, $pane_form, $pane
 
   $transaction->remote_status = COMMERCE_CREDIT_AUTH_CAPTURE;
   // Store the remote id.
-  $transaction->remote_id = XmlParser::getNode($sale_response, 'litleTxnId');
+  $transaction->remote_id = $init->getNode($sale_response, 'litleTxnId');
 
   // Build a meaningful response message.
   $message = array(
-    '<b>' . (XmlParser::getNode($sale_response, 'response') != '000' ? t('REJECTED') : t('ACCEPTED')) . ':</b> ' . check_plain(XmlParser::getNode($sale_response, 'message')),
+    '<b>' . ($init->getNode($sale_response, 'response') != '000' ? t('REJECTED') : t('ACCEPTED')) . ':</b> ' . check_plain($init->getNode($sale_response, 'message')),
   );
 
   $transaction->message = implode('<br />', $message);
@@ -712,11 +712,11 @@ function commerce_litle_cc_submit_form_submit($payment_method, $pane_form, $pane
   commerce_payment_transaction_save($transaction);
 
   // If the payment failed, display an error and rebuild the form.
-  if (XmlParser::getNode($sale_response, 'response') != '000') {
+  if ($init->getNode($sale_response, 'response') != '000') {
     drupal_set_message(t('We received an error processing your card. Please enter your information again or try a different card.'), 'error');
 
     if ($payment_method['settings']['verbose_gateway']) {
-      drupal_set_message(check_plain(XmlParser::getNode($sale_response, 'message')), 'error');
+      drupal_set_message(check_plain($init->getNode($sale_response, 'message')), 'error');
     }
 
     return FALSE;
@@ -846,7 +846,7 @@ function commerce_litle_cc_vault_cardonfile_charge($payment_method, $card_data, 
   commerce_payment_transaction_save($transaction);
   $request_data['id'] = substr($transaction->transaction_id, 0, 20);
 
-  // Allow modules to alter the values sent to Litle
+  // Allow modules to alter the values sent to Litle.
   $context = array(
     'payment_method' => $payment_method,
     'type' => 'cc_vault',
@@ -870,7 +870,7 @@ function commerce_litle_cc_vault_cardonfile_charge($payment_method, $card_data, 
   // @todo If the response is that the cardonfile isn't valid, deactivate it.
   // @todo Also need to remove the transaction.
   // If we didn't get an approval response code...
-  if (XmlParser::getNode($sale_response, 'response') != '000') {
+  if ($init->getNode($sale_response, 'response') != '000') {
     // Create a failed transaction with the error message.
     $transaction->status = COMMERCE_PAYMENT_STATUS_FAILURE;
   }
@@ -895,11 +895,11 @@ function commerce_litle_cc_vault_cardonfile_charge($payment_method, $card_data, 
   $transaction->remote_status = $txn_type;
 
   // Store the remote id.
-  $transaction->remote_id = XmlParser::getNode($sale_response, 'litleTxnId');
+  $transaction->remote_id = $init->getNode($sale_response, 'litleTxnId');
 
   // Build a meaningful response message.
   $message = array(
-    '<b>' . (XmlParser::getNode($sale_response, 'response') != '000' ? t('REJECTED') : t('ACCEPTED')) . ':</b> ' . check_plain(XmlParser::getNode($sale_response, 'message')),
+    '<b>' . ($init->getNode($sale_response, 'response') != '000' ? t('REJECTED') : t('ACCEPTED')) . ':</b> ' . check_plain($init->getNode($sale_response, 'message')),
   );
 
   $transaction->message = implode('<br />', $message);
@@ -907,11 +907,11 @@ function commerce_litle_cc_vault_cardonfile_charge($payment_method, $card_data, 
   commerce_payment_transaction_save($transaction);
 
   // If the payment failed, display an error and rebuild the form.
-  if (XmlParser::getNode($sale_response, 'response') != '000') {
+  if ($init->getNode($sale_response, 'response') != '000') {
     drupal_set_message(t('We received an error processing your card on file. Please enter your information again or try a different card.'), 'error');
 
     if ($payment_method['settings']['verbose_gateway']) {
-      drupal_set_message(check_plain(XmlParser::getNode($sale_response, 'message')), 'error');
+      drupal_set_message(check_plain($init->getNode($sale_response, 'message')), 'error');
     }
 
     return FALSE;
@@ -986,7 +986,7 @@ function commerce_litle_echeck_submit_form_submit($payment_method, $pane_form, $
   commerce_payment_transaction_save($transaction);
   $nvp['id'] = substr($transaction->transaction_id, 0, 20);
 
-  // Allow modules to alter the values sent to Litle
+  // Allow modules to alter the values sent to Litle.
   $context = array(
     'payment_method' => $payment_method,
     'type' => 'echeck',
@@ -1002,21 +1002,21 @@ function commerce_litle_echeck_submit_form_submit($payment_method, $pane_form, $
   $sale_response = $init->echeckSaleRequest($nvp);
   if (variable_get('commerce_litle_fraud', 0)) {
 
-    $order_id = XmlParser::getNode($sale_response, 'orderId');
-    $litle_txn_id = XmlParser::getNode($sale_response, 'litleTxnId');
-    $response_time = strtotime(XmlParser::getNode($sale_response, 'responseTime'));
-    $message = XmlParser::getNode($sale_response, 'message');
-    $avs_result = XmlParser::getNode($sale_response, 'avsResult');
-    $device_review_status = XmlParser::getNode($sale_response, 'deviceReviewStatus');
-    $device_reputation_score = XmlParser::getNode($sale_response, 'deviceReputationScore');
+    $order_id = $init->getNode($sale_response, 'orderId');
+    $litle_txn_id = $init->getNode($sale_response, 'litleTxnId');
+    $response_time = strtotime($init->getNode($sale_response, 'responseTime'));
+    $message = $init->getNode($sale_response, 'message');
+    $avs_result = $init->getNode($sale_response, 'avsResult');
+    $device_review_status = $init->getNode($sale_response, 'deviceReviewStatus');
+    $device_reputation_score = $init->getNode($sale_response, 'deviceReputationScore');
 
     $data = array(
       'order_id' => !empty($order_id) ? $order_id : NULL,
       'litle_txn_id' => !empty($litle_txn_id) ? $litle_txn_id : NULL,
       'response_time' => $response_time,
-      'message' => XmlParser::getNode($sale_response, 'message'),
+      'message' => $message,
       'avs_result' => !empty($avs_result) ? $avs_result : NULL,
-      'device_review_status' => XmlParser::getNode($sale_response, 'deviceReviewStatus'),
+      'device_review_status' => $device_review_status,
       'device_reputation_score' => !empty($device_reputation_score) ? $device_reputation_score : NULL,
     );
     drupal_write_record('commerce_litle_fraud', $data);
@@ -1027,29 +1027,29 @@ function commerce_litle_echeck_submit_form_submit($payment_method, $pane_form, $
 
     if (variable_get('commerce_litle_fraud', 0)) {
 
-       $order_id = XmlParser::getNode($sale_response, 'orderId');
-       $litle_txn_id = XmlParser::getNode($sale_response, 'litleTxnId');
-       $response_time = strtotime(XmlParser::getNode($sale_response, 'responseTime'));
-       $message = XmlParser::getNode($sale_response, 'message');
-       $avs_result = XmlParser::getNode($sale_response, 'avsResult');
-       $device_review_status = XmlParser::getNode($sale_response, 'deviceReviewStatus');
-       $device_reputation_score = XmlParser::getNode($sale_response, 'deviceReputationScore');
+      $order_id = $init->getNode($sale_response, 'orderId');
+      $litle_txn_id = $init->getNode($sale_response, 'litleTxnId');
+      $response_time = strtotime($init->getNode($sale_response, 'responseTime'));
+      $message = $init->getNode($sale_response, 'message');
+      $avs_result = $init->getNode($sale_response, 'avsResult');
+      $device_review_status = $init->getNode($sale_response, 'deviceReviewStatus');
+      $device_reputation_score = $init->getNode($sale_response, 'deviceReputationScore');
 
       $data = array(
-       'order_id' => !empty($order_id) ? $order_id : NULL,
-       'litle_txn_id' => !empty($litle_txn_id) ? $litle_txn_id : NULL,
-       'response_time' => $response_time,
-       'message' => XmlParser::getNode($sale_response, 'message'),
-       'avs_result' => !empty($avs_result) ? $avs_result : NULL,
-       'device_review_status' => XmlParser::getNode($sale_response, 'deviceReviewStatus'),
-       'device_reputation_score' => !empty($device_reputation_score) ? $device_reputation_score : NULL,
+        'order_id' => !empty($order_id) ? $order_id : NULL,
+        'litle_txn_id' => !empty($litle_txn_id) ? $litle_txn_id : NULL,
+        'response_time' => $response_time,
+        'message' => $message,
+        'avs_result' => !empty($avs_result) ? $avs_result : NULL,
+        'device_review_status' => $device_review_status,
+        'device_reputation_score' => !empty($device_reputation_score) ? $device_reputation_score : NULL,
       );
       drupal_write_record('commerce_litle_fraud', $data);
     }
   }
 
   // If we didn't get an approval response code...
-  if (XmlParser::getNode($sale_response, 'response') != '000') {
+  if ($init->getNode($sale_response, 'response') != '000') {
     // Create a failed transaction with the error message.
     $transaction->status = COMMERCE_PAYMENT_STATUS_FAILURE;
   }
@@ -1065,11 +1065,11 @@ function commerce_litle_echeck_submit_form_submit($payment_method, $pane_form, $
   // Store the type of transaction in the remote status.
   $transaction->remote_status = COMMERCE_CREDIT_AUTH_CAPTURE;
   // Store the remote id.
-  $transaction->remote_id = XmlParser::getNode($sale_response, 'litleTxnId');
+  $transaction->remote_id = $init->getNode($sale_response, 'litleTxnId');
 
   // Build a meaningful response message.
   $message = array(
-    '<b>' . (XmlParser::getNode($sale_response, 'response') != '000' ? t('REJECTED') : t('ACCEPTED')) . ':</b> ' . check_plain(XmlParser::getNode($sale_response, 'message')),
+    '<b>' . ($init->getNode($sale_response, 'response') != '000' ? t('REJECTED') : t('ACCEPTED')) . ':</b> ' . check_plain($init->getNode($sale_response, 'message')),
   );
 
   $transaction->message = implode('<br />', $message);
@@ -1077,11 +1077,11 @@ function commerce_litle_echeck_submit_form_submit($payment_method, $pane_form, $
   commerce_payment_transaction_save($transaction);
 
   // If the payment failed, display an error and rebuild the form.
-  if (XmlParser::getNode($sale_response, 'response') != '000') {
+  if ($init->getNode($sale_response, 'response') != '000') {
     drupal_set_message(t('We received an error processing your card. Please enter your information again or try a different card.'), 'error');
 
     if ($payment_method['settings']['verbose_gateway']) {
-      drupal_set_message(check_plain(XmlParser::getNode($sale_response, 'message')), 'error');
+      drupal_set_message(check_plain($init->getNode($sale_response, 'message')), 'error');
     }
 
     return FALSE;
@@ -1210,7 +1210,7 @@ function commerce_litle_echeck_vault_cardonfile_charge($payment_method, $card_da
   commerce_payment_transaction_save($transaction);
   $request_data['id'] = substr($transaction->transaction_id, 0, 20);
 
-  // Allow modules to alter the values sent to Litle
+  // Allow modules to alter the values sent to Litle.
   $context = array(
     'payment_method' => $payment_method,
     'type' => 'echeck_vault',
@@ -1232,7 +1232,7 @@ function commerce_litle_echeck_vault_cardonfile_charge($payment_method, $card_da
   }
 
   // If we didn't get an approval response code...
-  if (XmlParser::getNode($sale_response, 'response') != '000') {
+  if ($init->getNode($sale_response, 'response') != '000') {
     // Create a failed transaction with the error message.
     $transaction->status = COMMERCE_PAYMENT_STATUS_FAILURE;
   }
@@ -1248,11 +1248,11 @@ function commerce_litle_echeck_vault_cardonfile_charge($payment_method, $card_da
   // Store the type of transaction in the remote status.
   $transaction->remote_status = COMMERCE_CREDIT_AUTH_CAPTURE;
   // Store the remote id.
-  $transaction->remote_id = XmlParser::getNode($sale_response, 'litleTxnId');
+  $transaction->remote_id = $init->getNode($sale_response, 'litleTxnId');
 
   // Build a meaningful response message.
   $message = array(
-    '<b>' . (XmlParser::getNode($sale_response, 'response') != '000' ? t('REJECTED') : t('ACCEPTED')) . ':</b> ' . check_plain(XmlParser::getNode($sale_response, 'message')),
+    '<b>' . ($init->getNode($sale_response, 'response') != '000' ? t('REJECTED') : t('ACCEPTED')) . ':</b> ' . check_plain($init->getNode($sale_response, 'message')),
   );
 
   $transaction->message = implode('<br />', $message);
@@ -1260,11 +1260,11 @@ function commerce_litle_echeck_vault_cardonfile_charge($payment_method, $card_da
   commerce_payment_transaction_save($transaction);
 
   // If the payment failed, display an error and rebuild the form.
-  if (XmlParser::getNode($sale_response, 'response') != '000') {
+  if ($init->getNode($sale_response, 'response') != '000') {
     drupal_set_message(t('We received an error processing your card. Please enter your information again or try a different card.'), 'error');
 
     if ($payment_method['settings']['verbose_gateway']) {
-      drupal_set_message(check_plain(XmlParser::getNode($sale_response, 'message')), 'error');
+      drupal_set_message(check_plain($init->getNode($sale_response, 'message')), 'error');
     }
 
     return FALSE;
@@ -1375,34 +1375,14 @@ function _commerce_litle_request_echeck_credit($gateway, $input) {
 /**
  * Load the Litle SDK and return a LitleOnlineRequest.
  *
- * @return bool|\litle\sdk\LitleOnlineRequest
- *   The litle request object, or FALSE.
+ * @return LitleSDK
+ *   A LitleSDK object that has methods for the Litle REquest and XmlParser.
+ *
+ * @throws RuntimeException
+ *   If the Litle SDK can't be loaded.
  */
 function _commerce_litle_get_litle() {
-  $library = libraries_load('litle');
-
-  if (!empty($library['loaded'])) {
-    return new \litle\sdk\LitleOnlineRequest();
-  }
-
-  // Couldn't load the library. Try to get some info and watchdog it.
-  $replacements = array(
-    '@error' => '',
-    '@error_message' => '',
-  );
-
-  if (isset($library['error'])) {
-    $replacements['@error'] = $library['error'];
-  }
-  if (isset($library['error message'])) {
-    $replacements['@error_message'] = $library['error message'];
-  }
-
-  watchdog('Commerce Litle', 'Litle library not found! @error @error_message', $replacements, WATCHDOG_ALERT);
-
-  // @todo Should we throw an Exception and handle it somewhere in Commerce?
-  // We're pretty much dead in the water at this point.
-  return FALSE;
+  return new LitleSDK();
 }
 
 /**
@@ -1467,7 +1447,7 @@ function commerce_litle_register_token_request($litle, $litle_config, $data) {
   $data += $litle_config;
   $token_response = $litle->registerTokenRequest($data);
 
-  watchdog('commerce_litle', 'Litle Token response: !param', array('!param' => '<pre>' . check_plain(XmlParser::getDomDocumentAsString($token_response)) . '</pre>', WATCHDOG_DEBUG));
+  watchdog('commerce_litle', 'Litle Token response: !param', array('!param' => '<pre>' . check_plain($litle->getDomDocumentAsString($token_response)) . '</pre>', WATCHDOG_DEBUG));
 
   return $token_response;
 }
@@ -1499,7 +1479,6 @@ function _commerce_litle_cc_card_type_to_litle($type) {
 }
 
 /**
-
  * Translates commerce transaction type constants to the Litle equivalent.
  *
  * Returns the transaction type string for Litle that corresponds to the
@@ -1686,14 +1665,16 @@ function commerce_litle_vault_cardonfile_register_token($payment_method, $paymen
  *   A token string, or NULL if the response code indicated a failure.
  */
 function commerce_litle_get_token_from_response($response) {
+  $sdk = _commerce_litle_get_litle();
+
   $token = NULL;
-  $response_code = XmlParser::getNode($response, 'response');
+  $response_code = $sdk->getNode($response, 'response');
 
   // Keep in mind tokenResponseCode is different than response.
   // 801 Account number was successfully registered.
   // 802 Account number was previously registered.
   if (in_array($response_code, array(801, 802))) {
-    $token = XmlParser::getNode($response, 'litleToken');
+    $token = $sdk->getNode($response, 'litleToken');
   }
 
   return $token;
@@ -1759,7 +1740,8 @@ function commerce_litle_mask_string($number, $show_count = 4) {
  *   A response from Litle.
  */
 function commerce_litle_log_response($response) {
-  watchdog('commerce_litle', 'Litle response: !param', array('!param' => '<pre>' . check_plain(XmlParser::getDomDocumentAsString($response)) . '</pre>', WATCHDOG_DEBUG));
+  $sdk = _commerce_litle_get_litle();
+  watchdog('commerce_litle', 'Litle response: !param', array('!param' => '<pre>' . check_plain($sdk->getDomDocumentAsString($response)) . '</pre>', WATCHDOG_DEBUG));
 }
 
 /**
@@ -1853,10 +1835,10 @@ function commerce_litle_fundraiser_sustainers_recurring_success($donation) {
   }
 }
 
-/* *
- * Implements hook_settings_form
+/**
+ * Implements hook_settings_form().
  *
- * Configuration form for Litle/Threatmetrix Advanced Fraud Protection
+ * Configuration form for Litle/Threatmetrix Advanced Fraud Protection.
  */
 function commerce_litle_fraud_settings_form() {
 
@@ -1872,7 +1854,7 @@ function commerce_litle_fraud_settings_form() {
   $form['fraud']['commerce_litle_fraud'] = array(
     '#type' => 'checkbox',
     '#title' => 'Enable Advanced Fraud Protection',
-    '#default_value' => variable_get('commerce_litle_fraud',''),
+    '#default_value' => variable_get('commerce_litle_fraud', ''),
     '#prefix' => '<br />',
   );
 
@@ -1928,13 +1910,15 @@ function commerce_litle_fraud_settings_form() {
     ),
   );
 
-
   $form['#validate'][] = 'commerce_litle_fraud_settings_form_validate';
   return system_settings_form($form);
 }
 
+/**
+ * Validation handler for the fraud settings form.
+ */
 function commerce_litle_fraud_settings_form_validate($form, &$form_state) {
-  if($form_state['values']['commerce_litle_fraud'] == 1) {
+  if ($form_state['values']['commerce_litle_fraud'] == 1) {
     if ($form_state['values']['commerce_litle_fraud_id_prefix'] == '') {
       form_set_error('commerce_litle_fraud_id_prefix', t('Session ID prefix is a required field'));
     }
@@ -1943,4 +1927,3 @@ function commerce_litle_fraud_settings_form_validate($form, &$form_state) {
     }
   }
 }
-

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.module
@@ -1339,44 +1339,10 @@ function _commerce_litle_request_sale($gateway, $input) {
 }
 
 /**
- * Litle request function wrapper.
- *
- * Example input
- *   $input = array(
- *     'litleTxnId'=>'100000000000000002',
- *     'id'=> '456',
- *     'amount'=>'1010'
- *   );
- */
-function _commerce_litle_request_credit($gateway, $input) {
-  $litle = _commerce_litle_get_litle();
-  $input = array_merge($input, _commerce_litle_get_litle_config($gateway));
-  $input['id'] = $input['litleTxnId'];
-  return $litle->creditRequest($input);
-}
-
-/**
- * Litle echeck credit request function wrapper.
- *
- * Example input
- *   $input = array(
- *     'litleTxnId'=>'100000000000000002',
- *     'id'=> '456',
- *     'amount'=>'1010'
- *   );
- */
-function _commerce_litle_request_echeck_credit($gateway, $input) {
-  $litle = _commerce_litle_get_litle();
-  $input = array_merge($input, _commerce_litle_get_litle_config($gateway));
-  $input['id'] = $input['litleTxnId'];
-  return $litle->echeckCreditRequest($input);
-}
-
-/**
  * Load the Litle SDK and return a LitleOnlineRequest.
  *
  * @return LitleSDK
- *   A LitleSDK object that has methods for the Litle REquest and XmlParser.
+ *   A LitleSDK object that has methods for the Litle Request and XmlParser.
  *
  * @throws RuntimeException
  *   If the Litle SDK can't be loaded.

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.module
@@ -7,9 +7,47 @@
 define('COMMERCE_LITLE_CHECK_SALE', 'echeck_sale');
 
 /**
+ * Implements hook_libraries_info().
+ */
+function commerce_litle_libraries_info() {
+  $libraries = array();
+
+  $libraries['litle'] = array(
+    'name' => 'Litle SDK for PHP',
+    'vendor url' => 'https://github.com/LitleCo/litle-sdk-for-php',
+    'download url' => 'https://github.com/LitleCo/litle-sdk-for-php/archive/8.27.1.tar.gz',
+    'path' => 'litle/sdk',
+    'version arguments' => array(
+      'file' => 'litle/sdk/LitleOnline.php',
+      'pattern' => "@'CURRENT_SDK_VERSION', 'PHP;([0-9a-zA-Z\\.-]+)'@",
+      'lines' => 50,
+      'cols' => 50,
+    ),
+    'files' => array(
+      'php' => array(
+        'LitleOnline.php',
+        'LitleXmlMapper.php',
+        'XmlFields.php',
+        'Communication.php',
+        'XmlParser.php',
+        'Obj2xml.php',
+        'Checker.php',
+        'LitleOnlineRequest.php',
+        'UrlMapper.php',
+        'BatchRequest.php',
+        'LitleRequest.php',
+        'Transactions.php',
+        'LitleResponseProcessor.php',
+      ),
+    ),
+  );
+
+  return $libraries;
+}
+
+/**
  * Implements hook_views_api().
  */
-
 function commerce_litle_views_api() {
   return array(
     'api' => 3,
@@ -579,11 +617,11 @@ function commerce_litle_cc_submit_form_submit($payment_method, $pane_form, $pane
   );
 
   $nvp['billToAddress'] = commerce_litle_format_bill_to_address($order_wrapper);
- 
+
   if (variable_get('commerce_litle_fraud', 0) && isset($pane_values['session_id'])) {
     $nvp = _commerce_litle_fraud_sale_request_item($nvp, $pane_values['session_id']);
   }
- 
+
   // Config stored in a var because it's used again later.
   $litle_config = _commerce_litle_get_litle_config($payment_method);
   $nvp += $litle_config;
@@ -1335,15 +1373,36 @@ function _commerce_litle_request_echeck_credit($gateway, $input) {
 }
 
 /**
- * Helper function, locate and include the Litle SDK object.
+ * Load the Litle SDK and return a LitleOnlineRequest.
+ *
+ * @return bool|\litle\sdk\LitleOnlineRequest
+ *   The litle request object, or FALSE.
  */
 function _commerce_litle_get_litle() {
-  // Note the placement of the Litle SDK.
-  $library_path = variable_get('commerce_litle_sdk_path', 'sites/all/libraries/litle/lib');
-  $library_mode = variable_get('commerce_litle_sdk_mode', 'LitleOnline');
-  include_once $library_path . '/' . $library_mode . '.php';
-  $litle = new LitleOnlineRequest();
-  return $litle;
+  $library = libraries_load('litle');
+
+  if (!empty($library['loaded'])) {
+    return new \litle\sdk\LitleOnlineRequest();
+  }
+
+  // Couldn't load the library. Try to get some info and watchdog it.
+  $replacements = array(
+    '@error' => '',
+    '@error_message' => '',
+  );
+
+  if (isset($library['error'])) {
+    $replacements['@error'] = $library['error'];
+  }
+  if (isset($library['error message'])) {
+    $replacements['@error_message'] = $library['error message'];
+  }
+
+  watchdog('Commerce Litle', 'Litle library not found! @error @error_message', $replacements, WATCHDOG_ALERT);
+
+  // @todo Should we throw an Exception and handle it somewhere in Commerce?
+  // We're pretty much dead in the water at this point.
+  return FALSE;
 }
 
 /**
@@ -1361,6 +1420,27 @@ function _commerce_litle_get_litle_config($gateway) {
     'timeout' => !empty($gateway['settings']['commerce_litle_settings_timeout']) ? $gateway['settings']['commerce_litle_settings_timeout'] : '',
     'reportGroup' => !empty($gateway['settings']['commerce_litle_settings_reportGroup']) ? $gateway['settings']['commerce_litle_settings_reportGroup'] : '',
   );
+
+  // The following config is set because it's required by the SDK,
+  // but these features aren't yet implemented in this module.
+  // So there's no point in exposing them in the UI.
+  //
+  // Batch processing.
+  $auth_info['litle_requests_path'] = '';
+  $auth_info['batch_requests_path'] = '';
+  $auth_info['batch_url'] = '';
+  // Stream batch delivery.
+  $auth_info['tcp_port'] = '';
+  $auth_info['tcp_timeout'] = '';
+  // SFTP.
+  $auth_info['sftp_username'] = '';
+  $auth_info['sftp_password'] = '';
+  // Stream batch delivery?
+  // These are hardcoded in the SDK's setup script.
+  $auth_info['tcp_ssl'] = '1';
+  // This is for debugging the request and response xml inside the SDK.
+  // This should probably never be changed.
+  $auth_info['print_xml'] = 0;
 
   if ($gateway['settings']['commerce_litle_settings_sandbox'] == 1) {
     $auth_info['url'] = 'https://www.testlitle.com/sandbox/communicator/online';

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/includes/LitleSDK.php
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/includes/LitleSDK.php
@@ -1,0 +1,572 @@
+<?php
+/**
+ * @file
+ * Class to connect the Litle SDK library to Drupal Commerce.
+ */
+
+class LitleSDK {
+
+  /**
+   * @var null|\litle\sdk\LitleOnlineRequest
+   */
+  protected $request = NULL;
+
+  /**
+   * Loads the Litle SDK library and initializes a Request object.
+   *
+   * If the SDK can't be loaded, watchdog the error and throw an exception.
+   *
+   * @throws RuntimeException
+   *   If the Litle SDK can't be loaded.
+   */
+  public function __construct() {
+    $library = libraries_load('litle');
+
+    if (!empty($library['loaded'])) {
+      // Initialize an internal Request object.
+      $this->newRequest();
+      return;
+    }
+
+    // Couldn't load the library. Try to get some info and watchdog it.
+    $replacements = array(
+      '@error' => '',
+      '@error_message' => '',
+    );
+
+    if (isset($library['error'])) {
+      $replacements['@error'] = $library['error'];
+    }
+    if (isset($library['error message'])) {
+      $replacements['@error_message'] = $library['error message'];
+    }
+
+    watchdog('Commerce Litle', 'Litle library not found! @error @error_message', $replacements, WATCHDOG_ALERT);
+
+    throw new RuntimeException('Cannot load the Litle SDK');
+  }
+
+  /**
+   * Initialize the Request object.
+   */
+  public function newRequest() {
+    $this->request = new \litle\sdk\LitleOnlineRequest();
+  }
+
+  /**
+   * Parses the response XML as a DomDocument.
+   *
+   * This method wraps the XmlParser static call in the SDK.
+   *
+   * @param string $xml
+   *   The XML, usually from a response.
+   *
+   * @return DOMDocument
+   *   The response XML loaded in as a DomDocument.
+   */
+  public function domParser($xml) {
+    return \litle\sdk\XmlParser::domParser($xml);
+  }
+
+  /**
+   * Get an element value from the response.
+   *
+   * This method wraps the XmlParser static call in the SDK.
+   *
+   * @param DomDocument $dom
+   *   The response.
+   * @param string $elementName
+   *   The element/tag to match.
+   *
+   * @return string
+   *   The value of the last matching element in the document.
+   */
+  public function getNode($dom, $elementName) {
+    return \litle\sdk\XmlParser::getNode($dom, $elementName);
+  }
+
+  /**
+   * Gets an attribute from the first matched element in a DomDocument.
+   *
+   * This method wraps the XmlParser static call in the SDK.
+   *
+   * @param DomDocument $dom
+   *   The response.
+   * @param string $elementName
+   *   The element/tag to match.
+   * @param string $attributeName
+   *   The name of the attribute to get.
+   *
+   * @return string
+   *   The value of the attribute.
+   */
+  public function getAttribute($dom, $elementName, $attributeName) {
+    return \litle\sdk\XmlParser::getAttribute($dom, $elementName, $attributeName);
+  }
+
+  /**
+   * Get the entire response as a string.
+   *
+   * This method wraps the XmlParser static call in the SDK.
+   *
+   * @param DomDocument $dom
+   *   The response.
+   *
+   * @return bool|string
+   *   The full response as a string of XML, or FALSE.
+   */
+  public function getDomDocumentAsString($dom) {
+    return \litle\sdk\XmlParser::getDomDocumentAsString($dom);
+  }
+
+  /**
+   * Make an authorization API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   Request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function authorizationRequest($hash_in) {
+    return $this->request->authorizationRequest($hash_in);
+  }
+
+  /**
+   * Make a sale API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function saleRequest($hash_in) {
+    return $this->request->saleRequest($hash_in);
+  }
+
+  /**
+   * Make an authReversal request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function authReversalRequest($hash_in) {
+    return $this->request->authReversalRequest($hash_in);
+  }
+
+  /**
+   * Make a credit API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function creditRequest($hash_in) {
+    return $this->request->creditRequest($hash_in);
+  }
+
+  /**
+   * Make a registerToken API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function registerTokenRequest($hash_in) {
+    return $this->request->registerTokenRequest($hash_in);
+  }
+
+  /**
+   * Make a forceCapture API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function forceCaptureRequest($hash_in) {
+    return $this->request->forceCaptureRequest($hash_in);
+  }
+
+  /**
+   * Make a capture API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function captureRequest($hash_in) {
+    return $this->request->captureRequest($hash_in);
+  }
+
+  /**
+   * Make a captureGivenAuth API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function captureGivenAuthRequest($hash_in) {
+    return $this->request->captureGivenAuthRequest($hash_in);
+  }
+
+  /**
+   * Make an echeckRedeposit API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function echeckRedepositRequest($hash_in) {
+    return $this->request->echeckRedepositRequest($hash_in);
+  }
+
+  /**
+   * Make an echeckSale API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function echeckSaleRequest($hash_in) {
+    return $this->request->echeckSaleRequest($hash_in);
+  }
+
+  /**
+   * Make an echeckCredit API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function echeckCreditRequest($hash_in) {
+    return $this->request->echeckCreditRequest($hash_in);
+  }
+
+  /**
+   * Make an echeckVerification request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function echeckVerificationRequest($hash_in) {
+    return $this->request->echeckVerificationRequest($hash_in);
+  }
+
+  /**
+   * Make a void API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function voidRequest($hash_in) {
+    return $this->request->voidRequest($hash_in);
+  }
+
+  /**
+   * Make an echeckVoid API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function echeckVoidRequest($hash_in) {
+    return $this->request->echeckVoidRequest($hash_in);
+  }
+
+  /**
+   * Make a depositReversal API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function depositReversalRequest($hash_in) {
+    return $this->request->depositReversalRequest($hash_in);
+  }
+
+  /**
+   * Make a refundReversal API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function refundReversalRequest($hash_in) {
+    return $this->request->refundReversalRequest($hash_in);
+  }
+
+  /**
+   * Make an activateReversal API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function activateReversalRequest($hash_in) {
+    return $this->request->activateReversalRequest($hash_in);
+  }
+
+  /**
+   * Make a deactivateReversal API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function deactivateReversalRequest($hash_in) {
+    return $this->request->deactivateReversalRequest($hash_in);
+  }
+
+  /**
+   * Make a loadReversal API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function loadReversalRequest($hash_in) {
+    return $this->request->loadReversalRequest($hash_in);
+  }
+
+  /**
+   * Make an unloadReversal API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function unloadReversalRequest($hash_in) {
+    return $this->request->unloadReversalRequest($hash_in);
+  }
+
+  /**
+   * Make an updateCardValidationNumOnToken API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function updateCardValidationNumOnToken($hash_in) {
+    return $this->request->updateCardValidationNumOnToken($hash_in);
+  }
+
+  /**
+   * Make an updateSubscription API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function updateSubscription($hash_in) {
+    return $this->request->updateSubscription($hash_in);
+  }
+
+  /**
+   * Make a cancelSubscription API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function cancelSubscription($hash_in) {
+    return $this->request->cancelSubscription($hash_in);
+  }
+
+  /**
+   * Make an updatePlan API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function updatePlan($hash_in) {
+    return $this->request->updatePlan($hash_in);
+  }
+
+  /**
+   * Make a createPlan API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function createPlan($hash_in) {
+    return $this->request->createPlan($hash_in);
+  }
+
+  /**
+   * Make an activate API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function activate($hash_in) {
+    return $this->request->activate($hash_in);
+  }
+
+  /**
+   * Make a deactivate API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function deactivate($hash_in) {
+    return $this->request->deactivate($hash_in);
+  }
+
+  /**
+   * Make a load API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function load($hash_in) {
+    return $this->request->load($hash_in);
+  }
+
+  /**
+   * Make an unload API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function unload($hash_in) {
+    return $this->request->unload($hash_in);
+  }
+
+  /**
+   * Make a balanceInquiery API request.
+   *
+   * This method wraps the LitleOnlineRequest.
+   *
+   * @param array $hash_in
+   *   The request data.
+   *
+   * @return DOMDocument|SimpleXMLElement
+   *   The response.
+   */
+  public function balanceInquiry($hash_in) {
+    return $this->request->balanceInquiry($hash_in);
+  }
+
+}

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/tests/commerce_litle_test.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/tests/commerce_litle_test.module
@@ -194,7 +194,7 @@ function commerce_litle_test_register_token(DOMNode $node) {
     }
   }
 
-  $xml = "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
+  $xml = "<litleOnlineResponse version='8.27' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
   $xml .= "<registerTokenResponse id='ididid' reportGroup='rtpGrp' customerId='12345'>";
   $xml .= "<litleTxnId>501000000000000001</litleTxnId>";
 
@@ -236,7 +236,7 @@ function commerce_litle_test_sale(DOMNode $node) {
     }
   }
 
-  $xml = "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
+  $xml = "<litleOnlineResponse version='8.27' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
   $xml .= "<saleResponse id='ididid' reportGroup='rtpGrp' customerId='12345'>";
   $xml .= "<litleTxnId>774506068532487000</litleTxnId>";
   $xml .= "<orderId>" . $order_id . "</orderId>";
@@ -269,7 +269,7 @@ function commerce_litle_test_echeck_sale(DOMNode $node) {
     }
   }
 
-  $xml = "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
+  $xml = "<litleOnlineResponse version='8.27' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
   $xml .= "<echeckSalesResponse id='ididid' reportGroup='rtpGrp' customerId='12345'>";
   $xml .= "<litleTxnId>390936667563420000</litleTxnId>";
   $xml .= "<orderId>" . $order_id . "</orderId>";
@@ -292,7 +292,7 @@ function commerce_litle_test_echeck_sale(DOMNode $node) {
  *   The xml to print.
  */
 function commerce_litle_test_authorization(DOMNode $node) {
-  $xml = "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+  $xml = "<litleOnlineResponse version='8.27' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
   <authorizationResponse id='ididid' reportGroup='rtpGrp' customerId='12345'>
     <litleTxnId>900261330165740000</litleTxnId>
     <orderId>1</orderId>
@@ -317,7 +317,7 @@ function commerce_litle_test_authorization(DOMNode $node) {
  *   The xml to print.
  */
 function commerce_litle_test_unimplemented_request(DOMNode $node) {
-  $xml = "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
+  $xml = "<litleOnlineResponse version='8.27' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
   $xml .= "<error>Tag is known but not implemented in this mock API:  $node->tagName</error>";
   $xml .= "</litleOnlineResponse>";
   return $xml;
@@ -333,7 +333,7 @@ function commerce_litle_test_unimplemented_request(DOMNode $node) {
  *   The xml to print.
  */
 function commerce_litle_test_unknown_request(DOMNode $node) {
-  $xml = "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
+  $xml = "<litleOnlineResponse version='8.27' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
   $xml .= "<error>Tag is unknown:  $node->tagName</error>";
   $xml .= "</litleOnlineResponse>";
   return $xml;
@@ -342,27 +342,14 @@ function commerce_litle_test_unknown_request(DOMNode $node) {
 /**
  * The response when we can't find a request in the usual places.
  *
+ * Keep in mind this is not a normal Litle response.
+ *
  * @return string
  *   The xml to print.
  */
 function commerce_litle_test_no_request_found() {
-  $xml = "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
-
+  $xml = "<litleOnlineResponse version='8.27' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>";
   $xml .= "<error>No request found.</error>";
-
-  $xml .= "<request><![CDATA[";
-  $xml .= var_export($_REQUEST, TRUE);
-  $xml .= "]]></request>";
-
-  $xml .= "<files><![CDATA[";
-  $xml .= var_export($_FILES, TRUE);
-  $xml .= "]]></files>";
-
-  global $HTTP_RAW_POST_DATA;
-  $xml .= "<rawPostData><![CDATA[";
-  $xml .= var_export($HTTP_RAW_POST_DATA, TRUE);
-  $xml .= "]]></rawPostData>";
-
   $xml .= "</litleOnlineResponse>";
 
   return $xml;


### PR DESCRIPTION
This goes along with the matching branch of the Springboard build repo.

 - Switched to using the libraries module for a definition of the Litle SDK. It now uses that for autoloading the needed files.
 - Added an example make file, like how salesforce_soap does.
 - Added a LitleSDK class to abstract the interactions between the Litle SDK and Commerce Litle.
 - Adjusted XmlParser and LitleOnlilneRequest calls in commerce_litle to use the LitleSDK class.
