### PR TITLE
add querystring to drupal_goto in secure_prepopulate_clear

### DIFF
--- a/secure_prepopulate/secure_prepopulate.module
+++ b/secure_prepopulate/secure_prepopulate.module
@@ -47,7 +47,8 @@ function secure_prepopulate_clear($nid) {
     $user = drupal_anonymous_user();
   }
 
-  drupal_goto('node/' . $nid);
+  // Send the user on their way with a querystring attached.
+  drupal_goto('node/' . $nid, drupal_query_string_encode($_GET, array('af', 'q')));
 }
 
 /**


### PR DESCRIPTION
By default, secure_prepopulate's "not-me" page callback excludes querystring parameters in its redirect. This pull request adds querystring params except for the secure prepop hash (which, by nature of the not-me callback, isn't correct), and 'q' (which creates an infinite redirect).
