### PR TITLE
Use Drupal Queue for Sustainer Processing

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.drush.inc
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.drush.inc
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Drush commands for the Fundraiser Sustainer module.
+ */
+
+/**
+ * Implements hook_drush_help().
+ */
+function fundraiser_sustainers_drush_help($command) {
+  switch ($command) {
+    case 'drush:fundraiser-sustainers-process':
+      return dt('Processes the sustainer queue.');
+  }
+}
+
+/**
+ * Implements hook_drush_command().
+ */
+function fundraiser_sustainers_drush_command() {
+  $items = array();
+  $items['fundraiser-sustainers-process'] = array(
+    'description' => dt('Processes the sustainer queue.'),
+    'arguments' => array(
+      'max_queue' => dt('Max amount of sustainers to attempt to process. If left empty this defaults to the site setting.'),
+    ),
+    'examples' => array(
+      'Standard example' => 'drush fundraiser-sustainers-process',
+      'Argument example' => 'drush fundraiser-sustainers-process 2000',
+    ),
+    'aliases' => array('fsp'),
+  );
+  return $items;
+}
+
+/**
+ * Callback function for drush fundraiser-sustainer-process.
+ *
+ * Processes the Fundraiser Sustainer queue.
+ *
+ * @param numeric $max_queue
+ *   An optional max amount of donations to attempt to process. Defaults to the site setting.
+ */
+function drush_fundraiser_sustainers_process($max_queue = NULL) {
+  if (variable_get('fundraiser_sustainers_cron_type', NULL) !== 'drush') {
+    drush_log('The Fundraiser Sustainers cron setting is not enabled for drush. Nothing has been processed.', 'error');
+    return;
+  }
+
+  if (empty($max_queue)) {
+    $max_queue = variable_get('fundraiser_sustainers_max_queue', 1000);
+  }
+
+  _fundraiser_sustainers_process_recurring($max_queue);
+}

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
@@ -488,3 +488,17 @@ function fundraiser_sustainers_update_7007() {
 function fundraiser_sustainers_update_7008() {
   registry_rebuild();
 }
+
+/**
+ * Switch the sustainer cron settings to the new variable.
+ */
+function fundraiser_sustainers_update_7009() {
+  if (variable_get('fundraiser_standalone_cron_enabled', 0)) {
+    variable_set('fundraiser_sustainers_cron_type', 'standalone_http');
+  }
+  else {
+    variable_set('fundraiser_sustainers_cron_type', 'drupal_cron');  
+  }
+
+  variable_del('fundraiser_standalone_cron_enabled');
+}

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -44,7 +44,6 @@ function fundraiser_sustainers_cron() {
     watchdog('fundraiser_cron', 'Standard cron run.', NULL, WATCHDOG_INFO);
     fundraiser_sustainers_standalone_cron();
   }
-
 }
 
 /**
@@ -671,27 +670,64 @@ function fundraiser_sustainers_fundraiser_donation_delete($donation) {
 }
 
 /**
- * Helper function, kick off recurring donations for payment. Called on cron usually.
+ * Process recurring donations with a queue.
  */
 function fundraiser_sustainers_process_recurring_donations() {
   // Provide a hook to allow for modules to respond.
   module_invoke_all('fundraiser_donation_recurring');
+
+  // Keep a running tally of successes and failures.
   $log = array(
     'successes' => 0,
     'fails' => 0,
+    'errors' => 0,
   );
-  $donations = _fundraiser_sustainers_cron_get_recurring();
-  $sustainer_key = fundraiser_sustainers_get_sustainer_key_value();
 
-  // Loop over the found orders
+  //Get our queue object.
+  $queue = new SystemQueue('SustainerQueue');
+  $queue->createQueue();
+
+  // Populate our queue with donations.
+  $record_count = variable_get('fundraiser_sustainer_max_queue', 1000);
+  $donations = _fundraiser_sustainers_cron_get_recurring($record_count);
+
+  // Loop over the found orders and add to the queue.
   foreach ($donations as $recurring) {
-    fundraiser_sustainers_process_single_recurring_donation($log, $recurring, $sustainer_key);
+    $queue->createItem($recurring);
+  }
 
+  $end = time() + variable_get('fundraiser_sustainers_queue_time', 30);
+
+  while (time() < $end && ($item = $queue->claimItem())) {
+    // Delete the item before processing.
+    $queue->deleteItem($item);
+
+    // Attempt to process the item.
+    try {
+      $success = fundraiser_sustainers_process_single_recurring_donation($item->data);
+
+      // Update the log array.
+      if ($success) {
+        $log['successes']++;
+      }
+      else {
+        $log['fails']++;
+      }
+    }
+    catch (Exception $e) {
+      watchdog('fundraiser_sustainers', 'Recurring donation !did failed during processing, the error was: @error.',
+        array('!did' => $item->data->did, '@error' => $e->getMessage()));
+
+      // Update error
+      $log['errors']++;
+    }
   }
+
   if ($log['successes'] > 0 || $log['fails'] > 0) {
-    watchdog('fundraiser_sustainers', '!successes recurring donations processed successfully; !fails failed.',
-      array('!successes' => $log['successes'], '!fails' => $log['fails']));
+    watchdog('fundraiser_sustainers', '!successes recurring donations processed successfully; !fails failed; errors reported: !errors.',
+      array('!successes' => $log['successes'], '!fails' => $log['fails'], '!errors' => $log['errors']));
   }
+
   // And after all of that is done, provide a hook to allow for modules to respond.
   module_invoke_all('fundraiser_donation_post_recurring');
 }
@@ -699,7 +735,9 @@ function fundraiser_sustainers_process_recurring_donations() {
 /**
  * Process an individual sustainer record.
  */
-function fundraiser_sustainers_process_single_recurring_donation(&$log, $recurring, $sustainer_key) {
+function fundraiser_sustainers_process_single_recurring_donation($recurring) {
+  // Confirm sustainer key match.
+  $sustainer_key = fundraiser_sustainers_get_sustainer_key_value();
   if ($sustainer_key == $recurring->sustainer_key) {
     // Prepare a log record.
     $log_record = array(
@@ -745,6 +783,9 @@ function fundraiser_sustainers_process_single_recurring_donation(&$log, $recurri
     // Since we already created the donation (and saved any CC info at that time).
     // All we need to do is process it and respond afterwards as needed.
     fundraiser_donation_process($donation);
+    if ($donation->did == 58) {
+        throw new Exception('Error with processor.');
+    }
     if (!isset($donation->result['message'])) {
       $donation->result['message'] = '';
     }
@@ -752,21 +793,22 @@ function fundraiser_sustainers_process_single_recurring_donation(&$log, $recurri
     if (isset($donation->result['success']) && $donation->result['success']) {
       fundraiser_donation_success($donation);
       // Record the success.
-      $log['successes']++;
-      $log_record['success'] = TRUE;
+      $success = $log_record['success'] = TRUE;
       // Perform any post-processing required by the gateway.
       module_invoke_all('fundraiser_sustainers_recurring_success', $donation);
     }
     else {
       $donation->result['success'] = FALSE;
-      $log_record['success'] = FALSE;
+      $success = $log_record['success'] = FALSE;
       fundraiser_donation_decline($donation);
       // Record the fail.
-      $log['fails']++;
     }
 
     // Write the log record.
     drupal_write_record('fundraiser_sustainers_log', $log_record);
+
+    // Return the success flag.
+    return $success;
   }
   else {
     // TODO: Unlock the sustainer record. Currently the lock has not been ported from D6.
@@ -774,6 +816,8 @@ function fundraiser_sustainers_process_single_recurring_donation(&$log, $recurri
     watchdog('fundraiser_sustainers', 'Sustainer order id !did not processed because of sustainer key mismatch. ' .
       'Key file value (!key_file) did not match record value (!record_value).',
       array('!did' => $recurring->did, '!key_file' => $sustainer_key, '!record_value' => $recurring->sustainer_key), WATCHDOG_CRITICAL);
+
+    return FALSE;
   }
 }
 

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -37,12 +37,10 @@ function fundraiser_sustainers_cron() {
     rules_invoke_event('fundraiser_sustainer_health_check_failure', $message);
   }
 
-  if (variable_get('fundraiser_standalone_cron_enabled', 0)) {
-    return 0;
-  }
-  else {
+  // Run the processing on standard cron if enabled.
+  if (variable_get('fundraiser_sustainers_cron_type', NULL) === 'drupal_cron') {
     watchdog('fundraiser_cron', 'Standard cron run.', NULL, WATCHDOG_INFO);
-    fundraiser_sustainers_standalone_cron();
+    _fundraiser_sustainers_process_recurring();
   }
 }
 
@@ -90,7 +88,7 @@ function fundraiser_sustainers_views_api() {
 function fundraiser_sustainers_menu() {
   // Add the cron handler if it's enabled.
   $items['fundraiser_cron'] = array(
-    'page callback' => 'fundraiser_sustainers_standalone_cron',
+    'page callback' => '_fundraiser_sustainers_process_recurring',
     'access callback' => 'fundraiser_sustainers_standalone_cron_access',
     'type' => MENU_CALLBACK,
   );
@@ -239,7 +237,7 @@ function fundraiser_sustainers_springboard_admin_alias_patterns() {
  * Access callback for running standalone cron.
  */
 function fundraiser_sustainers_standalone_cron_access() {
-  if (variable_get('fundraiser_standalone_cron_enabled', 0)) {
+  if (variable_get('fundraiser_sustainers_cron_type', NULL) === 'standalone_http') {
     return TRUE;
   }
   return FALSE;
@@ -272,14 +270,18 @@ function _fundraiser_sustainers_user_has_recurring_donations($user) {
 /**
  * Menu callback for the standalone cron.
  */
-function fundraiser_sustainers_standalone_cron() {
+function _fundraiser_sustainers_process_recurring($max_queue = NULL) {
   // Process recurring donations.
   $process_recurring = TRUE;
   $processor_key_match = fundraiser_sustainers_processor_key_match();
-  drupal_alter('fundraiser_sustainers_process_recurring', $process_recurring);
+  drupal_alter('fundraiser_sustainers_process_recurring', $process_recurring, $max_queue);
 
   if ($process_recurring && $processor_key_match) {
-    fundraiser_sustainers_process_recurring_donations();
+    if (empty($max_queue)) {
+      $max_queue = variable_get('fundraiser_sustainers_max_queue', 1000);
+    }
+
+    _fundraiser_sustainers_process_with_queue($max_queue);
   }
   if (!$process_recurring) {
     $message = t('Standalone sustainer processing has been disabled by another module.');
@@ -671,13 +673,17 @@ function fundraiser_sustainers_fundraiser_donation_delete($donation) {
 
 /**
  * Process recurring donations with a queue.
+ *
+ * @param numeric $max_queue
+ *    Maximum amount of sustainers to queue up and attempt to run.
  */
-function fundraiser_sustainers_process_recurring_donations() {
+function _fundraiser_sustainers_process_with_queue($max_queue = 100) {
   // Provide a hook to allow for modules to respond.
   module_invoke_all('fundraiser_donation_recurring');
 
-  // Keep a running tally of successes and failures.
+  // Keep a running tally of the outcome of the processed donations.
   $log = array(
+    'total' => 0,
     'successes' => 0,
     'fails' => 0,
     'errors' => 0,
@@ -688,18 +694,21 @@ function fundraiser_sustainers_process_recurring_donations() {
   $queue->createQueue();
 
   // Populate our queue with donations.
-  $record_count = variable_get('fundraiser_sustainer_max_queue', 1000);
-  $donations = _fundraiser_sustainers_cron_get_recurring($record_count);
+  $donations = _fundraiser_sustainers_cron_get_recurring($max_queue);
 
   // Loop over the found orders and add to the queue.
   foreach ($donations as $recurring) {
     $queue->createItem($recurring);
   }
 
+  // Track the processing time.
   $end = time() + variable_get('fundraiser_sustainers_queue_time', 30);
 
-  while (time() < $end && ($item = $queue->claimItem())) {
-    // Delete the item before processing.
+  // Process the queue items while we are under the time and max queue settings.
+  while (time() < $end && ($item = $queue->claimItem()) && $log['total'] <= $max_queue) {
+    $log['total']++;
+
+    // Delete the item before processing to avoid a fatal error leaving the sustainer to re-process.
     $queue->deleteItem($item);
 
     // Attempt to process the item.
@@ -716,16 +725,23 @@ function fundraiser_sustainers_process_recurring_donations() {
     }
     catch (Exception $e) {
       watchdog('fundraiser_sustainers', 'Recurring donation !did failed during processing, the error was: @error.',
-        array('!did' => $item->data->did, '@error' => $e->getMessage()));
+        array('!did' => $item->data->did, '@error' => $e->getMessage()), WATCHDOG_ERROR);
 
-      // Update error
+      // Update error logging.
       $log['errors']++;
     }
   }
 
+  // Log the tally of processed donation outcomes.
   if ($log['successes'] > 0 || $log['fails'] > 0) {
-    watchdog('fundraiser_sustainers', '!successes recurring donations processed successfully; !fails failed; errors reported: !errors.',
-      array('!successes' => $log['successes'], '!fails' => $log['fails'], '!errors' => $log['errors']));
+    watchdog('fundraiser_sustainers', '!total recurring donations processed: !successes successful; !fails failed; !errors errors reported.',
+      array('!total' => $log['total'], '!successes' => $log['successes'], '!fails' => $log['fails'], '!errors' => $log['errors']));
+  }
+
+  // Warn about not processing as many donations as are queued.
+  $count = $queue->numberOfItems();
+  if ($count) {
+    watchdog('fundraiser_sustainers', 'The sustainer job did not process all the queued donations, !count remain enqueued.', array('!count' => $count), WATCHDOG_WARNING);
   }
 
   // And after all of that is done, provide a hook to allow for modules to respond.
@@ -1171,13 +1187,41 @@ function fundraiser_sustainers_form_fundraiser_admin_settings_alter(&$form, &$fo
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
   );
-  $form['fundraiser_sustainers']['fundraiser_cron']['fundraiser_standalone_cron_enabled'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Enable standalone cron.'),
-    '#description' => t('If this option is enabled all fundraiser related cron tasks will be removed from the ' .
-      'standard cron run. These tasks will need to be cronned separately via sitename/fundraiser_cron'),
-    '#default_value' => variable_get('fundraiser_standalone_cron_enabled', 0),
+
+  $cron_type_help = t('For the "On a standalone HTTP request" and "Drush" options fundraiser sustainer processing tasks will be removed from the standard cron run.');
+  $cron_type_help .= t(' The http request will need to be cronned separately via a request to site-uri/fundraiser_cron.');
+  $cron_type_help .= t(' For the drush command run "$ drush fundraiser-sustainers-process" from the command line.');
+
+  $form['fundraiser_sustainers']['fundraiser_cron']['fundraiser_sustainers_cron_type'] = array(
+    '#type' => 'select',
+    '#title' => t('Select the type of cron job to run the processor'),
+    '#description' => $cron_type_help,
+    '#default_value' => variable_get('fundraiser_sustainers_cron_type', NULL),
+    '#options' => array(
+      '' => '--Select One--',
+      'drupal_cron' => 'Standard Drupal cron',
+      'standalone_http' => 'On a standalone HTTP request',
+      'drush' => 'With Drush',
+    ),
+    '#required' => TRUE,
   );
+
+  $form['fundraiser_sustainers']['fundraiser_cron']['fundraiser_sustainers_max_queue'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Maximum Donations to Process'),
+    '#description' => t('Maximum amount of donations to attempt during single processing run.'),
+    '#default_value' => variable_get('fundraiser_sustainers_max_queue', 1000),
+    '#element_validate' => array('element_validate_number'),
+  );
+
+  $form['fundraiser_sustainers']['fundraiser_cron']['fundraiser_sustainers_queue_time'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Queue Time'),
+    '#description' => t('Amount of time, in seconds, to run the sustainer processing.'),
+    '#default_value' => variable_get('fundraiser_sustainers_queue_time', 30),
+    '#element_validate' => array('element_validate_number'),
+  );
+
   // CC expiration message to send when sustainer donation is almost out.
   $form['fundraiser_sustainers']['fundraiser_cc_expiration_message'] = array(
     '#type' => 'fieldset',
@@ -1223,9 +1267,11 @@ function fundraiser_sustainers_form_fundraiser_admin_settings_alter(&$form, &$fo
  * Submit handler updates cron menu handler.
  */
 function fundraiser_update_cron_settings($form, $form_state) {
-  $cron_enabled = variable_get('fundraiser_standalone_cron_enabled', 0);
-  if ($cron_enabled != $form_state['values']['fundraiser_standalone_cron_enabled']) {
-    variable_set('fundraiser_standalone_cron_enabled', $form_state['values']['fundraiser_standalone_cron_enabled']);
+  $cron_enabled = variable_get('fundraiser_sustainers_cron_type', NULL);
+  if (
+    $cron_enabled != $form_state['values']['fundraiser_sustainers_cron_type']
+    && $cron_enabled === 'standalone_http'
+  ) {
     // Refresh menu cache.
     menu_rebuild();
   }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -675,7 +675,7 @@ function fundraiser_sustainers_fundraiser_donation_delete($donation) {
  * Process recurring donations with a queue.
  *
  * @param numeric $max_queue
- *    Maximum amount of sustainers to queue up and attempt to run.
+ *   Maximum amount of sustainers to queue up and attempt to run.
  */
 function _fundraiser_sustainers_process_with_queue($max_queue = 100) {
   // Provide a hook to allow for modules to respond.
@@ -689,7 +689,7 @@ function _fundraiser_sustainers_process_with_queue($max_queue = 100) {
     'errors' => 0,
   );
 
-  //Get our queue object.
+  // Get our queue object.
   $queue = new SystemQueue('SustainerQueue');
   $queue->createQueue();
 
@@ -725,7 +725,10 @@ function _fundraiser_sustainers_process_with_queue($max_queue = 100) {
     }
     catch (Exception $e) {
       watchdog('fundraiser_sustainers', 'Recurring donation !did failed during processing, the error was: @error.',
-        array('!did' => $item->data->did, '@error' => $e->getMessage()), WATCHDOG_ERROR);
+        array(
+          '!did' => $item->data->did,
+          '@error' => $e->getMessage()
+        ), WATCHDOG_ERROR);
 
       // Update error logging.
       $log['errors']++;
@@ -1188,14 +1191,14 @@ function fundraiser_sustainers_form_fundraiser_admin_settings_alter(&$form, &$fo
     '#collapsed' => FALSE,
   );
 
-  $cron_type_help = t('For the "On a standalone HTTP request" and "Drush" options fundraiser sustainer processing tasks will be removed from the standard cron run.');
-  $cron_type_help .= t(' The http request will need to be cronned separately via a request to site-uri/fundraiser_cron.');
-  $cron_type_help .= t(' For the drush command run "$ drush fundraiser-sustainers-process" from the command line.');
+  $cron_type_help[] = t('For the "On a standalone HTTP request" and "Drush" options fundraiser sustainer processing tasks will be removed from the standard cron run.');
+  $cron_type_help[] = t('The http request will need to be cronned separately via a request to site-uri/fundraiser_cron.');
+  $cron_type_help[] = t('For the drush command run "$ drush fundraiser-sustainers-process" from the command line.');
 
   $form['fundraiser_sustainers']['fundraiser_cron']['fundraiser_sustainers_cron_type'] = array(
     '#type' => 'select',
     '#title' => t('Select the type of cron job to run the processor'),
-    '#description' => $cron_type_help,
+    '#description' => implode($cron_type_help, ' '),
     '#default_value' => variable_get('fundraiser_sustainers_cron_type', NULL),
     '#options' => array(
       '' => '--Select One--',

--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.admin.inc
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.admin.inc
@@ -29,32 +29,6 @@ function fundraiser_date_mode_admin() {
     '#multiple' => FALSE,
     '#default_value' => variable_get('fundraiser_date_mode_set_dates', '15'),
   );
-  $form['cron_settings'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Sustainer processing'),
-  );
-  $form['cron_settings']['fundraiser_date_mode_batch_record_count'] = array(
-    '#type' => 'textfield',
-    '#size' => 6,
-    '#title' => t('# of records to batch per run'),
-    '#default_value' => variable_get('fundraiser_date_mode_batch_record_count', 1000),
-  );
-  $form['cron_settings']['fundraiser_date_mode_skip_on_cron'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Skip sustainer processing queue on cron'),
-    '#description' => t('If this is checked the sustainer order queue will not be processed when cron is run.'),
-    '#default_value' => variable_get('fundraiser_date_mode_skip_on_cron', TRUE),
-  );
-  $seconds = array_combine(range(1, 60), range(1, 60));
-  $form['cron_settings']['fundraiser_date_mode_set_seconds'] = array(
-    '#type' => 'select',
-    '#title' => t('Seconds spent'),
-    '#description' => t('Set how many seconds for each drupal queue run to spend on the queue processing sustainer charges.
-      If drupal queue is running as part of drupal cron, leave this at about 30 seconds or less so it won\'t time out.
-      If drupal queue is running standalone through drush then this can be higher to process more sustainers in a single run.'),
-    '#options' => $seconds,
-    '#default_value' => variable_get('fundraiser_date_mode_set_seconds', 30),
-  );
 
   $form['batch_warning'] = array(
     '#type' => 'markup',

--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
@@ -7,59 +7,6 @@
  */
 
 /**
- * Implements hook_cron_queue_info().
- *
- * Queue runs on cron unless configured to skip.
- */
-function fundraiser_date_mode_cron_queue_info() {
-  $queues = array();
-  $queues['sustainerQueue'] = array(
-    'worker callback' => 'fundraiser_date_mode_process_queue_item',
-    'time' => variable_get('fundraiser_date_mode_set_seconds', 30),
-    'skip on cron' => variable_get('fundraiser_date_mode_skip_on_cron', TRUE),
-  );
-  return $queues;
-}
-
-/**
- * Implements hook_fundraiser_sustainers_process_recurring_alter().
- */
-function fundraiser_date_mode_fundraiser_sustainers_process_recurring_alter(&$process_recurring) {
-  // When date mode is enabled all sustaining orders for a given month process
-  // on the same day. Fundraiser Sustainers will attempt to process all of
-  // these orders at the same time resulting in timeouts, missed charges, and
-  // other mayhem.
-  //
-  // To prevent this we turn off Fundraiser Sustainer's recurring order process
-  // when date mode is enabled and use Date Mode's processor, which uses a
-  // queue.
-  if (variable_get('fundraiser_date_mode_set_date_mode', FALSE)) {
-    $process_recurring = FALSE;
-    $queue = DrupalQueue::get('sustainerQueue');
-    $queue->createQueue();
-    // Select records (up to configured maximum).
-    $record_count = variable_get('fundraiser_date_mode_batch_record_count', 1000);
-    $donations = _fundraiser_sustainers_cron_get_recurring($record_count);
-    $sustainer_key = fundraiser_sustainers_get_sustainer_key_value();
-    // Loop over the found orders.
-    foreach ($donations as $recurring) {
-      if ($sustainer_key == $recurring->sustainer_key) {
-        $queue->createItem($recurring);
-      }
-      else {
-        // Skip record & unlock.
-        db_query('
-         UPDATE {fundraiser_sustainers}
-         SET lock_id = 0
-         WHERE did = :did',
-          array(':did' => $recurring->did)
-        );
-      }
-    }
-  }
-}
-
-/**
  * Implements hook_permission().
  */
 function fundraiser_date_mode_permission() {
@@ -70,7 +17,6 @@ function fundraiser_date_mode_permission() {
     ),
   );
 }
-
 
 /**
  * Implements hook_menu().
@@ -547,30 +493,6 @@ function _fundraiser_date_mode_alter_next_charge($date, $master_order, $series_o
         fundraiser_date_mode_update_sustainer_date($time_delta, $order['master_did'], $order['did']);
       }
     }
-  }
-}
-
-/**
- * Process a single item from the sustainer queue.
- */
-function fundraiser_date_mode_process_queue_item($item) {
-  // Log that the item has been claimed from the queue for processing.
-  watchdog('fundraiser_sustainers_date_mode', 'Sustainer order id !did has been claimed from the queue for processing.', array('!did' => $item->did), WATCHDOG_NOTICE);
-
-  $sustainer_key = fundraiser_sustainers_get_sustainer_key_value();
-  $recurring = $item;
-  if ($sustainer_key == $recurring->sustainer_key) {
-    $log = array(
-      'successes' => 0,
-      'fails' => 0,
-    );
-    fundraiser_sustainers_process_single_recurring_donation($log, $recurring, $sustainer_key);
-    // If we get to here the transaction has been completed.
-    watchdog('fundraiser_sustainers_date_mode', 'Sustainer order id !did has finished processing.', array('!did' => $recurring->did), WATCHDOG_NOTICE);
-  }
-  else {
-    watchdog('fundraiser_sustainers_date_mode', 'Sustainer key value for order id !did (!record_key) did not match the site\'s sustainer key (!site_key).',
-      array('!did' => $recurring->did, '!record_key' => $recurring->sustainer_key, '!site_key' => $sustainer_key), WATCHDOG_NOTICE);
   }
 }
 

--- a/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers.test
+++ b/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers.test
@@ -266,6 +266,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
    * during normal Drupal cron run.
    */
   public function testFundraiserSustainerNoProcessOnMissingKeyStandardCronRun() {
+    variable_set('fundraiser_sustainers_cron_type', 'drupal_cron');
     // Create a recurring donation to test with.
     $master_did = $this->fundraiserSustainerCreateRecurringDonation();
     // On initial start, there is no key.
@@ -289,7 +290,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
    */
   public function testFundraiserSustainerNoProcessOnMissingKeyStandaloneCronRun() {
     // Turn on standalone cron.
-    variable_set('fundraiser_standalone_cron_enabled', 1);
+    variable_set('fundraiser_sustainers_cron_type', 'standalone_http');
     // Create a recurring donation to test with.
     $master_did = $this->fundraiserSustainerCreateRecurringDonation();
     // On initial start, there is no key.
@@ -312,6 +313,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
    * with a bad key.
    */
   public function testFundraiserSustainerNoProcessOnKeyMismatch() {
+    variable_set('fundraiser_sustainers_cron_type', 'drupal_cron');
     $file_path = variable_get('file_public_path', conf_path() . '/files');
     if (is_writable($file_path)) {
       $this->assertEqual(1, 1, $file_path . ' is writable.');
@@ -348,6 +350,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
    * correctly, but the recurring record has a different value.
    */
   public function testFundraiserSustainerNoProcessOnEnvironmentMismatch() {
+    variable_set('fundraiser_sustainers_cron_type', 'drupal_cron');
     $file_path = variable_get('file_public_path', conf_path() . '/files');
     if (is_writable($file_path)) {
       $this->assertEqual(1, 1, $file_path . ' is writable.');
@@ -371,7 +374,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
       if (file_exists($file_path . '/sustainer.key')) {
         unlink($file_path . '/sustainer.key');
       }
-      file_put_contents($file_path . '/sustainer.key', trim($_SERVER['HTTP_HOST'])); // Set up key correctly for this environment.
+      file_put_contents($file_path . '/sustainer.key', trim($_SERVER['HTTP_HOST']) . rtrim(base_path(), '/')); // Set up key correctly for this environment.
       // With key setup, advance one charge and check the state afterwards.
       $yesterday = strtotime('-1 day'); // Use yesterday because the cron run happens right after setting this
       db_update('fundraiser_sustainers')
@@ -402,6 +405,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
    * correctly, with a matching key value in the key file and in the sustainer record.
    */
   public function testFundraiserSustainerProcessOnEnvironmentMatch() {
+    variable_set('fundraiser_sustainers_cron_type', 'drupal_cron');
     $file_path = variable_get('file_public_path', conf_path() . '/files');
     if (is_writable($file_path)) {
       $this->assertEqual(1, 1, $file_path . ' is writable.');
@@ -410,7 +414,8 @@ class FundraiserSustainerTest extends FundraiserSetup {
       }
       // Set up sustainer key file with a bad key on purpose.
       variable_set('encrypt_secure_key_path', $file_path);
-      file_put_contents($file_path . '/sustainer.key', trim($_SERVER['HTTP_HOST']));
+
+      file_put_contents($file_path . '/sustainer.key', trim($_SERVER['HTTP_HOST']) . rtrim(base_path(), '/'));
       // Create a recurring donation to test with. These donations should have example.production
       // as their sustainer key.
       $master_did = $this->fundraiserSustainerCreateRecurringDonation();
@@ -419,7 +424,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
       foreach ($donations as $donation) {
         // Skip the first order.
         if ($donation->did != $donation->master_did) {
-          $this->assertEqual(trim($_SERVER['HTTP_HOST']), $donation->sustainer_key, 'Sustainer record contains the correct sustainer key.');
+          $this->assertEqual(trim($_SERVER['HTTP_HOST']) . rtrim(base_path(), '/'), $donation->sustainer_key, 'Sustainer record contains the correct sustainer key.');
         }
       }
       // With key setup, advance one charge and check the state afterwards.

--- a/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers.test
+++ b/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers.test
@@ -455,6 +455,42 @@ class FundraiserSustainerTest extends FundraiserSetup {
   }
 
   /**
+   * Test to see if a sustainer failure will be handled correctly.
+   */
+  public function testFundraiserSustainerProcessFailures() {
+    variable_set('fundraiser_sustainers_cron_type', 'drupal_cron');
+    $this->fundraiserSustainerCreateGoodKey();
+
+    // Create a recurring donation to test with.
+    $master_did = $this->fundraiserSustainerCreateRecurringDonationForFailure();
+
+    // Advance one charge and check the state afterwards.
+    db_update('fundraiser_sustainers')
+      ->fields(array(
+        'next_charge' => time() - 3600,
+      ))
+      ->condition('did', 2, '=')
+      ->execute();
+
+    // Run cron.
+    $this->cronRun();
+
+    // Reload the page to render drupal messages.
+    $this->drupalGet('');
+
+    // Donation success message is displayed.
+    $this->assertText(t('Donation transaction failed.'), t('Donation failure message is displayed.'));
+
+    // Get the total number of sustainers processed.
+    $sustainers_processed = $this->fundraiserSustainerSeriesStatusCount($master_did, 'failed');
+
+    // Ensure only the one failed.
+    $this->assertEqual(1, $sustainers_processed, 'Number of sustainers failed is 1.');
+
+    $this->fundraiserSustainerKeyCleanup();
+  }
+
+  /**
    * Helper to create a fundraiser sustainer donation.
    */
   protected function createFundraiserSustainer() {
@@ -500,6 +536,37 @@ class FundraiserSustainerTest extends FundraiserSetup {
   }
 
   /**
+   * Helper function to create a series of recurring donations that will fail.
+   */
+  private function fundraiserSustainerCreateRecurringDonationForFailure() {
+    $file_path = variable_get('file_public_path', conf_path() . '/files');
+    // Set the encryption path to avoid errors during get node, etc.
+    variable_set('encrypt_secure_key_path', $file_path);
+    // Create a node.
+    $created_user = $this->createFundraiserUser();
+    $this->drupalLogin($created_user);
+    $node = $this->createDonationForm();
+    // Post to the node.
+    $month = date('n', strtotime('+1 year'));
+    $year = date('Y', strtotime('+1 year'));
+    $post['submitted[payment_information][recurs_monthly][recurs]'] = 'recurs';
+    $post['submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_month]'] = $month;
+    $post['submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_year]'] = $year;
+    $post['submitted[donor_information][mail]'] = $created_user->mail;
+    // The example gateway will fail a sustainer with the 55555 zip code.
+    $post['submitted[billing_information][zip]'] = '55555';
+    $this->submitDonation($node->nid, $post);
+    // Get the master did.
+    $donations = _fundraiser_get_donations();
+    $master_did = '';
+    foreach ($donations as $donation) {
+      $master_did = $donation->did;
+      break;
+    }
+    return $master_did;
+  }
+
+  /**
    * Helper function to check how many sustainers were processed after cron is run.
    */
   private function fundraiserSustainerChargeCount($master_did) {
@@ -509,6 +576,56 @@ class FundraiserSustainerTest extends FundraiserSetup {
       ->condition('gateway_resp', 'success', '=')
       ->condition('did', $master_did, '!='); // exclude first order in series
     return $query->countQuery()->execute()->fetchField();
+  }
+
+  /**
+   * Get a count for a status, or array of statuses for a series.
+   *
+   * @param numeric $master_did
+   *   The did of the master donatoin for this series.
+   *
+   * @param mixed $status
+   *   Single status or array of statuses to filter on.
+   *
+   * @return
+   *   The count for sustainer's matching that status.
+   */
+  private function fundraiserSustainerSeriesStatusCount($master_did, $status) {
+    $query = db_select('fundraiser_sustainers', 'f')
+      ->fields('f')
+      ->condition('master_did', $master_did, '=')
+      ->condition('gateway_resp', $status)
+      ->condition('did', $master_did, '!='); // exclude first order in series
+
+    return $query->countQuery()->execute()->fetchField();
+  }
+
+  /**
+   * Create a good sustainer key.
+   */
+  public function fundraiserSustainerCreateGoodKey() {
+    $file_path = variable_get('file_public_path', conf_path() . '/files');
+    if (is_writable($file_path)) {
+      $this->assertEqual(1, 1, $file_path . ' is writable.');
+      if (file_exists($file_path . '/sustainer.key')) {
+        unlink($file_path . '/sustainer.key');
+      }
+      // Set the encrypt key path setting.
+      variable_set('encrypt_secure_key_path', $file_path);
+
+      file_put_contents($file_path . '/sustainer.key', trim($_SERVER['HTTP_HOST']) . rtrim(base_path(), '/'));
+    }
+  }
+
+  /**
+   * To avoid issues with other tests clear the sustainer key.
+   */
+  public function fundraiserSustainerKeyCleanup() {
+    // Remove the key file.
+    $file_path = variable_get('file_public_path', conf_path() . '/files');
+    if (file_exists($file_path . '/sustainer.key')) {
+      unlink($file_path . '/sustainer.key');
+    }
   }
 
 }


### PR DESCRIPTION
To prevent timeouts and stuck sustainers this update:
- Uses a Drupal queue for processing sustainers
- Adds a Drush command for running the sustainer queue
- Fixes the sustainer tests and adds a test for failure handling
- Removes the Fundraiser Date Mode module's specific queue code
