### PR TITLE
Sustainers performance enhancements

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -1880,7 +1880,7 @@ function fundraiser_sustainers_billing_update_form_submit($form, &$form_state) {
     global $user;
     $username = isset($user->name) ? $user->name : 'Anonymous';
     fundraiser_donation_comment($donation, 'The card to be charged was changed on @date by @username.',
-      array('@date' => format_date(strtotime('now')), '@username' => $username));
+      array('@date' => format_date(REQUEST_TIME), '@username' => $username));
     watchdog('fundraiser_sustainers', 'Billing information updated for #@did.',
       array('@did' => $donation->did));
 

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -2650,12 +2650,16 @@ function _fundraiser_sustainers_get_donations_recurr_by_masterdid($master_did) {
  * DB funct, count order donation sets that are remaining.
  */
 function _fundraiser_sustainers_count_donations_recurr_remaining($master_did) {
-  $donations = _fundraiser_sustainers_get_donations_recurr_remaining($master_did);
-  $count = 0;
-  foreach ($donations as $donation) {
-    $count++;
-  }
-  return $count;
+  $max_processing_attempts = variable_get('fundraiser_sustainers_max_processing_attempts', 3);
+  $replacements = array(
+    ':master_did' => $master_did,
+    ':status' => FUNDRAISER_SUSTAINERS_RETRY_STATUS,
+    ':max_attempts' => $max_processing_attempts,
+  );
+
+  $count = db_query('SELECT COUNT(*) FROM {fundraiser_sustainers} r WHERE r.master_did = :master_did AND (r.gateway_resp IS NULL OR (r.gateway_resp = :status && r.attempts != :max_attempts))', $replacements)->fetchField();
+
+  return is_numeric($count) ? $count : 0;
 }
 
 /**

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -1302,7 +1302,7 @@ function fundraiser_sustainers_edit_form($did) {
   $billing_info .= '</div>';
 
   // Format payment schedule into a data table
-  $donation_set = _fundraiser_sustainers_get_donations_recurr_by_member($did);
+  $donation_set = _fundraiser_sustainers_get_donations_recurr_by_masterdid($did);
   $donations_header = array('Donation ID', 'Amount', 'Charge Date', 'Processed Status');
 
   if (user_access('administrate recurring donations')) {
@@ -2603,7 +2603,7 @@ function _fundraiser_sustainers_get_donation_sets() {
 function _fundraiser_sustainers_get_donations_recurr_by_member($did) {
   $donations = db_query('SELECT * FROM {fundraiser_sustainers} r ' .
     'LEFT JOIN {fundraiser_donation} d on r.did = d.did ' .
-    'WHERE d.did = :did OR r.master_did = :master_did ' .
+    'WHERE r.did = :did OR r.master_did = :master_did ' .
     'ORDER BY r.next_charge ASC', array(':did' => $did, ':master_did' => $did))->fetchAll();
   return $donations;
 }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -1585,11 +1585,12 @@ function fundraiser_sustainers_donation_date_form_submit($form, &$form_state) {
  */
 function fundraiser_sustainers_change_charge_date($master_did, $new_day) {
   $donations = _fundraiser_sustainers_get_donations_recurr_remaining($master_did);
-  $current_time = _fundraiser_sustainers_explode_date(time());
+  $time = time();
+  $current_time = _fundraiser_sustainers_explode_date($time);
   foreach ($donations as $donation) {
     $old_charge_date = $donation->next_charge;
     // Ignore orders that are ready to process.
-    if ($old_charge_date < time()) {
+    if ($old_charge_date < $time) {
       continue;
     }
     $donation_time = _fundraiser_sustainers_explode_date($old_charge_date);

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -305,10 +305,10 @@ function fundraiser_sustainers_charge_now($did) {
   // Given a did, update the charge date to now.
   $donation = new stdClass();
   $donation->did = $did;
-  $donation->next_charge = strtotime('now');
+  $donation->next_charge = REQUEST_TIME;
   _fundraiser_sustainers_update_recurring($donation);
   drupal_set_message(t('The charge date for donation #@did has been advanced to @date. It will be charged on the next Fundraiser cron.',
-    array('@did' => $did, '@date' => format_date(strtotime('now')))));
+    array('@did' => $did, '@date' => format_date(REQUEST_TIME))));
   // Afterwards return where we came from.
   drupal_goto( drupal_get_destination() );
 }


### PR DESCRIPTION
 - Replaces strtotime('now') in a few places where being off by a second or two shouldn't matter.
 - Changes the by_member() call on the sustainer edit form to by_masterdid().
 - Updates the by_member() query to use the base table in the WHERE clause instead of the joined table.
 - Creates a count remaining donation query that doesn't use a LEFT JOIN or ORDER BY and does the count inside the query. This is used on the sustainer edit form and on the donation success hook implementation.
