### PR TITLE
For sb admin menu items set a default module value.

### DIFF
--- a/springboard/modules/springboard_admin/springboard_admin.menu.inc
+++ b/springboard/modules/springboard_admin/springboard_admin.menu.inc
@@ -377,6 +377,12 @@ function springboard_admin_create_menu_item($item, &$mlids, $plid = 0, $parent =
   if ($plid > 0) {
     $item['plid'] = $plid;
   }
+
+  // Set a default module value.
+  if (!isset($item['module'])) {
+    $item['module'] = 'menu';
+  }
+
   // Save a the item.
   $mlid = menu_link_save($item, array(), array($plid => $parent));
   $mlids[] = $mlid;


### PR DESCRIPTION
Without setting a menu item's module these php notices appear when rebuilding the sb menu:

Notice: Undefined index: module in user_menu_link_alter() (line 1888 of /modules/user/user.module).
Notice: Undefined index: module in user_menu_link_alter() (line 1894 of /modules/user/user.module).