### PR TITLE
Add fundraiser_status value to each order status

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -346,10 +346,14 @@ function fundraiser_commerce_commerce_order_status_info() {
  * Implements hook_commerce_order_status_info_alter().
  */
 function fundraiser_commerce_commerce_order_status_info_alter(&$order_statuses) {
-  // Loop through the statuses used by fundraiser and flag them.
-  foreach (_fundraiser_commerce_commerce_order_statuses_used() as $status) {
-    if (isset($order_statuses[$status])) {
+  // Loop through the statuses and flag the one's fundraiser uses.
+  $fundraiser_statuses = _fundraiser_commerce_commerce_order_statuses_used();
+  foreach ($order_statuses as $status => $properties) {
+    if (in_array($status, $fundraiser_statuses)) {
       $order_statuses[$status]['fundraiser_status'] = TRUE;
+    }
+    else {
+      $order_statuses[$status]['fundraiser_status'] = FALSE;
     }
   }
 }


### PR DESCRIPTION
This adds the fundraiser_status property to each Commerce order status. It sets the value to FALSE for non-fundraiser statuses.

If the popertry is only added to the fundraiser statuses then Undefined index errors will appear on the donation stage mapping form.