### PR TITLE
Add 'skipped' to list of used order statuses.

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -366,6 +366,7 @@ function _fundraiser_commerce_commerce_order_statuses_used() {
     'refunded',
     'partially_refunded',
     'payment_received',
+    'skipped',
   );
 }
 


### PR DESCRIPTION
This value needs to be here so the 'skipped' status can be mapped to an SF stage.