### PR TITLE
Adds a filter on P2P action to only show donors with successful donations

### DIFF
--- a/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.views_default.inc
+++ b/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.views_default.inc
@@ -1440,6 +1440,11 @@ function springboard_p2p_personal_campaign_views_default_views() {
   $handler->display->display_options['arguments']['nid_1']['summary']['number_of_records'] = '0';
   $handler->display->display_options['arguments']['nid_1']['summary']['format'] = 'default_summary';
   $handler->display->display_options['arguments']['nid_1']['summary_options']['items_per_page'] = '25';
+  /* Filter criterion: P2P action: Status */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'springboard_p2p_personal_campaign_action';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = '1';
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page_1');


### PR DESCRIPTION
This change will require a features revert on Springboard P2P Personal Campaigns.

Alternatively, add the filter manually. On the donor dashboard View, add a filter on P2P Action: Status and set Visible to Yes.
