### PR TITLE
PHP notices caused by P2P email wrappers token set

### DIFF
--- a/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.module
+++ b/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.module
@@ -314,7 +314,15 @@ function springboard_p2p_personal_campaign_webform_confirmations_token_replace_a
   }
 }
 
+/**
+ * Implements hook_email_wrappers_token_set_alter().
+ */
 function springboard_p2p_personal_campaign_email_wrappers_token_set_alter(&$token_set, $message) {
+  // Not all email wrapper messages come with a submission.
+  if (!isset($message['params']['submission'])) {
+    return;
+  }
+
   $submission = $message['params']['submission'];
   $components = _fundraiser_webform_get_components_by_nid($submission->nid);
   $personal_campaign = _springboard_p2p_personal_campaign_lookup_personal_campaign($submission, $components);


### PR DESCRIPTION
P2P adds some tokens to email wrappers messages. The problem was upsell sends an email but doesn't include $message['params']['submission'] so a few PHP notices resulted.

This change checks first.
