### PR TITLE
Change some market source p2p personal campaign fields to textareas

### DIFF
--- a/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.features.field_base.inc
+++ b/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.features.field_base.inc
@@ -61,11 +61,9 @@ function springboard_p2p_personal_campaign_field_default_field_bases() {
     ),
     'locked' => 0,
     'module' => 'text',
-    'settings' => array(
-      'max_length' => 255,
-    ),
+    'settings' => array(),
     'translatable' => 0,
-    'type' => 'text',
+    'type' => 'text_long',
   );
 
   // Exported field_base: 'field_ms_ms'
@@ -119,11 +117,9 @@ function springboard_p2p_personal_campaign_field_default_field_bases() {
     ),
     'locked' => 0,
     'module' => 'text',
-    'settings' => array(
-      'max_length' => 255,
-    ),
+    'settings' => array(),
     'translatable' => 0,
-    'type' => 'text',
+    'type' => 'text_long',
   );
 
   // Exported field_base: 'field_ms_search_engine'

--- a/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.features.field_instance.inc
+++ b/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.features.field_instance.inc
@@ -134,9 +134,9 @@ function springboard_p2p_personal_campaign_field_default_field_instances() {
       'active' => 1,
       'module' => 'text',
       'settings' => array(
-        'size' => 60,
+        'rows' => 5,
       ),
-      'type' => 'text_textfield',
+      'type' => 'text_textarea',
       'weight' => 13,
     ),
   );
@@ -205,17 +205,18 @@ function springboard_p2p_personal_campaign_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'field_ms_referrer',
     'label' => 'Referrer',
-    'required' => FALSE,
+    'required' => 0,
     'settings' => array(
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
+      'active' => 1,
       'module' => 'text',
       'settings' => array(
-        'size' => 60,
+        'rows' => 5,
       ),
-      'type' => 'text_textfield',
+      'type' => 'text_textarea',
       'weight' => 12,
     ),
   );

--- a/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.info
+++ b/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.info
@@ -91,4 +91,5 @@ features[views_view][] = p2p_personal_campaigns_by_category
 features[views_view][] = p2p_suggested_donation
 features[views_view][] = p2p_top_personal_campaigns_by_category
 features[views_view][] = personal_campaign_donor_dashboard
+mtime = 1421423212
 project path = sites/all/modules/springboard/springboard_p2p/modules

--- a/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.install
+++ b/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.install
@@ -26,3 +26,43 @@ function springboard_p2p_personal_campaign_update_7002() {
   // In case of field type change, revert the feature
   features_revert(array('springboard_p2p_personal_campaign' => array('field')));
 }
+
+/**
+ * Change field_ms_referrer and field_ms_initial_referrer to textareas.
+ */
+function springboard_p2p_personal_campaign_update_7003() {
+
+  $fields = array(
+    'field_ms_referrer',
+    'field_ms_initial_referrer',
+  );
+
+  foreach ($fields as $field_name) {
+    // Manual database changes.
+    db_update('field_config')
+      ->fields(array('type' => 'text_long'))
+      ->condition('field_name', $field_name)
+      ->execute();
+
+    $data_table = 'field_data_' . $field_name;
+    $revision_table = 'field_revision_' . $field_name;
+    $value_field = $field_name . '_value';
+
+    // From text.install for long text fields
+    $textarea_spec = array(
+      'type' => 'text',
+      'size' => 'big',
+      'not null' => FALSE,
+    );
+
+    db_change_field($data_table, $value_field, $value_field, $textarea_spec);
+
+    db_change_field($revision_table, $value_field, $value_field, $textarea_spec);
+  }
+
+  // Clear caches.
+  field_cache_clear(TRUE);
+
+  // Apply the new field instance configuration.
+  features_revert(array('springboard_p2p_personal_campaign' => array('field')));
+}


### PR DESCRIPTION
(originally PR https://github.com/JacksonRiver/springboard_modules/pull/683)

Changed p2p ms referrer and p2p ms initial referrer to textareas in an update hook and updated the features.

This reverts the p2p personal campaign feature for fields when the update hook is run.