### PR TITLE
Reinstating template specific css class on form element.

### DIFF
--- a/form_layouts/form_layouts.module
+++ b/form_layouts/form_layouts.module
@@ -183,6 +183,8 @@ function form_layouts_form_webform_client_form_alter(&$form, &$form_state, $form
 
   if (form_layouts_template_themes_webform($template)) {
     $form['#theme'] = array($template['theme'] . '_' . $nid, $template['theme']);
+    $form['#attributes']['class'][] = 'form-layouts';
+    $form['#attributes']['class'][] = $template['template'];
   }
 }
 


### PR DESCRIPTION
This update reinstates the template specific css class that form layouts would add to the form element. This feature was lost during updates to form layouts in 4.5.