### PR TITLE
Token replacement in webform emails

### DIFF
--- a/email_wrappers/email_wrappers.module
+++ b/email_wrappers/email_wrappers.module
@@ -114,6 +114,7 @@ function email_wrappers_form_webform_submission_resend_alter(&$form, &$form_stat
       }
   }
 }
+
 /**
  * Overrides webform_submission_resend_submit()
  */
@@ -180,7 +181,6 @@ function email_wrappers_form_webform_emails_form_alter(&$form, $form_state) {
     if ($cid) {
       $form['add']['email_component']['#default_value'] = $cid;
     }
-
   }
 }
 
@@ -191,29 +191,24 @@ function email_wrappers_form_webform_emails_form_alter(&$form, $form_state) {
  * settings form.
  */
 function email_wrappers_form_webform_email_edit_form_alter(&$form, &$form_state, $form_id) {
-
   // Add a few tweaks to the webform email list form.
   if ($form_id === 'webform_email_edit_form') {
     $path = drupal_get_path('module', 'email_wrappers');
-    drupal_add_js($path . '/script/email_wrappers.template_select.js');
-    $template_nid = FALSE;
-    if (isset($form_state['input']['email_wrappers_email_template']) && $form_state['input']['email_wrappers_email_template']) {
-      $template_nid = $form_state['input']['email_wrappers_email_template'];
-    }
-    ctools_include('ajax');
-    ctools_include('modal');
-    ctools_modal_add_js();
+    // Attached the script for showing a warning.
+    $form['#attached']['js'][] = $path . '/script/email_wrappers.template_select.js';
+
+    // Include the ctools functions for the modal preview.
+    ctools_form_include($form_state, 'ajax');
+    ctools_form_include($form_state, 'modal');
+    // We have to use an after build to run ctools_modal_add_js() when form is cached.
+    $form['#after_build'][] = '_email_wrappers_form_webform_email_edit_after_build';
+
     global $base_path;
 
     $defaults = array();
     // Check the db for settings.
     if (isset($form['eid']['#value'])) {
       $defaults = email_wrappers_load_settings($form['node']['#value']->nid, $form['eid']['#value']);
-    }
-
-    // No settings available, load defaults from the selected template.
-    if ($template_nid) {
-      $defaults = email_wrappers_load_defaults_from_template($form_state['input']['email_wrappers_email_template']);
     }
 
     // Alter email header values based on defaults.
@@ -227,30 +222,32 @@ function email_wrappers_form_webform_email_edit_form_alter(&$form, &$form_state,
       _email_wrappers_webform_option_defaults($form, 'from_name', $defaults['from_name']);
     }
 
+    if (!isset($defaults['html_message'])) {
+      $defaults['html_message'] = '';
+    }
+
+    if (!isset($defaults['text_message'])) {
+      $defaults['text_message'] = '';
+    }
+
     // We're gonna cache these since they may come in handy later.
     $form['email_wrappers_defaults'] = array(
       '#type' => 'value',
       '#value' => $defaults,
     );
 
-    // Set ajax target div.
-    $form['#prefix'] = '<div id="webform-email-form-wrapper">';
-    $form['#suffix'] = '</div>';
-
     $form['email_wrappers_email_template'] = array(
       '#type' => 'select',
-      '#title' => t('Template'),
+      '#title' => t('Email Template'),
       '#options' => _email_wrappers_list_templates(),
+      '#description' => t('Select a template to load its settings and provide additional functionality.'),
       '#weight' => -50,
       '#default_value' => (isset($defaults['tid']) && $defaults['tid']) ? $defaults['tid'] : 0,
       '#ajax' => array(
         'callback' => 'email_wrappers_email_ajax',
-        'wrapper' => 'webform-email-form-wrapper',
-        'effect' => 'fade',
       ),
     );
 
-    // Add bcc field.
     $form['email_wrappers_bcc'] = array(
       '#type' => 'textfield',
       '#title' => t('BCC addresses'),
@@ -264,41 +261,52 @@ function email_wrappers_form_webform_email_edit_form_alter(&$form, &$form_state,
       ),
     );
 
-    // Throw some defaults at webform's built in templating system since
-    // it's being overridden anyway.
-    if ((isset($form_state['input']['email_wrappers_email_template']) && $form_state['input']['email_wrappers_email_template']) || isset($defaults['html_message'])) {
+    // Hide webform's built in templating system when a template is selected.
+    $form['template']['template_option']['#states'] = array(
+      'invisible' => array(
+        ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+      ),
+    );
 
-      $form['template']['template_option']['#access'] = FALSE;
+    $form['template']['template']['#states'] = array(
+      'invisible' => array(
+        ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+      ),
+    );
 
-      $form['template']['template']['#access'] = FALSE;
+    // TODO: include filter settings?
+    $form['template']['email_wrappers_html_message'] = array(
+      '#type' => 'textarea',
+      '#title' => t('HTML message'),
+      '#description' => t('This version of your message will be displayed by users who can view HTML email'),
+      '#default_value' => $defaults['html_message'],
+      '#states' => array(
+        'visible' => array(
+          ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+         ),
+        'required' => array(
+          ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+        ),
+      ),
+    );
 
-      // TODO: include filter settings?
-      $form['template']['email_wrappers_html_message'] = array(
-        '#type' => 'textarea',
-        '#title' => t('HTML message'),
-        '#description' => t('This version of your message will be displayed by users who can view HTML email'),
-        '#default_value' => $defaults['html_message'],
-        '#required' => TRUE,
-      );
+    $form['template']['email_wrappers_text_message'] = array(
+      '#type' => 'textarea',
+      '#title' => t('Text-only message (no HTML allowed)'),
+      '#description' => t('This version of your message will be displayed if a user can only view email in plaintext.'),
+      '#default_value' => $defaults['text_message'],
+      '#states' => array(
+        'visible' => array(
+           ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+        ),
+        'required' => array(
+          ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+        ),
+      ),
+    );
 
-      $form['template']['email_wrappers_text_message'] = array(
-        '#type' => 'textarea',
-        '#title' => t('Text-only message (no HTML allowed)'),
-        '#description' => t('This version of your message will be displayed if a user can only view email in plaintext.'),
-        '#default_value' => $defaults['text_message'],
-        '#required' => TRUE,
-      );
-
-      $form['template']['tokens']['#weight'] = 9;
-      $form['template']['components']['#weight'] = 10;
-
-      // Unset $form_state['input'] values so imported template defaults
-      // aren't overwritten by $_POST values during ajax
-      // @see:http://drupal.org/node/990502
-      unset($form_state['input']['email_wrappers_html_message']);
-      unset($form_state['input']['email_wrappers_text_message']);
-      unset($form_state['input']['email_wrappers_bcc']);
-    }
+    $form['template']['tokens']['#weight'] = 9;
+    $form['template']['components']['#weight'] = 10;
 
     // Ctools modals setup for preview button.
     $form['template']['preview_url'] = array(
@@ -306,13 +314,22 @@ function email_wrappers_form_webform_email_edit_form_alter(&$form, &$form_state,
       '#attributes' => array('class' => array('email-wrappers-preview-url')),
       '#value' => url('email_wrappers/preview_modal/nojs/preview'),
     );
-    $form['template']['preview'] = array(
-      '#type' => 'button',
-      '#id' => 'email-wrappers-preview',
-      '#value' => t('Preview'),
-      '#attributes' => array('class' => array('ctools-use-modal')),
+
+    $form['template']['preview-container'] = array(
+      '#type' => 'container',
       '#weight' => 20,
+      '#states' => array(
+        'visible' => array(
+          ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+        ),
+      ),
     );
+    $form['template']['preview-container']['preview'] = array(
+      '#type' => 'button',
+      '#value' => t('Preview'),
+      '#attributes' => array('class' => array('ctools-use-modal'), 'id' => 'email-wrappers-preview'),
+    );
+
     $form['#validate'][] = 'email_wrappers_email_validate_callback';
     $form['#submit'][] = 'email_wrappers_email_submit_callback';
   }
@@ -323,29 +340,25 @@ function email_wrappers_form_webform_email_edit_form_alter(&$form, &$form_state,
 }
 
 /**
- * Validation callback for webform email edit form.
+ * After build function to run ctools_modal_add_js().
  */
-function email_wrappers_email_validate_callback(&$form, &$form_state) {
-  // TODO: validate and clean up email addresses.
+function _email_wrappers_form_webform_email_edit_after_build($form, $form_state) {
+  ctools_modal_add_js();
+  return $form;
+}
 
-  // Fix inconsistencies between submitted input and $form_state['values']
-  // This is caused by setting #value on header detail fields. Note: simply
-  // setting #default_value on these fields causes defaults to not render
-  // after the template select ajax event has executed.
-  $keys = array('subject', 'from_address', 'from_name');
-  foreach ($keys as $key) {
-    $fields = array('option', 'custom', 'component');
-    foreach ($fields as $field) {
-      $full_key = $key . '_' . $field;
-      // Not all of these input items are available when using the AJAX
-      // prefill template selector.
-      if (isset($form_state['input'][$full_key])) {
-        $form_state['values'][$full_key] = $form_state['input'][$full_key];
-      }
-      else {
-        // Maintain current behavior when the input value is not set.
-        $form_state['values'][$full_key] = NULL;
-      }
+/**
+ * Validate callback for webform email edit form.
+ */
+function email_wrappers_email_validate_callback($form, $form_state) {
+  if (!empty($form_state['values']['email_wrappers_email_template'])) {
+    // Display error if the HTML or text messages are empty.
+    if (empty($form_state['values']['email_wrappers_html_message'])) {
+      form_error($form['template']['email_wrappers_html_message'], t('HTML message field is required.'));
+    }
+
+    if (empty($form_state['values']['email_wrappers_text_message'])) {
+      form_error($form['template']['email_wrappers_text_message'], t('Text message field is required.'));
     }
   }
 }
@@ -356,10 +369,10 @@ function email_wrappers_email_validate_callback(&$form, &$form_state) {
 function email_wrappers_email_submit_callback($form, $form_state) {
   $values = $form_state['values'];
 
-  // If any information has been added to "extra" by other modules,
-  // it is saved at this time. This approach allows other modules to append
-  // useful configuration information to the email without having to join
-  // across a bunch of lookup tables to get all the settings for a given mail.
+  // Delete any existing configurations for this email.
+  email_wrappers_delete_settings($values['node']->nid, $values['eid']);
+
+  // Save the new settings.
   if (is_numeric($values['email_wrappers_email_template']) && $values['email_wrappers_email_template'] > 0) {
     $settings = array(
       'nid' => $values['node']->nid,
@@ -369,9 +382,10 @@ function email_wrappers_email_submit_callback($form, $form_state) {
       'html_message' => $values['email_wrappers_html_message'],
       'html_message_format' => '',
       'text_message' => $values['email_wrappers_text_message'],
+      // If any information has been added to "extra" by other modules,
+      // it is saved at this time.
       'extra' => !empty($form_state['extra']) ? serialize($form_state['extra']) : serialize(array()),
     );
-    email_wrappers_delete_settings($values['node']->nid, $values['eid']);
     email_wrappers_save_settings($values['node']->nid, $values['eid'], $settings);
   }
 }
@@ -575,6 +589,7 @@ function email_wrappers_mail_alter(&$message) {
       'node' => isset($message['params']['node']) ? $message['params']['node'] : NULL,
     );
     $message['subject'] = token_replace($message['params']['mail']->subject, $token_set, array('clear' => TRUE));
+
     $message['body'] = array(email_wrappers_render_email_body(FALSE, $message));
 
     // Add Cc and Bcc headers if needed.
@@ -921,14 +936,41 @@ function _email_wrappers_concat_bcc($node) {
 function _email_wrappers_webform_option_defaults(&$form, $field_key, $value) {
   $form[$field_key . '_option']['default']['#value'] = '';
   $form[$field_key . '_option']['custom']['#value'] = 'custom';
-  $form[$field_key . '_custom']['#value'] = $value;
+  $form[$field_key . '_custom']['#default_value'] = $value;
 }
 
 /**
  * Ajax callback for template select box.
  */
 function email_wrappers_email_ajax($form, $form_state) {
-  return $form;
+  // Load the default settings for the selected template.
+  $template_nid = $form_state['values']['email_wrappers_email_template'];
+  if (empty($template_nid)) {
+    return array();
+  }
+
+  $defaults = email_wrappers_load_defaults_from_template($template_nid);
+
+  $commands = array();
+
+  // Set the values on the various webform email settings.
+  $commands[] = ajax_command_invoke('input[name=subject_option][value=custom]', 'prop', array('checked', TRUE));
+  $commands[] = ajax_command_invoke('input[name=subject_custom]', 'val', array($defaults['subject']));
+
+  $commands[] = ajax_command_invoke('input[name=from_name_option][value=custom]', 'prop', array('checked', TRUE));
+  $commands[] = ajax_command_invoke('input[name=from_name_custom]', 'val', array($defaults['from_name']));
+
+  $commands[] = ajax_command_invoke('input[name=from_address_option][value=custom]', 'prop', array('checked', TRUE));
+  $commands[] = ajax_command_invoke('input[name=from_address_custom]', 'val', array($defaults['from_mail']));
+
+  // BCC email will be an array when coming from the node.
+  $bcc_email = is_array($defaults['bcc_email']) ? implode($defaults['bcc_email'], ',') : $defaults['bcc_email'];
+  $commands[] = ajax_command_invoke('input[name=email_wrappers_bcc]', 'val', array($bcc_email));
+
+  $commands[] = ajax_command_invoke('textarea[name=email_wrappers_html_message]', 'val', array($defaults['html_message']));
+  $commands[] = ajax_command_invoke('textarea[name=email_wrappers_text_message]', 'val', array($defaults['text_message']));
+
+  return array('#type' => 'ajax', '#commands' => $commands);
 }
 
 /**

--- a/email_wrappers/tests/email_wrappers.test
+++ b/email_wrappers/tests/email_wrappers.test
@@ -5,7 +5,7 @@
  * Common functions for all the secure prepopulate tests.
  */
 
-class EmailWrappersTestCase extends DrupalWebTestCase {
+class EmailWrappersTestCase extends AJAXTestCase {
 
   public static function getInfo() {
     return array(
@@ -73,15 +73,69 @@ class EmailWrappersTestCase extends DrupalWebTestCase {
     // confirm settings ui available
     $this->assertOptionSelected('edit-email-wrappers-email-template', 0, t('Email template selection field present on form with no default selected.'));
 
-    // confirm select ajax populates fields
+    // Confirm ajax commands are correct.
     $edit['email_wrappers_email_template'] = 2;
-    $this->drupalPostAJAX(NULL, $edit, 'email_wrappers_email_template');
-    $this->assertFieldByName('email_wrappers_bcc', 'bcc0@example.com', t('BCC default inherited from template selection'));
-    $this->assertFieldByName('subject_custom', 'Test webform submission mail', t('Subject default inherited from template selection'));
-    $this->assertFieldByName('from_address_custom', 'from@example.com', t('From address default inherited from template selection'));
-    $this->assertFieldByName('from_name_custom', 'Email Wrappers Test', t('From name default inherited from template selection'));
-    $this->assertFieldByName('email_wrappers_html_message', '<p>This is an html message</p>', t('HTML message default inherited from template selection'));
-    $this->assertFieldByName('email_wrappers_text_message', 'This is a text message', t('Text message default inherited from template selection'));
+    $commands = $this->drupalPostAJAX(NULL, $edit, 'email_wrappers_email_template');
+
+    $expected = array(
+      'command' => 'invoke',
+      'selector' => 'input[name=email_wrappers_bcc]',
+      'method' => 'val',
+      'arguments' => array(
+        0 => 'bcc0@example.com',
+      ),
+    );
+    $this->assertCommand($commands, $expected, 'BCC default inherited from template selection');
+
+    $expected = array(
+      'command' => 'invoke',
+      'selector' => 'input[name=subject_custom]',
+      'method' => 'val',
+      'arguments' => array(
+        0 => 'Test webform submission mail',
+      ),
+    );
+    $this->assertCommand($commands, $expected, 'Subject default inherited from template selection');
+
+    $expected = array (
+      'command' => 'invoke',
+      'selector' => 'input[name=from_address_custom]',
+      'method' => 'val',
+      'arguments' => array(
+        0 => 'from@example.com',
+      ),
+    );
+    $this->assertCommand($commands, $expected, 'From address default inherited from template selection');
+
+    $expected = array(
+      'command' => 'invoke',
+      'selector' => 'input[name=from_name_custom]',
+      'method' => 'val',
+      'arguments' => array(
+        0 => 'Email Wrappers Test',
+      ),
+    );
+    $this->assertCommand($commands, $expected, 'From name default inherited from template selection');
+
+    $expected = array(
+      'command' => 'invoke',
+      'selector' => 'textarea[name=email_wrappers_html_message]',
+      'method' => 'val',
+      'arguments' => array(
+         0 => '<p>This is an html message</p>',
+       ),
+    );
+    $this->assertCommand($commands, $expected, 'HTML message default inherited from template selection');
+
+    $expected = array(
+      'command' => 'invoke',
+      'selector' => 'textarea[name=email_wrappers_text_message]',
+      'method' => 'val',
+      'arguments' => array(
+        0 => 'This is a text message',
+      ),
+    );
+    $this->assertCommand($commands, $expected, 'Text message default inherited from template selection');
 
     // save
     $edit = array(

--- a/webform_confirmations/webform_confirmations.module
+++ b/webform_confirmations/webform_confirmations.module
@@ -147,13 +147,19 @@ function webform_confirmations_get_submission_session($sid) {
 /**
  * Implements hook_form_FORM_ID_alter().
  *
- *  Conditionally add send on order success checkbox to webform email configuration forms.
+ * Conditionally add send on order success checkbox to webform email configuration forms.
  */
 function webform_confirmations_form_webform_email_edit_form_alter(&$form, $form_state, $form_id) {
+  // We can only control the sending of emails and Drupal token replacement when working with email wrappers.
+  if (!module_exists('email_wrappers')) {
+    return;
+  }
+
   $node = $form['node']['#value'];
   $is_donation = fundraiser_is_donation_type($form['node']['#value']->type);
 
-  if (module_exists('email_wrappers') && !empty($is_donation)) {
+  // For donations add the option to choose when to send.
+  if (!empty($is_donation)) {
     $node = $form['node']['#value'];
     $send_default = _webform_confirmation_send_on_settings($form_state);
     $send_options = array(
@@ -161,7 +167,7 @@ function webform_confirmations_form_webform_email_edit_form_alter(&$form, $form_
       1 => t('Donation succeeds'),
       2 => t('Donation fails'),
     );
-    // TODO: correctly set default on this form element based on prior settings.
+
     $form['send_on_settings'] = array(
       '#type' => 'radios',
       '#title' => t('Send when'),
@@ -169,38 +175,49 @@ function webform_confirmations_form_webform_email_edit_form_alter(&$form, $form_
       '#options' => $send_options,
       '#default_value' => $send_default,
       '#weight' => -49,
+      // Only show when we have a selected email wrappers template.
+      '#states' => array(
+        'visible' => array(
+          ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+        ),
+      ),
     );
+
     $form['#validate'][] = '_webform_confirmations_email_edit_validate';
   }
-  if (module_exists('email_wrappers'))  {
-    $form['template']['tokens'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('Available tokens'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
-      '#weight' => 9,
-    );
-    $token_set = array('node');
-    // Then add any other token set as needed.
-    drupal_alter('webform_confirmations_token_info', $token_set, $node);
-    $form['template']['tokens']['tokens'] = array(
-      '#type' => 'item',
-      '#title' => t('Drupal tokens'),
-      '#description' => theme('token_tree', array('token_types' => $token_set, 'recursion_limit' => 2, 'click_insert' => FALSE)),
-    );
-    if(empty($is_donation)) {
-      $form['template']['tokens']['tokens']['#states'] = array(
-        'invisible' => array(
-          ':input[name="email_wrappers_email_template"]' => array('value' => 0),
-        ),
-      );
-    }
-    $form['template']['tokens']['webform_tokens'] = array(
-      '#type' => 'item',
-      '#title' => t('Webform tokens'),
-      '#description' => theme('webform_token_help', array()),
-    );
-  }
+
+  // Redo the token help element, adding the Drupal token set.
+  unset($form['template']['tokens']);
+
+  $form['template']['tokens'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Available tokens'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#weight' => 9,
+  );
+  $token_set = array('node');
+
+  // Then add any other token set as needed.
+  drupal_alter('webform_confirmations_token_info', $token_set, $node);
+
+  $form['template']['tokens']['tokens'] = array(
+    '#type' => 'item',
+    '#title' => t('Drupal tokens'),
+    '#description' => theme('token_tree', array('token_types' => $token_set, 'recursion_limit' => 2, 'click_insert' => FALSE)),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+      ),
+    ),
+  );
+
+  // Add the webform tokens help message.
+  $form['template']['tokens']['webform_tokens'] = array(
+    '#type' => 'item',
+    '#title' => t('Webform tokens'),
+    '#description' => theme('webform_token_help', array()),
+  );
 }
 
 /**


### PR DESCRIPTION
This cleans up some of the email wrappers and webform confirmation handling.

Investigating the original issue of token replacement not working in standard webform emails (SB ticket 40)  it was discovered the process around token replacement and control over the email sending on donation success was closely tied together.

The changes here make it clear that token replacement and email send control is not supported on standard webform emails.