### PR TITLE
Changed the way fundraiser_commerce handles creation of extra line items

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -981,9 +981,6 @@ function fundraiser_commerce_fundraiser_donation_create($donation) {
   foreach (module_implements('fundraiser_commerce_generate_line_items') as $module) {
     $function = $module . '_fundraiser_commerce_generate_line_items';
     $line_items_created = $function($donation, $order);
-    if ($line_items_created == TRUE){
-      break;
-    }
   }
 
   if (!$line_items_created) {
@@ -1005,7 +1002,8 @@ function fundraiser_commerce_fundraiser_donation_create($donation) {
     commerce_line_item_save($line_item_wrapper->value());
 
     // Add the line item to the order.
-    $order->commerce_line_items[LANGUAGE_NONE][0]['line_item_id'] = $line_item->line_item_id;
+    $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
+    $order_wrapper->commerce_line_items[] = $line_item;
   }
 
   // Save the customer information. Contains billing info.


### PR DESCRIPTION
Previously, fundraiser_commerce allowed one module to create line items. It used a foreach() loop to iterate through all modules that implemented the generate_line_items hook, and had a 'break' statement once it found one. It then prevented itself from adding the 'donation' line item if another module implemented the hook and returned TRUE. To that end, I've removed the 'break' statement in this branch, allowing more than one custom module to add line items.

I've also slightly changed the way fundraiser_commerce.module adds its line item. On line 1008, it was explicitly setting delta '0', so I changed it to use entity_metadata_wrapper(), and to add a line item here regardless of what was already added in other places (as long as the other module returns FALSE, which indicates that we shouldn't stop processing).

It's not the most elegant solution, but in the absence of completly rewriting, it allows the functionality be more abstract.

Discussed this with @dbarbar previous to changing.