### PR TITLE
Fixed error in which salesforce_genmap returned a fatal error.

### DIFF
--- a/salesforce/salesforce_genmap/includes/modules/webform.inc
+++ b/salesforce/salesforce_genmap/includes/modules/webform.inc
@@ -17,7 +17,7 @@ function webform_form_salesforce_genmap_map_form_alter(&$form, &$form_state) {
   // Check to see if this form has been designated as a webform user form. If
   // so, we add an additional submit handler that will scan the fields in the
   // mapped Salesforce object for a foreign key to the contact object.
-  $fundraiser = fundraiser_is_donation_type($form['#node']->type);
+  $fundraiser = module_exists('fundraiser') ? fundraiser_is_donation_type($form['#node']->type) : FALSE;
   if (module_exists('webform_user') && !$fundraiser) {
     if (!empty($form['#node']) && _webform_user_is_webform_user_node($form['#node'])) {
       $sobject_type = $form['salesforce_object_info']['salesforce_object_type']['#default_value'];


### PR DESCRIPTION
As I noted briefly in the commit message, the salesforce_genmap returned a fatal error whenever I loaded the node/%/salesforce menu item on any webform node. This happens if the Fundraiser module is not installed. This is because it calls the function 'fundraiser_is_donation_type()', but the module does not have a hard dependency on fundraiser.module in its .info file. I added a module_exists() check to remedy this (rather than adding the dependency).

I discovered this in an installation in which I was using salesforce_genmap to map webform nodes to Salesforce, but without the need for the whole Fundraiser suite. I think this module_exists() check will remedy it, as it'll still let the $fundraiser variable be set to FALSE.