### PR TITLE
Date Mode Setting Wrong Date when Transitioning Donations

### DIFF
--- a/email_wrappers/email_wrappers.module
+++ b/email_wrappers/email_wrappers.module
@@ -114,6 +114,7 @@ function email_wrappers_form_webform_submission_resend_alter(&$form, &$form_stat
       }
   }
 }
+
 /**
  * Overrides webform_submission_resend_submit()
  */
@@ -180,7 +181,6 @@ function email_wrappers_form_webform_emails_form_alter(&$form, $form_state) {
     if ($cid) {
       $form['add']['email_component']['#default_value'] = $cid;
     }
-
   }
 }
 
@@ -191,29 +191,24 @@ function email_wrappers_form_webform_emails_form_alter(&$form, $form_state) {
  * settings form.
  */
 function email_wrappers_form_webform_email_edit_form_alter(&$form, &$form_state, $form_id) {
-
   // Add a few tweaks to the webform email list form.
   if ($form_id === 'webform_email_edit_form') {
     $path = drupal_get_path('module', 'email_wrappers');
-    drupal_add_js($path . '/script/email_wrappers.template_select.js');
-    $template_nid = FALSE;
-    if (isset($form_state['input']['email_wrappers_email_template']) && $form_state['input']['email_wrappers_email_template']) {
-      $template_nid = $form_state['input']['email_wrappers_email_template'];
-    }
-    ctools_include('ajax');
-    ctools_include('modal');
-    ctools_modal_add_js();
+    // Attached the script for showing a warning.
+    $form['#attached']['js'][] = $path . '/script/email_wrappers.template_select.js';
+
+    // Include the ctools functions for the modal preview.
+    ctools_form_include($form_state, 'ajax');
+    ctools_form_include($form_state, 'modal');
+    // We have to use an after build to run ctools_modal_add_js() when form is cached.
+    $form['#after_build'][] = '_email_wrappers_form_webform_email_edit_after_build';
+
     global $base_path;
 
     $defaults = array();
     // Check the db for settings.
     if (isset($form['eid']['#value'])) {
       $defaults = email_wrappers_load_settings($form['node']['#value']->nid, $form['eid']['#value']);
-    }
-
-    // No settings available, load defaults from the selected template.
-    if ($template_nid) {
-      $defaults = email_wrappers_load_defaults_from_template($form_state['input']['email_wrappers_email_template']);
     }
 
     // Alter email header values based on defaults.
@@ -227,30 +222,32 @@ function email_wrappers_form_webform_email_edit_form_alter(&$form, &$form_state,
       _email_wrappers_webform_option_defaults($form, 'from_name', $defaults['from_name']);
     }
 
+    if (!isset($defaults['html_message'])) {
+      $defaults['html_message'] = '';
+    }
+
+    if (!isset($defaults['text_message'])) {
+      $defaults['text_message'] = '';
+    }
+
     // We're gonna cache these since they may come in handy later.
     $form['email_wrappers_defaults'] = array(
       '#type' => 'value',
       '#value' => $defaults,
     );
 
-    // Set ajax target div.
-    $form['#prefix'] = '<div id="webform-email-form-wrapper">';
-    $form['#suffix'] = '</div>';
-
     $form['email_wrappers_email_template'] = array(
       '#type' => 'select',
-      '#title' => t('Template'),
+      '#title' => t('Email Template'),
       '#options' => _email_wrappers_list_templates(),
+      '#description' => t('Select a template to load its settings and provide additional functionality.'),
       '#weight' => -50,
       '#default_value' => (isset($defaults['tid']) && $defaults['tid']) ? $defaults['tid'] : 0,
       '#ajax' => array(
         'callback' => 'email_wrappers_email_ajax',
-        'wrapper' => 'webform-email-form-wrapper',
-        'effect' => 'fade',
       ),
     );
 
-    // Add bcc field.
     $form['email_wrappers_bcc'] = array(
       '#type' => 'textfield',
       '#title' => t('BCC addresses'),
@@ -264,41 +261,52 @@ function email_wrappers_form_webform_email_edit_form_alter(&$form, &$form_state,
       ),
     );
 
-    // Throw some defaults at webform's built in templating system since
-    // it's being overridden anyway.
-    if ((isset($form_state['input']['email_wrappers_email_template']) && $form_state['input']['email_wrappers_email_template']) || isset($defaults['html_message'])) {
+    // Hide webform's built in templating system when a template is selected.
+    $form['template']['template_option']['#states'] = array(
+      'invisible' => array(
+        ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+      ),
+    );
 
-      $form['template']['template_option']['#access'] = FALSE;
+    $form['template']['template']['#states'] = array(
+      'invisible' => array(
+        ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+      ),
+    );
 
-      $form['template']['template']['#access'] = FALSE;
+    // TODO: include filter settings?
+    $form['template']['email_wrappers_html_message'] = array(
+      '#type' => 'textarea',
+      '#title' => t('HTML message'),
+      '#description' => t('This version of your message will be displayed by users who can view HTML email'),
+      '#default_value' => $defaults['html_message'],
+      '#states' => array(
+        'visible' => array(
+          ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+         ),
+        'required' => array(
+          ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+        ),
+      ),
+    );
 
-      // TODO: include filter settings?
-      $form['template']['email_wrappers_html_message'] = array(
-        '#type' => 'textarea',
-        '#title' => t('HTML message'),
-        '#description' => t('This version of your message will be displayed by users who can view HTML email'),
-        '#default_value' => $defaults['html_message'],
-        '#required' => TRUE,
-      );
+    $form['template']['email_wrappers_text_message'] = array(
+      '#type' => 'textarea',
+      '#title' => t('Text-only message (no HTML allowed)'),
+      '#description' => t('This version of your message will be displayed if a user can only view email in plaintext.'),
+      '#default_value' => $defaults['text_message'],
+      '#states' => array(
+        'visible' => array(
+           ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+        ),
+        'required' => array(
+          ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+        ),
+      ),
+    );
 
-      $form['template']['email_wrappers_text_message'] = array(
-        '#type' => 'textarea',
-        '#title' => t('Text-only message (no HTML allowed)'),
-        '#description' => t('This version of your message will be displayed if a user can only view email in plaintext.'),
-        '#default_value' => $defaults['text_message'],
-        '#required' => TRUE,
-      );
-
-      $form['template']['tokens']['#weight'] = 9;
-      $form['template']['components']['#weight'] = 10;
-
-      // Unset $form_state['input'] values so imported template defaults
-      // aren't overwritten by $_POST values during ajax
-      // @see:http://drupal.org/node/990502
-      unset($form_state['input']['email_wrappers_html_message']);
-      unset($form_state['input']['email_wrappers_text_message']);
-      unset($form_state['input']['email_wrappers_bcc']);
-    }
+    $form['template']['tokens']['#weight'] = 9;
+    $form['template']['components']['#weight'] = 10;
 
     // Ctools modals setup for preview button.
     $form['template']['preview_url'] = array(
@@ -306,13 +314,22 @@ function email_wrappers_form_webform_email_edit_form_alter(&$form, &$form_state,
       '#attributes' => array('class' => array('email-wrappers-preview-url')),
       '#value' => url('email_wrappers/preview_modal/nojs/preview'),
     );
-    $form['template']['preview'] = array(
-      '#type' => 'button',
-      '#id' => 'email-wrappers-preview',
-      '#value' => t('Preview'),
-      '#attributes' => array('class' => array('ctools-use-modal')),
+
+    $form['template']['preview-container'] = array(
+      '#type' => 'container',
       '#weight' => 20,
+      '#states' => array(
+        'visible' => array(
+          ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+        ),
+      ),
     );
+    $form['template']['preview-container']['preview'] = array(
+      '#type' => 'button',
+      '#value' => t('Preview'),
+      '#attributes' => array('class' => array('ctools-use-modal'), 'id' => 'email-wrappers-preview'),
+    );
+
     $form['#validate'][] = 'email_wrappers_email_validate_callback';
     $form['#submit'][] = 'email_wrappers_email_submit_callback';
   }
@@ -323,29 +340,25 @@ function email_wrappers_form_webform_email_edit_form_alter(&$form, &$form_state,
 }
 
 /**
- * Validation callback for webform email edit form.
+ * After build function to run ctools_modal_add_js().
  */
-function email_wrappers_email_validate_callback(&$form, &$form_state) {
-  // TODO: validate and clean up email addresses.
+function _email_wrappers_form_webform_email_edit_after_build($form, $form_state) {
+  ctools_modal_add_js();
+  return $form;
+}
 
-  // Fix inconsistencies between submitted input and $form_state['values']
-  // This is caused by setting #value on header detail fields. Note: simply
-  // setting #default_value on these fields causes defaults to not render
-  // after the template select ajax event has executed.
-  $keys = array('subject', 'from_address', 'from_name');
-  foreach ($keys as $key) {
-    $fields = array('option', 'custom', 'component');
-    foreach ($fields as $field) {
-      $full_key = $key . '_' . $field;
-      // Not all of these input items are available when using the AJAX
-      // prefill template selector.
-      if (isset($form_state['input'][$full_key])) {
-        $form_state['values'][$full_key] = $form_state['input'][$full_key];
-      }
-      else {
-        // Maintain current behavior when the input value is not set.
-        $form_state['values'][$full_key] = NULL;
-      }
+/**
+ * Validate callback for webform email edit form.
+ */
+function email_wrappers_email_validate_callback($form, $form_state) {
+  if (!empty($form_state['values']['email_wrappers_email_template'])) {
+    // Display error if the HTML or text messages are empty.
+    if (empty($form_state['values']['email_wrappers_html_message'])) {
+      form_error($form['template']['email_wrappers_html_message'], t('HTML message field is required.'));
+    }
+
+    if (empty($form_state['values']['email_wrappers_text_message'])) {
+      form_error($form['template']['email_wrappers_text_message'], t('Text message field is required.'));
     }
   }
 }
@@ -356,10 +369,10 @@ function email_wrappers_email_validate_callback(&$form, &$form_state) {
 function email_wrappers_email_submit_callback($form, $form_state) {
   $values = $form_state['values'];
 
-  // If any information has been added to "extra" by other modules,
-  // it is saved at this time. This approach allows other modules to append
-  // useful configuration information to the email without having to join
-  // across a bunch of lookup tables to get all the settings for a given mail.
+  // Delete any existing configurations for this email.
+  email_wrappers_delete_settings($values['node']->nid, $values['eid']);
+
+  // Save the new settings.
   if (is_numeric($values['email_wrappers_email_template']) && $values['email_wrappers_email_template'] > 0) {
     $settings = array(
       'nid' => $values['node']->nid,
@@ -369,9 +382,10 @@ function email_wrappers_email_submit_callback($form, $form_state) {
       'html_message' => $values['email_wrappers_html_message'],
       'html_message_format' => '',
       'text_message' => $values['email_wrappers_text_message'],
+      // If any information has been added to "extra" by other modules,
+      // it is saved at this time.
       'extra' => !empty($form_state['extra']) ? serialize($form_state['extra']) : serialize(array()),
     );
-    email_wrappers_delete_settings($values['node']->nid, $values['eid']);
     email_wrappers_save_settings($values['node']->nid, $values['eid'], $settings);
   }
 }
@@ -575,6 +589,7 @@ function email_wrappers_mail_alter(&$message) {
       'node' => isset($message['params']['node']) ? $message['params']['node'] : NULL,
     );
     $message['subject'] = token_replace($message['params']['mail']->subject, $token_set, array('clear' => TRUE));
+
     $message['body'] = array(email_wrappers_render_email_body(FALSE, $message));
 
     // Add Cc and Bcc headers if needed.
@@ -921,14 +936,41 @@ function _email_wrappers_concat_bcc($node) {
 function _email_wrappers_webform_option_defaults(&$form, $field_key, $value) {
   $form[$field_key . '_option']['default']['#value'] = '';
   $form[$field_key . '_option']['custom']['#value'] = 'custom';
-  $form[$field_key . '_custom']['#value'] = $value;
+  $form[$field_key . '_custom']['#default_value'] = $value;
 }
 
 /**
  * Ajax callback for template select box.
  */
 function email_wrappers_email_ajax($form, $form_state) {
-  return $form;
+  // Load the default settings for the selected template.
+  $template_nid = $form_state['values']['email_wrappers_email_template'];
+  if (empty($template_nid)) {
+    return array();
+  }
+
+  $defaults = email_wrappers_load_defaults_from_template($template_nid);
+
+  $commands = array();
+
+  // Set the values on the various webform email settings.
+  $commands[] = ajax_command_invoke('input[name=subject_option][value=custom]', 'prop', array('checked', TRUE));
+  $commands[] = ajax_command_invoke('input[name=subject_custom]', 'val', array($defaults['subject']));
+
+  $commands[] = ajax_command_invoke('input[name=from_name_option][value=custom]', 'prop', array('checked', TRUE));
+  $commands[] = ajax_command_invoke('input[name=from_name_custom]', 'val', array($defaults['from_name']));
+
+  $commands[] = ajax_command_invoke('input[name=from_address_option][value=custom]', 'prop', array('checked', TRUE));
+  $commands[] = ajax_command_invoke('input[name=from_address_custom]', 'val', array($defaults['from_mail']));
+
+  // BCC email will be an array when coming from the node.
+  $bcc_email = is_array($defaults['bcc_email']) ? implode($defaults['bcc_email'], ',') : $defaults['bcc_email'];
+  $commands[] = ajax_command_invoke('input[name=email_wrappers_bcc]', 'val', array($bcc_email));
+
+  $commands[] = ajax_command_invoke('textarea[name=email_wrappers_html_message]', 'val', array($defaults['html_message']));
+  $commands[] = ajax_command_invoke('textarea[name=email_wrappers_text_message]', 'val', array($defaults['text_message']));
+
+  return array('#type' => 'ajax', '#commands' => $commands);
 }
 
 /**

--- a/email_wrappers/tests/email_wrappers.test
+++ b/email_wrappers/tests/email_wrappers.test
@@ -5,7 +5,7 @@
  * Common functions for all the secure prepopulate tests.
  */
 
-class EmailWrappersTestCase extends DrupalWebTestCase {
+class EmailWrappersTestCase extends AJAXTestCase {
 
   public static function getInfo() {
     return array(
@@ -73,15 +73,69 @@ class EmailWrappersTestCase extends DrupalWebTestCase {
     // confirm settings ui available
     $this->assertOptionSelected('edit-email-wrappers-email-template', 0, t('Email template selection field present on form with no default selected.'));
 
-    // confirm select ajax populates fields
+    // Confirm ajax commands are correct.
     $edit['email_wrappers_email_template'] = 2;
-    $this->drupalPostAJAX(NULL, $edit, 'email_wrappers_email_template');
-    $this->assertFieldByName('email_wrappers_bcc', 'bcc0@example.com', t('BCC default inherited from template selection'));
-    $this->assertFieldByName('subject_custom', 'Test webform submission mail', t('Subject default inherited from template selection'));
-    $this->assertFieldByName('from_address_custom', 'from@example.com', t('From address default inherited from template selection'));
-    $this->assertFieldByName('from_name_custom', 'Email Wrappers Test', t('From name default inherited from template selection'));
-    $this->assertFieldByName('email_wrappers_html_message', '<p>This is an html message</p>', t('HTML message default inherited from template selection'));
-    $this->assertFieldByName('email_wrappers_text_message', 'This is a text message', t('Text message default inherited from template selection'));
+    $commands = $this->drupalPostAJAX(NULL, $edit, 'email_wrappers_email_template');
+
+    $expected = array(
+      'command' => 'invoke',
+      'selector' => 'input[name=email_wrappers_bcc]',
+      'method' => 'val',
+      'arguments' => array(
+        0 => 'bcc0@example.com',
+      ),
+    );
+    $this->assertCommand($commands, $expected, 'BCC default inherited from template selection');
+
+    $expected = array(
+      'command' => 'invoke',
+      'selector' => 'input[name=subject_custom]',
+      'method' => 'val',
+      'arguments' => array(
+        0 => 'Test webform submission mail',
+      ),
+    );
+    $this->assertCommand($commands, $expected, 'Subject default inherited from template selection');
+
+    $expected = array (
+      'command' => 'invoke',
+      'selector' => 'input[name=from_address_custom]',
+      'method' => 'val',
+      'arguments' => array(
+        0 => 'from@example.com',
+      ),
+    );
+    $this->assertCommand($commands, $expected, 'From address default inherited from template selection');
+
+    $expected = array(
+      'command' => 'invoke',
+      'selector' => 'input[name=from_name_custom]',
+      'method' => 'val',
+      'arguments' => array(
+        0 => 'Email Wrappers Test',
+      ),
+    );
+    $this->assertCommand($commands, $expected, 'From name default inherited from template selection');
+
+    $expected = array(
+      'command' => 'invoke',
+      'selector' => 'textarea[name=email_wrappers_html_message]',
+      'method' => 'val',
+      'arguments' => array(
+         0 => '<p>This is an html message</p>',
+       ),
+    );
+    $this->assertCommand($commands, $expected, 'HTML message default inherited from template selection');
+
+    $expected = array(
+      'command' => 'invoke',
+      'selector' => 'textarea[name=email_wrappers_text_message]',
+      'method' => 'val',
+      'arguments' => array(
+        0 => 'This is a text message',
+      ),
+    );
+    $this->assertCommand($commands, $expected, 'Text message default inherited from template selection');
 
     // save
     $edit = array(

--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1447,7 +1447,7 @@ function _fundraiser_donation_form_js_validation_config($node) {
   }
   // Give 3rd party modules an opportunity to alter.
   drupal_alter('fundraiser_donation_form_js_validation', $settings, $node);
-  drupal_add_js(array('fundraiser' => array('js_validation_settings' => $settings)), 'setting');
+
   return $settings;
 }
 
@@ -1457,13 +1457,23 @@ function _fundraiser_donation_form_js_validation_config($node) {
  */
 function fundraiser_donation_form(&$form, &$form_state) {
   $node = $form['#node'];
-  $form_validation_js_config = _fundraiser_donation_form_js_validation_config($node);
+
   // Attach the js files
   $form['#attached']['js'] = array(
     drupal_get_path('module', 'fundraiser') . '/js/jquery.alphanumeric.min.js',
     drupal_get_path('module', 'fundraiser') . '/js/jquery.validate.min.js',
     drupal_get_path('module', 'fundraiser') . '/js/donation_validation.min.js',
   );
+
+  // Add the validation configuration settings array.
+  $form_validation_js = _fundraiser_donation_form_js_validation_config($node);
+  if (!empty($form_validation_js)) {
+    $form['#attached']['js'][] = array(
+      'data' => array('fundraiser' => array('js_validation_settings' => $form_validation_js)),
+      'type' => 'setting',
+    );
+  }
+
   if(isset($form['#node']->minimum_donation_amount)) {
     $min = array('minimum_donation_amount' => $form['#node']->minimum_donation_amount);
     $form['#attached']['js'][] = array(

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_cybersource.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_cybersource.inc
@@ -161,7 +161,7 @@ function commerce_cybersource_fundraiser_commerce_update($donation, $card_data =
   }
 
   // Pull the new credit card values from the donation
-  $pane_values['values'] = _fundraiser_commerce_credit_card_pane_values($donation);
+  $pane_values = array('values' => _fundraiser_commerce_credit_card_pane_values($donation));
 
   // Load the card on file values for this donation
   $cardonfile_fields = _fundraiser_commerce_credit_card_cardonfile_fields($donation);

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_cybersource/commerce_cybersource.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_cybersource/commerce_cybersource.module
@@ -1139,7 +1139,7 @@ function commerce_cybersource_soap_api_request($payment_method, $request) {
     $response = $soapClient->runTransaction($request);
   }
   catch (SoapFault $exception) {
-    watchdog('commerce_cybersource', 'CyberSource SOAP error: !exception', array('!exception' => $exception->getMessage()), WATCHDOG_ERROR);
+    watchdog('commerce_cybersource', 'CyberSource SOAP error: @exception', array('@exception' => $exception->getMessage()), WATCHDOG_ERROR);
     return FALSE;
   }
 

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_cybersource/commerce_cybersource.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_cybersource/commerce_cybersource.module
@@ -974,8 +974,6 @@ function commerce_cybersource_soap_refund($order, $transaction, $amount) {
     }
 
     commerce_payment_transaction_save($transaction);
-
-    return $response;
   }
   else {
     return FALSE;
@@ -1141,7 +1139,7 @@ function commerce_cybersource_soap_api_request($payment_method, $request) {
     $response = $soapClient->runTransaction($request);
   }
   catch (SoapFault $exception) {
-    watchdog('commerce_cybersource', 'SoapFault: !exception', array('!exception' => '<pre>' . print_r($exception, TRUE) . '</pre>'), WATCHDOG_ERROR);
+    watchdog('commerce_cybersource', 'CyberSource SOAP error: !exception', array('!exception' => $exception->getMessage()), WATCHDOG_ERROR);
     return FALSE;
   }
 
@@ -1728,7 +1726,9 @@ function commerce_cybersource_form_commerce_cardonfile_update_form_alter(&$form,
 function commerce_cybersource_cardonfile_update($form, &$form_state, $payment_method, $card_data) {
   $result = commerce_cybersource_update_customer_profile_request($payment_method, $form_state, $card_data);
 
-  return $result->paySubscriptionUpdateReply->reasonCode == 100;
+  if ($result) {
+    return $result->paySubscriptionUpdateReply->reasonCode == 100;
+  }
 }
 
 /**

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_payment_example.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_payment_example.inc
@@ -78,30 +78,46 @@ function commerce_payment_example_fundraiser_commerce_expire($submission_fields)
 /**
  * Callback function, charge the gateway.
  */
-function commerce_payment_example_fundraiser_commerce_charge($payment_method, $donation) {
-  // Translate from donation settings to the correct values for the plugin.
+function commerce_payment_example_fundraiser_commerce_charge($method_instance, $donation) {
+  module_load_include('inc', 'fundraiser_commerce', 'includes/fundraiser_commerce.credit_card');
+
+  // Translate donation settings to the correct values for the commerce gateway.
   $order = commerce_order_load($donation->did);
-  $charge = $order->commerce_order_total[LANGUAGE_NONE][0];
-  $name = $donation->donation['first_name'] . ' ' . $donation->donation['last_name'];
-  // Use 0000000000000000 to test a failed payment, anything else for a good one. Use
-  // zipcode 55555 to simulate failed sustainer payments.
-  if ($donation->donation['payment_fields']['credit']['card_number'] == '0000000000000000' || ($donation->reference_charge && $donation->donation['zip'] == '55555')) {
+  $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
+  $charge = $order_wrapper->commerce_order_total->value();
+  $pane_values = _fundraiser_commerce_credit_card_pane_values($donation);
+
+  // Add fundraiser commerce data to the pane values array.
+  _fundraiser_commerce_submit_handler_pane_values($pane_values, $donation);
+
+  // Process the transaction. First look for special values that force a failure.
+  if (
+    // Use 4222222222222 to test a failed payment, anything else for a good one.
+    $donation->donation['payment_fields']['credit']['card_number'] == '4222222222222'
+    // Use zipcode 55555 to simulate failed sustainer payments.
+    || ($donation->reference_charge && $donation->donation['zip'] == '55555')
+  ) {
     $success = FALSE;
     // Add a payment transaction record for failed payments.
     $transaction = commerce_payment_transaction_new('commerce_payment_example', $order->order_id);
-    $transaction->instance_id = $payment_method['instance_id'];
+    $transaction->instance_id = $method_instance['instance_id'];
     $transaction->amount = $charge['amount'];
     $transaction->status = COMMERCE_PAYMENT_STATUS_FAILURE;
     $transaction->remote_status = 'remote_failed';
     $transaction->message = t('Failed due to sustainer failure simulation mode.');
     commerce_payment_transaction_save($transaction);
   }
+  // Pass the values through to the submit function.
   else {
     $success = TRUE;
-    // commerce_payment_example has helpfully split submission efforts outside of form submission,
-    // so we can directly call it as follows:
-    commerce_payment_example_transaction($payment_method, $order, $charge, $name);
+    // During a reference charge the example gateway expects a credit card of a certain length for the transaction message.
+    if (!empty($donation->reference_charge)) {
+      $pane_values['credit_card']['number']  = str_pad($pane_values['credit_card']['number'], 8, 'x', STR_PAD_LEFT);
+    }
+
+    commerce_payment_example_submit_form_submit($method_instance, array(), $pane_values, $order, $charge);
   }
+
   return $success;
 }
 

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.info
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.info
@@ -10,6 +10,11 @@ dependencies[] = rules
 files[] = includes/FundraiserSustainersHealthChecks.php
 files[] = includes/FundraiserSustainerRecordViewsController.php
 
+;Sustainer schedule class files
+files[] = includes/schedules/sustainersBaseSchedule.inc
+files[] = includes/schedules/sustainersMonthlySchedule.inc
+
 ;Testing files
 files[] = tests/fundraiser_sustainers.test
 files[] = tests/fundraiser_sustainers_health_checks.test
+files[] = tests/fundraiser_sustainers_eom.test

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -2001,9 +2001,10 @@ function _fundraiser_sustainers_create_future_orders($donation, $month, $year, $
   if (is_null($start)) {
     $start = strtotime("now");
   }
-
-  $previous_charge = $start;
-
+watchdog('debug', print_r($start, 1));
+  // Create a DateTime from the start timestamp.
+  $previous_charge = new DateTime("@$start");
+watchdog('debug', print_r($previous_charge, 1));
   // Allow other modules to modify the stop date.
   $end_date = array(
     'month' => $month,
@@ -2017,21 +2018,23 @@ function _fundraiser_sustainers_create_future_orders($donation, $month, $year, $
   $month = $end_date['month'];
   $year = $end_date['year'];
 
-  $stop = mktime(0, 0, 0, $month, 1, $year);
-  $months = ((idate('Y', $stop) * 12) + idate('m', $stop)) - ((idate('Y', $start) * 12) + idate('m', $start));
-  $processed_months = 0;
+  // Create a schedule object from the starting charge and the expiration date.
+  $schedule = new sustainersMonthlySchedule($previous_charge, $month . '/1/' . $year, $donation);
+
   $sustainer_key = fundraiser_sustainers_get_sustainer_key_value();
 
-  // Start counting.
-  $create_limit = variable_get('fundraiser_sustainers_create_limit', 50);
   // Get existing donations, if they exist.
   $existing_recurring = _fundraiser_sustainers_get_donations_recurr_by_masterdid($donation->did);
 
   unset($existing_recurring[0]); // 0 is the master, we don't need to count it.
-  while ($processed_months < $months && $processed_months < $create_limit) {
-    $processed_months++;
-    // Check if we have a donation for this next month.
-    if (!isset($existing_recurring[$processed_months])) {
+
+  $processed = 0;
+  while ($processed <= $schedule->scheduleAmount() && $processed <= $schedule->scheduleLimit()) {
+    // Set the increment value.
+    $increment = $processed + 1;
+
+    // Check if we have a donation for this next period.
+    if (!isset($existing_recurring[$increment])) {
       // Create a new one donation from the source or master donation
       $new_donation = !empty($source_donation) ? _fundraiser_donation_copy($source_donation) : _fundraiser_donation_copy($donation);
       $new_donation->sid = 0; // Not actually submitted, it's automated, so no sid.
@@ -2046,13 +2049,20 @@ function _fundraiser_sustainers_create_future_orders($donation, $month, $year, $
 
       fundraiser_donation_create($new_donation);
 
-      // Build a context to determine the next charge date.
+      // Generate the next_charge timestamp.
+      $next = $schedule->advanceDate($increment);
+      $next_charge = $next->format('U');
+
+      // Build a context array for the next_charge alter function.
       $context = array(
         'master_did' => $donation->did,
         'did' => $new_donation->did,
+        'previous_charge' => $previous_charge,
+        'schedule' => $schedule,
+        'increment' => $increment,
+        'next' => $next,
       );
-
-      $next_charge = fundraiser_sustainers_get_next_charge_time($previous_charge, $context);
+      drupal_alter('fundraiser_sustainers_recurring_next_charge', $next_charge, $context);
 
       fundraiser_donation_comment($new_donation, 'Sustainer donation scheduled to be charged at @next_charge',
         array('@next_charge' => format_date($next_charge)));
@@ -2073,18 +2083,24 @@ function _fundraiser_sustainers_create_future_orders($donation, $month, $year, $
         salesforce_genmap_send_object_to_queue('salesforce_donation', 'insert',
           $sf_donation->node, $sf_donation->did, $sf_donation, 'donation');
       }
+
+      // Update the previous charge object.
+      $previous_charge = $next;
     }
     else {
       // Unset this from the existing recurring. By the time this loop is done,
       // only recurring orders outside of our range will still be in the set.
-      unset($existing_recurring[$processed_months]);
+      unset($existing_recurring[$increment]);
       // If an existing recurring order is changed to use a card with a later
       // expiration than the original card, we will need to add orders to the
       // series. Iterating $previous_charge by a month for each existing order
       // in the series keeps it in sync with the month as we advance through
       // the existing orders.
-      $previous_charge = strtotime('+1 month', $previous_charge);
+      $previous_charge = $schedule->advanceDate($increment);
     }
+
+    // Update the processed counter.
+    $processed++;
   }
 
   // Done with the loop, everything has been created that needs to be created.
@@ -2100,32 +2116,6 @@ function _fundraiser_sustainers_create_future_orders($donation, $month, $year, $
     // Delete these donations so do won't appear in the list of recurring donations.
     fundraiser_donation_delete($this_donation);
   }
-}
-
-/**
- * Determine the next_charge time taking any altering into account.
- *
- * @param null|int $time
- *   A timestamp as provided by strtotime(), or NULL to use now.
- *   Either the current time or the time of the previous charge
- *   in order to get back the next scheduled time to charge.
- * @param array $context
- *   An associative array potentially including a 'master_did' and a new
- *   donation 'did'.
- *
- * @return int
- *   The timestamp of when to make a next charge.
- */
-function fundraiser_sustainers_get_next_charge_time(&$time = NULL, $context = array()) {
-  if (is_null($time)) {
-    $time = strtotime('now');
-  }
-
-  $next_charge = strtotime('+1 month', $time);
-  // Allow other modules to adjust next_charge as needed.
-  $time = $next_charge;
-  drupal_alter('fundraiser_sustainers_recurring_next_charge', $next_charge, $context);
-  return $next_charge;
 }
 
 /**

--- a/fundraiser/modules/fundraiser_sustainers/includes/schedules/sustainersBaseSchedule.inc
+++ b/fundraiser/modules/fundraiser_sustainers/includes/schedules/sustainersBaseSchedule.inc
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @file
+ * Base class for sustainer schedules.
+ */
+
+class sustainersBaseSchedule {
+
+  /**
+   * Constructor, each schedule will need a start, end and interval date object.
+   *
+   * @param string|DateTime object $start
+   *   A date/time object or string to be converted. Enter NULL here to obtain the current time.
+   * @param string|DateTime object $end
+   *   A date/time object or string to be converted. Enter NULL here to obtain the current time.
+   * @param object $donation
+   *   An optional donation object, could be used by some schedules.
+   */
+  public function __construct($start = NULL, $end = NULL, $donation = NULL) {
+    // Create the start DateTime object, if a DateTime object has been passed use that.
+    if ($start && $start instanceof DateTime) {
+      $this->start = $start;
+    }
+    else {
+      $this->start = new DateTime($start);
+    }
+
+    // Create the end DateTime object, if a DateTime object has been passed use that.
+    if ($end && $end instanceof DateTime) {
+      $this->end = $end;
+    }
+    else {
+      $this->end = new DateTime($end);
+    }
+
+    // Create an interval object.
+    $this->interval = $this->end->diff($this->start);
+
+    // Calculate the amount of segments in the interval.
+    $this->intervalAmount = $this->calcIntervalAmount();
+
+    $this->donation = $donation;
+  }
+
+  /**
+   * Return the start Datetime object.
+   */
+  public function startDateTime() {
+    return $this->start;
+  }
+
+  /**
+   * Return the end Datetime object.
+   */
+  public function endDateTime() {
+    return $this->end;
+  }
+
+  /**
+   * Return the interval Datetime object.
+   */
+  public function intervalDateTime() {
+    return $this->interval;
+  }
+
+  /**
+   * Return the amount of segments in the interval.
+   */
+  public function intervalAmount() {
+    return $this->intervalAmount;
+  }
+
+  /**
+   * Return the amount of payments for this schedule.
+   *
+   * This function is called by sustainers when creating future orders.
+   */
+  public function scheduleAmount() {
+    return $this->scheduleAmount;
+  }
+
+  /**
+   * Return the max amount of sustainers this schedule can create.
+   */
+  public function scheduleLimit() {
+    return variable_get('fundraiser_sustainers_create_limit', 50);
+  }
+
+  /**
+   * Calculate the amount of payments from the interval.
+   */
+  public function calcIntervalAmount() {
+  }
+
+  /**
+   * Return a DateTime object incremented by the passed amount.
+   * 
+   * @param numeric $increment
+   *    Number of payments to increment.
+   */
+  public function advanceDate($increment) {
+  }
+}

--- a/fundraiser/modules/fundraiser_sustainers/includes/schedules/sustainersMonthlySchedule.inc
+++ b/fundraiser/modules/fundraiser_sustainers/includes/schedules/sustainersMonthlySchedule.inc
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Contains class for generating a monthly payment schedule.
+ */
+
+class sustainersMonthlySchedule extends sustainersBaseSchedule {
+
+  /**
+   * Return the amount of payments for this schedule.
+   */
+  public function scheduleAmount() {
+    // Return the interval amount since no adjustments required.
+    return $this->intervalAmount;
+  }
+
+  /**
+   * Calculate the amount of months from the interval DateTime object.
+   */
+  public function calcIntervalAmount() {
+    return ($this->interval->format('%y') * 12) + $this->interval->format('%m');
+  }
+
+  /**
+   * Return a DateTime object incremented by the passed amount.
+   */
+  public function advanceDate($increment) {
+    $next = clone $this->start;
+
+    // Get the start date string.
+    $date = $this->start->format('Y-n-j');
+
+    // Create an array of the individual date values.
+    list($y, $m, $d) = explode('-', $date);
+
+    // Add the number of months to the current count, loop through to add to the years.
+    $m += $increment;
+    while ($m > 12) {
+      $m -= 12;
+      $y++;
+    }
+
+    // If this current month doesn't have enough days as the start month, move the day value to the month's last day.
+    $last_day = date('t', strtotime("$y-$m-1"));
+    if ($d > $last_day) {
+      $d = $last_day;
+    }
+
+    $next->setDate($y, $m, $d);
+    return $next;
+  }
+}

--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
@@ -262,8 +262,21 @@ function _fundraiser_date_mode_calculate_delta($charge_time, $date) {
  */
 function _fundraiser_date_mode_validate_order_dates($series_orders, $master_order_day = NULL) {
   $dates = array();
-  foreach ($series_orders as $order) {
-    $date = _fundraiser_date_mode_explode_date($order['next_charge']);
+  // Return FALSE if no orders.
+  if (empty($series_orders)) {
+    return FALSE;
+  }
+
+  // Pull all the next charge values for these dids.
+  $next_charges = db_select('fundraiser_sustainers', 's')
+    ->fields('s', array('did', 'next_charge'))
+    ->condition('did', $series_orders)
+    ->execute()
+    ->fetchAllKeyed();
+
+  foreach ($series_orders as $did) {
+    $date = _fundraiser_date_mode_explode_date($next_charges[$did]);
+
     // If supplied, validate order days against the master order day.
     if ($master_order_day && $master_order_day != $date['day']) {
       return FALSE;

--- a/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers.test
+++ b/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers.test
@@ -19,7 +19,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
     return array(
       'name' => 'Fundraiser sustainers',
       'description' => 'Tests fundraiser sustainers behavior.',
-      'group' => 'Fundraiser',
+      'group' => 'Fundraiser Sustainers',
     );
   }
 
@@ -87,7 +87,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
    */
   public function testSustainerRetries() {
     // Set up a valid sustainer key.
-    $this->setSustainerKey(trim($_SERVER['HTTP_HOST']));
+    $this->setSustainerKey(trim($_SERVER['HTTP_HOST']) . rtrim(base_path(), '/'));
 
     // Use 55555 which will cause the example gateway to fail future charges.
     $post = array(
@@ -332,7 +332,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
     $this->assertText('All future payments cancelled.', t('The donation sequence is cancelled.'), t('Fundraiser Cancel'));
     // Check display in table.
     $this->drupalGet('user/' . $created_user->uid . '/recurring_overview');
-    $this->assertText('Cancelled', t('The donation sequence is listed as cancelled in overview.'), t('Fundraiser Cancel'));
+    $this->assertText('Canceled', t('The donation sequence is listed as cancelled in overview.'), t('Fundraiser Cancel'));
     // Check display in page.
     $this->drupalGet('user/' . $created_user->uid . '/recurring_overview/' . $master_did);
     $this->assertText('Canceled', t('The donation sequence is listed as cancelled in overview.'), t('Fundraiser Cancel'));
@@ -428,7 +428,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
       }
     }
 
-    $this->setSustainerKey(trim($_SERVER['HTTP_HOST']));
+    $this->setSustainerKey(trim($_SERVER['HTTP_HOST']) . rtrim(base_path(), '/'));
     // With key setup, advance one charge and check the state afterwards.
     $yesterday = strtotime('-1 day'); // Use yesterday because the cron run happens right after setting this
     db_update('fundraiser_sustainers')
@@ -453,7 +453,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
    */
   public function testFundraiserSustainerProcessOnEnvironmentMatch() {
     // Set up a legitimate sustainer key value.
-    $this->setSustainerKey(trim($_SERVER['HTTP_HOST']));
+    $this->setSustainerKey(trim($_SERVER['HTTP_HOST']) . rtrim(base_path(), '/'));
     // Create a recurring donation to test with. These donations should have example.production
     // as their sustainer key.
     $master_did = $this->fundraiserSustainerCreateRecurringDonation();
@@ -462,7 +462,7 @@ class FundraiserSustainerTest extends FundraiserSetup {
     foreach ($donations as $donation) {
       // Skip the first order.
       if ($donation->did != $donation->master_did) {
-        $this->assertEqual(trim($_SERVER['HTTP_HOST']), $donation->sustainer_key, 'Sustainer record contains the correct sustainer key.');
+        $this->assertEqual(trim($_SERVER['HTTP_HOST']) . rtrim(base_path(), '/'), $donation->sustainer_key, 'Sustainer record contains the correct sustainer key.');
       }
     }
     // With key setup, advance one charge and check the state afterwards.

--- a/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers_eom.test
+++ b/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers_eom.test
@@ -1,0 +1,201 @@
+<?php
+/**
+ * @file
+ * Fundraiser sustainer tests for end of month behavior change implemented
+ * in version 4.6.3.
+ */
+
+/**
+ * Setup and tear down web class. Does nothing else.
+ */
+class FundraiserSustainersEOMTestCase extends DrupalUnitTestCase {
+
+  /**
+   * Implements getInfo().
+   */
+  public static function getInfo() {
+    return array(
+      'name' => 'Fundraiser sustainers end of month handling',
+      'description' => 'Tests fundraiser sustainers end of month behavior change.',
+      'group' => 'Fundraiser Sustainers',
+    );
+  }
+
+  function setUp() {
+    // Load the include files.
+    module_load_include('inc', 'fundraiser_sustainers', 'includes/schedules/sustainersMonthlySchedule');
+    module_load_include('inc', 'fundraiser_sustainers', 'includes/schedules/sustainersBaseSchedule');
+    parent::setUp();
+  }
+
+  /**
+   * Ensures non-leap year Feburary's are handled correctly when the
+   * initial date is the 29th of the month.
+   */
+  function testTwentyNinethHandling() {
+    $start = date('Y-m-d', strtotime('2015-1-29'));
+    $end = date('Y-m-d', strtotime('+11 months', strtotime($start)));
+
+    $timestamps = $this->month_timestamps($start, $end);
+
+    foreach($timestamps as $timestamp) {
+      $month_number = date('n', $timestamp);
+      $day = date('d', $timestamp);
+      $month_name = date('F', $timestamp);
+
+      // If the month is Feburary the payment date should be the 28th because there is no 29th in a non-leap year.
+      if ($month_number == 2) {
+        $this->assertEqual(28, $day, 'Payment for Feburary falls on the 28th.');
+      }
+      else {
+        $this->assertEqual(29, $day, t('Payment for @month_name falls on the 29th (@date).', array('@month_name' => $month_name, '@date' => date('m-d-Y', $timestamp))));
+      }
+    }
+
+    // Ensure 12 dates were generated.
+    $this->assertEqual(12, count($timestamps), t('12 payment dates where generated the first year.'));
+  }
+
+  /**
+   * Ensures non-leap year Feburary's are handled correctly when the
+   * initial date is the 30th of the month.
+   */
+  function testThirtiethHandling() {
+    $start = date('Y-m-d', strtotime('2015-1-30'));
+    $end = date('Y-m-d', strtotime('+11 months', strtotime($start)));
+
+    $timestamps = $this->month_timestamps($start, $end);
+
+    foreach($timestamps as $timestamp) {
+      $month_number = date('n', $timestamp);
+      $day = date('d', $timestamp);
+      $month_name = date('F', $timestamp);
+
+      // If the month is Feburary the payment date should be the 28th because there is no 30th in a non-leap year.
+      if ($month_number == 2) {
+        $this->assertEqual(28, $day, 'Payment for Feburary falls on the 28th.');
+      }
+      else {
+        $this->assertEqual(30, $day, t('Payment for @month_name falls on the 30th (@date).', array('@month_name' => $month_name, '@date' => date('m-d-Y', $timestamp))));
+      }
+    }
+
+    // Ensure 12 dates were generated.
+    $this->assertEqual(12, count($timestamps), t('12 payment dates where generated the first year.'));
+  }
+
+  /**
+   * Ensures all generated dates are the last day in the month.
+   */
+  function testThirtyFirstHandling() {
+    $start = date('Y-m-d', strtotime('2015-1-31'));
+    $end = date('Y-m-d', strtotime('+11 months', strtotime($start)));
+
+    $timestamps = $this->month_timestamps($start, $end);
+
+    foreach ($timestamps as $timestamp) {
+      $is_last_day_in_month = $this->dayIsLastDayOfMonth($timestamp);
+      $date = date('m-d-Y', $timestamp);
+      $month_name = date('F', $timestamp);
+      $this->assertTrue($is_last_day_in_month, t('Payment for @month_name falls on the last day of the month, @date.', array('@month_name' => $month_name, '@date' => $date)));
+    }
+
+    // Ensure 12 dates were generated.
+    $this->assertEqual(12, count($timestamps), t('12 payment dates where generated the first year.'));
+  }
+
+  /**
+   * Ensures leap year Feburary's are handled correctly.
+   *
+   * Extend the dates over a 2 year period to test non-leap years as well.
+   */
+  function testLeapYearHandling() {
+    $start = date('Y-m-d', strtotime('2012-1-31'));
+    $end = date('Y-m-d', strtotime('+23 months', strtotime($start)));
+
+    $timestamps = $this->month_timestamps($start, $end);
+
+    $first_year_transaction_count = 0;
+
+    foreach($timestamps as $timestamp) {
+      $month_number = date('n', $timestamp);
+      $day = date('d', $timestamp);
+      $date = date('m-d-Y', $timestamp);
+      $year = date('Y', $timestamp);
+      $month_name = date('F', $timestamp);
+
+      // Keep track of the first year's count so we can check it later.
+      if ($year == 2012) {
+        $first_year_transaction_count++;
+      }
+
+      // If the month is Feburary the payment date should be the 29th in a leap year.
+      if ($month_number == 2 && $year == 2012) {
+        $this->assertEqual(29, $day, 'Payment for Feburary on a leap year falls on the 29th.');
+      }
+      else if ($month_number == 2 && $year == 2013) {
+        // Non-leap year should go back to the 28th.
+        $this->assertEqual(28, $day, 'Payment for Feburary on a non-leap year falls on the 28th.');
+      }
+      else {
+        $is_last_day_in_month = $this->dayIsLastDayOfMonth($timestamp);
+        $this->assertTrue($is_last_day_in_month, t('Payment for @month_name falls on the last day of the month, @date.', array('@month_name' => $month_name, '@date' => $date)));
+      }
+    }
+
+    // Ensure 12 dates were generated.
+    $this->assertEqual(12, $first_year_transaction_count, t('12 payment dates where generated the first year.'));
+  }
+
+  /**
+   * Ensures payment date that exists in all months is calculated properly.
+   */
+  function testNormalDayHandling() {
+    $start = date('Y-m-d', strtotime('2015-1-15'));
+    $end = date('Y-m-d', strtotime('+11 months', strtotime($start)));
+
+    $timestamps = $this->month_timestamps($start, $end);
+
+    foreach($timestamps as $timestamp) {
+      $day = date('d', $timestamp);
+      $month_name = date('F', $timestamp);
+
+      // Every payment should fall on the 15th of the month.
+      $this->assertEqual(15, $day, t('Payment for @month_name falls on the 15th (@date).', array('@month_name' => $month_name, '@date' => date('m-d-Y', $timestamp))));
+    }
+
+    // Ensure 12 dates were generated.
+    $this->assertEqual(12, count($timestamps), t('12 payment dates where generated the first year.'));
+  }
+
+  /**
+   * Determines if a given date is the last day of the month.
+   */
+  function dayIsLastDayOfMonth($timestamp) {
+    $days_in_month = date('t', $timestamp);
+    $computed_day = date('d', $timestamp);
+    return $days_in_month == $computed_day;
+  }
+
+  /**
+   * Create array of timestamps for sustainers.
+   *
+   * TODO: This would get removed and we'd call the actual fundraiser sustainers function instead.
+   */
+  function month_timestamps($start, $end) {
+    $schedule = new sustainersMonthlySchedule($start, $end);
+
+    // Create timestamps for each month until the end time is reached.
+    $processed = 0;
+
+    // This while loop matches the one sustainers uses to generate the series.
+    while ($processed <= $schedule->scheduleAmount()) {
+      // Get the next months charge date.
+      $next = $schedule->advanceDate($processed);
+      $times[] = $next->format('U');
+      $processed++;
+    }
+
+    return $times;
+  }
+}

--- a/fundraiser/modules/fundraiser_upsell/fundraiser_upsell.module
+++ b/fundraiser/modules/fundraiser_upsell/fundraiser_upsell.module
@@ -1213,16 +1213,19 @@ function fundraiser_upsell_create_master_donation($upsold_donation, $new_amount)
 
   // If we're charging in a month, save a sustainers record and add a comment.
   if ($charge_time == 'one_month') {
-    $next_charge = fundraiser_sustainers_get_next_charge_time();
+    // Use the monthly schedule to get the next payment date.
+    $schedule = new sustainersMonthlySchedule();
+    $next = $schedule->advanceDate(1);
+
     fundraiser_donation_comment($master_donation, 'Initial Upsell donation scheduled to be charged at @next_charge',
-      array('@next_charge' => format_date($next_charge)));
+      array('@next_charge' => $next->format(variable_get('date_format_medium', 'D, m/d/Y - H:i'))));
 
     // At this point, the donation did and donation data is set.
     // Now we need to create a recurring record for it as the master donation.
     $recurring_donation_record = array(
       'master_did' => $master_donation->did,
       'did' => $master_donation->did,
-      'next_charge' => $next_charge,
+      'next_charge' => $next->format('U'),
       'sustainer_key' => fundraiser_sustainers_get_sustainer_key_value(),
     );
     // Update the recurring table.

--- a/salesforce/salesforce_genmap/includes/modules/webform.inc
+++ b/salesforce/salesforce_genmap/includes/modules/webform.inc
@@ -17,7 +17,12 @@ function webform_form_salesforce_genmap_map_form_alter(&$form, &$form_state) {
   // Check to see if this form has been designated as a webform user form. If
   // so, we add an additional submit handler that will scan the fields in the
   // mapped Salesforce object for a foreign key to the contact object.
-  $fundraiser = fundraiser_is_donation_type($form['#node']->type);
+  if (module_exists('fundraiser')) {
+    $fundraiser = fundraiser_is_donation_type($form['#node']->type);
+  }
+  else {
+    $fundraiser = FALSE;
+  }
   if (module_exists('webform_user') && !$fundraiser) {
     if (!empty($form['#node']) && _webform_user_is_webform_user_node($form['#node'])) {
       $sobject_type = $form['salesforce_object_info']['salesforce_object_type']['#default_value'];
@@ -31,7 +36,7 @@ function webform_form_salesforce_genmap_map_form_alter(&$form, &$form_state) {
             if ($field['type'] == 'reference' && $field['referenceTo'][0] == 'Contact') {
               $options[$field['name']] = $field['label'];
             }
-          } 
+          }
         }
         if (!empty($options) && count($options) > 1) {
           $form['webform_user'] = array(
@@ -72,7 +77,7 @@ function salesforce_genmap_node_insert($node) {
     if (array_key_exists($nid, $webform_user_reference_fields)) {
       $webform_user_reference_fields[$node->nid] = $webform_user_reference_fields[$nid];
       variable_set('webform_user_reference_fields', $webform_user_reference_fields);
-    }  
+    }
     $map = salesforce_genmap_load_map($nid, 'webform');
     if (!empty($map)) {
       // Copy the map to the node.

--- a/springboard/modules/springboard_admin/springboard_admin.menu.inc
+++ b/springboard/modules/springboard_admin/springboard_admin.menu.inc
@@ -377,6 +377,12 @@ function springboard_admin_create_menu_item($item, &$mlids, $plid = 0, $parent =
   if ($plid > 0) {
     $item['plid'] = $plid;
   }
+
+  // Set a default module value.
+  if (!isset($item['module'])) {
+    $item['module'] = 'menu';
+  }
+
   // Save a the item.
   $mlid = menu_link_save($item, array(), array($plid => $parent));
   $mlids[] = $mlid;

--- a/springboard/modules/springboard_stats/springboard_stats.module
+++ b/springboard/modules/springboard_stats/springboard_stats.module
@@ -8,6 +8,17 @@ define('SPRINGBOARD_STATS_DEFAULT_HAM_MINIMUM', 1);
 define('SPRINGBOARD_STATS_DEFAULT_HAM_MAXIMUM', 99999);
 
 /**
+ * Implements hook_cron_queue_info().
+ */
+function springboard_stats_cron_queue_info() {
+  $queues['springboard_stats'] = array(
+    'worker callback' => 'springboard_stats_process_queue_item',
+    'time' => 20,
+  );
+  return $queues;
+}
+
+/**
  * Implements hook_form_springboard_admin_settings_alter().
  */
 function springboard_stats_form_springboard_admin_settings_alter(&$form, &$form_state, $form_id) {
@@ -338,6 +349,48 @@ function springboard_stats_update_all_fields($node) {
   field_attach_update('node', $node);
 }
 
+function springboard_stats_enqueue($nid, $field = 'all') {
+  static $queued = array();
+  
+  // If all fields were already queued for this node, don't queue any more.
+  if (in_array("$nid-all", $queued)) return;
+  
+  // If this field was already queued for this node, don't queue it again.
+  if (in_array("$nid-$field", $queued)) return;
+  
+  // Queue this field (or all fields) for tallying on the next cron.
+  $queue = DrupalQueue::get('springboard_stats');
+  $item = array(
+    'nid' => $nid,
+    'field' => $field,
+  );
+  $queue->createItem($item);
+  
+  // Remember that we've queued this field (or all fields) on this node.
+  $queued[] = "$nid-$field";
+}
+
+function springboard_stats_process_queue_item($item) {
+  static $processed = array();
+  
+  // Skip item if this node was already fully processed.
+  if (in_array($item['nid'] . '-all', $processed)) return;
+  
+  // Skip item if this field of this node was already processed.
+  if (in_array($item['nid'] . '-' . $item['field'], $processed)) return;
+  
+  // Load the node and process the field(s) requested.
+  $node = node_load($item['nid']);
+  if ($item['field'] == 'all') {
+    springboard_stats_update_all_fields($node);
+  } else {
+    springboard_stats_update_field($node, $item['field']);
+  }
+  
+  // Remember that we've processed this field (or all fields) on this node.
+  $processed[] = $node->nid . '-' . $item['field'];
+}
+
 /****************************************
  * HOOKS TO RESPOND TO FORM SUBMISSIONS *
  ****************************************/
@@ -346,37 +399,54 @@ function springboard_stats_update_all_fields($node) {
  * Implements hook_webform_submission_insert().
  */
 function springboard_stats_webform_submission_insert($node, $submission) {
-  springboard_stats_update_field($node, 'count_submissions');
+  // Count submissions for non-donation webforms.
+  if ($node->type != 'donation_form') {
+    springboard_stats_enqueue($node->nid, 'count_submissions');
+  }
 }
 
 /**
  * Implements hook_webform_submission_delete().
  */
 function springboard_stats_webform_submission_delete($node, $submission) {
-  springboard_stats_update_field($node, 'count_submissions');
+  // Count submissions for non-donation webforms.
+  if ($node->type != 'donation_form') {
+    springboard_stats_enqueue($node->nid, 'count_submissions');
+  }
 }
 
 /**
- * Implements hook_fundraiser_donation_post_create().
+ * Implements hook_fundraiser_donation_success().
  */
-function springboard_stats_fundraiser_donation_post_create($donation) {
-  $node = node_load($donation->nid);
-  springboard_stats_update_field($node, 'count_pending');
-  springboard_stats_update_field($node, 'total_pending');
+function springboard_stats_fundraiser_donation_success($donation) {
+  // Count pending orders when a recurring donation is made.
+  if (!empty($donation->donation['recurs_monthly'])) {
+    springboard_stats_enqueue($donation->nid, 'count_pending');
+    springboard_stats_enqueue($donation->nid, 'total_pending');
+  }
+}
+
+/**
+ * Implements hook_upsell_master_donation_alter().
+ */
+function springboard_stats_upsell_master_donation_alter(&$master_donation) {
+  // Count pending orders when a donation is made recurring via Upsell.
+  springboard_stats_enqueue($master_donation->nid, 'count_pending');
+  springboard_stats_enqueue($master_donation->nid, 'total_pending');
 }
 
 /**
  * Implements hook_fundraiser_donation_post_update().
  */
 function springboard_stats_fundraiser_donation_post_update($donation) {
-  $node = node_load($donation->nid);
-  springboard_stats_update_all_fields($node);
+  // Count everything when a donation is updated, which happens when payment is processed (as well as other times).
+  springboard_stats_enqueue($donation->nid);
 }
 
 /**
  * Implements hook_fundraiser_donation_delete().
  */
 function springboard_stats_fundraiser_donation_delete($donation) {
-  $node = node_load($donation->nid);
-  springboard_stats_update_all_fields($node);
+  // Count everything when a donation is deleted.
+  springboard_stats_enqueue($donation->nid);
 }

--- a/springboard/modules/springboard_views/springboard_views.install
+++ b/springboard/modules/springboard_views/springboard_views.install
@@ -12,6 +12,23 @@ function springboard_views_install() {
 }
 
 /**
+ * Implements hook_uninstall().
+ *
+ * Removes the Springboard Feed.
+ */
+function springboard_views_uninstall() {
+  // Find the feed ID.
+  $fid = db_query("SELECT fid FROM {aggregator_feed} WHERE title = 'Springboard Feed';")
+    ->fetchField();
+
+  // Passing in only the feed ID will delete it and related items
+  // and categories.
+  if (is_numeric($fid)) {
+    aggregator_save_feed(array('fid' => $fid));
+  }
+}
+
+/**
  * Implements hook_requirements().
  *
  * Checks Views for anonymous access.
@@ -73,24 +90,34 @@ function springboard_views_requirements($phase) {
 }
 
 /**
- * Enables new module dependencies. Creates new Aggregator item for the
- * Springboard Notes view.
+ * Enables aggregator and views_data_export, and creates the Springboard Feed.
  */
- function springboard_views_update_7000() {
-   module_enable(array('aggregator', 'views_data_export'));
-   springboard_views_create_aggregator_feed();
- }
+function springboard_views_update_7000() {
+  module_enable(array('aggregator', 'views_data_export'));
+  springboard_views_create_aggregator_feed();
+}
 
- /**
-  * Helper function. Creates Aggregator feed for the Springboard Notes view.
-  */
+/**
+ * Creates Aggregator feed for the Springboard Notes view.
+ */
 function springboard_views_create_aggregator_feed() {
   // Create the Aggregator feed needed for the sbv_springboard_notes view.
-   $feed = array(
-     'title' => 'Springboard Feed',
-     'url' => 'http://www.jacksonriver.com/sb-admin-feed.xml',
-     'refresh' => 3600,
-     'block' => 5,
-   );
-   aggregator_save_feed($feed);
+  $feed = array(
+    'title' => 'Springboard Feed',
+    'url' => 'http://www.jacksonriver.com/sb-admin-feed.xml',
+    'refresh' => 3600,
+    'block' => 5,
+  );
+
+  // See if this feed already exists.
+  $fid = db_query("SELECT fid FROM {aggregator_feed} WHERE title = 'Springboard Feed';")
+    ->fetchField();
+
+  // When providing a feed ID, aggregator will edit the existing feed.
+  // So this will repair the feed instead of creating a new one.
+  if (is_numeric($fid)) {
+    $feed['fid'] = $fid;
+  }
+
+  aggregator_save_feed($feed);
 }

--- a/springboard/springboard.install
+++ b/springboard/springboard.install
@@ -10,14 +10,13 @@
 function springboard_install() {
   // Set the variable to provide configure button on settings page.
   variable_set('springboard_needs_config', TRUE);
-  // Add a message about configuring Springboard
+  // Add a message about configuring Springboard.
   drupal_set_message(st('The Springboard module was successfully enabled. !link',
     array('!link' => l(st('Please configure Springboard now.'), 'admin/springboard/options/springboard'))));
 }
 
 /**
- * Implements hook_update_N().
- * Uninstall the table in favor of hook based panes.
+ * Uninstall the springboard_sf_status table in favor of hook based panes.
  */
 function springboard_update_7000() {
   // If we used to be a Springboard profile install, switch to standard.
@@ -32,11 +31,14 @@ function springboard_update_7000() {
 }
 
 /**
- * Implements hook_update_N().
- *
- * Add the Admin field_group to the user entity move standard fields under it.
+ * Add the Admin field_group to the user entity & move standard fields under it.
  */
 function springboard_update_7001() {
+  if (!module_exists('field_group')) {
+    $t = get_t();
+    throw new DrupalUpdateException($t('Springboard update 7001 requires the Field Group module. Install this module and run the update again.'));
+  }
+
   module_load_include('inc', 'springboard', 'springboard.admin');
   // Check for an existing or disabled field group to set update message.
   $existing = field_group_load_field_group('group_profile_admin', 'user', 'user', 'form');
@@ -46,15 +48,13 @@ function springboard_update_7001() {
 
   springboard_add_admin_field_group_to_user_entity();
 
-  return !$existing ? t('The admin field group has been added to the user entity.') : t('The admin field group already exists on the user entity.') ;
+  return !$existing ? t('The admin field group has been added to the user entity.') : t('The admin field group already exists on the user entity.');
 }
 
 /**
- * Implements hook_update_N().
- *
  * Enable new Springboard Dashboard panes.
  */
 function springboard_update_7002() {
-    module_load_include('module', 'springboard');
-    springboard_enable_new_panes();
+  module_load_include('module', 'springboard');
+  springboard_enable_new_panes();
 }

--- a/springboard_api/resources/springboard_api.form_resources.inc
+++ b/springboard_api/resources/springboard_api.form_resources.inc
@@ -66,7 +66,7 @@ function springboard_api_form_resource_index($node_type = NULL) {
  *   Associative array of webform component form_keys and their submitted
  *   values.
  */
-function springboard_api_form_action_submit($nid, $app_id = NULL, $submission) {
+function springboard_api_form_action_submit($nid, $app_id = NULL, $submission = array()) {
   if (is_numeric($nid)) {
     $node = node_load($nid);
     // Typecast in case the submission was JSON encoded as an object.
@@ -74,18 +74,9 @@ function springboard_api_form_action_submit($nid, $app_id = NULL, $submission) {
     // Convert submission values to nested array.
     $submission = _springboard_api_convert_submission($submission, $node);
 
-    // TODO: find a long term solution here. We have to have the exact text of
-    // the submission button on the form when submitting.
-    // This value is added to the form by post process function or after build.
-    // It is potentially expensive to go through all the steps required to
-    // generate the full form programmatically so we can then crawl the form api
-    // array looking for the submit button title.
-    if (module_exists('fundraiser') && fundraiser_is_donation_type($node->type)) {
-      $submit_text = t('Donate');
-    }
-    else {
-      $submit_text = t('Submit');
-    }
+    // The op value must match the configured submit_text value.
+    $submit_text = empty($node->webform['submit_text']) ? t('Submit') : t($node->webform['submit_text']);
+
     $form_id = 'webform_client_form_' . $nid;
     $form_state['webform_completed'] = 1;
     $form_state['values'] = array(

--- a/springboard_api/tests/springboard_api.test
+++ b/springboard_api/tests/springboard_api.test
@@ -195,7 +195,7 @@ class SpringboardAPITestCase extends DrupalWebTestCase {
       'hidden' => 'hidden value',
       'textfield_test' => 'textfield value',
     );
-    springboard_api_form_action_submit(1, $values);
+    springboard_api_form_action_submit(1, NULL, $values);
     module_load_include('inc', 'webform', 'includes/webform.submissions');
     return webform_get_submission(1, 1);
   }
@@ -364,7 +364,7 @@ class SpringboardAPITestCase extends DrupalWebTestCase {
         'confirmation_format' => filter_default_format(),
         'redirect_url' => '<confirmation>',
         'teaser' => '0',
-        'allow_draft' => '1',
+        'allow_draft' => '0',
         'submit_text' => '',
         'submit_limit' => '-1',
         'submit_interval' => '-1',

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -2101,7 +2101,8 @@ function springboard_p2p_fundraiser_donation_success($donation) {
   }
 
   $action = springboard_p2p_get_personal_campaign_action_by_sid($donation->sid);
-  if ($action) {
+  // The second condition is to prevent this code from running multiple times.
+  if ($action && $action['status'] != 1) {
     $amount = $donation->donation['amount'];
     if (!empty($donation->donation['quantity'])) {
       $amount = $amount * $donation->donation['quantity'];

--- a/webform_confirmations/webform_confirmations.module
+++ b/webform_confirmations/webform_confirmations.module
@@ -147,13 +147,19 @@ function webform_confirmations_get_submission_session($sid) {
 /**
  * Implements hook_form_FORM_ID_alter().
  *
- *  Conditionally add send on order success checkbox to webform email configuration forms.
+ * Conditionally add send on order success checkbox to webform email configuration forms.
  */
 function webform_confirmations_form_webform_email_edit_form_alter(&$form, $form_state, $form_id) {
+  // We can only control the sending of emails and Drupal token replacement when working with email wrappers.
+  if (!module_exists('email_wrappers')) {
+    return;
+  }
+
   $node = $form['node']['#value'];
   $is_donation = fundraiser_is_donation_type($form['node']['#value']->type);
 
-  if (module_exists('email_wrappers') && !empty($is_donation)) {
+  // For donations add the option to choose when to send.
+  if (!empty($is_donation)) {
     $node = $form['node']['#value'];
     $send_default = _webform_confirmation_send_on_settings($form_state);
     $send_options = array(
@@ -161,7 +167,7 @@ function webform_confirmations_form_webform_email_edit_form_alter(&$form, $form_
       1 => t('Donation succeeds'),
       2 => t('Donation fails'),
     );
-    // TODO: correctly set default on this form element based on prior settings.
+
     $form['send_on_settings'] = array(
       '#type' => 'radios',
       '#title' => t('Send when'),
@@ -169,38 +175,49 @@ function webform_confirmations_form_webform_email_edit_form_alter(&$form, $form_
       '#options' => $send_options,
       '#default_value' => $send_default,
       '#weight' => -49,
+      // Only show when we have a selected email wrappers template.
+      '#states' => array(
+        'visible' => array(
+          ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+        ),
+      ),
     );
+
     $form['#validate'][] = '_webform_confirmations_email_edit_validate';
   }
-  if (module_exists('email_wrappers'))  {
-    $form['template']['tokens'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('Available tokens'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
-      '#weight' => 9,
-    );
-    $token_set = array('node');
-    // Then add any other token set as needed.
-    drupal_alter('webform_confirmations_token_info', $token_set, $node);
-    $form['template']['tokens']['tokens'] = array(
-      '#type' => 'item',
-      '#title' => t('Drupal tokens'),
-      '#description' => theme('token_tree', array('token_types' => $token_set, 'recursion_limit' => 2, 'click_insert' => FALSE)),
-    );
-    if(empty($is_donation)) {
-      $form['template']['tokens']['tokens']['#states'] = array(
-        'invisible' => array(
-          ':input[name="email_wrappers_email_template"]' => array('value' => 0),
-        ),
-      );
-    }
-    $form['template']['tokens']['webform_tokens'] = array(
-      '#type' => 'item',
-      '#title' => t('Webform tokens'),
-      '#description' => theme('webform_token_help', array()),
-    );
-  }
+
+  // Redo the token help element, adding the Drupal token set.
+  unset($form['template']['tokens']);
+
+  $form['template']['tokens'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Available tokens'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#weight' => 9,
+  );
+  $token_set = array('node');
+
+  // Then add any other token set as needed.
+  drupal_alter('webform_confirmations_token_info', $token_set, $node);
+
+  $form['template']['tokens']['tokens'] = array(
+    '#type' => 'item',
+    '#title' => t('Drupal tokens'),
+    '#description' => theme('token_tree', array('token_types' => $token_set, 'recursion_limit' => 2, 'click_insert' => FALSE)),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="email_wrappers_email_template"]' => array('!value' => '0'),
+      ),
+    ),
+  );
+
+  // Add the webform tokens help message.
+  $form['template']['tokens']['webform_tokens'] = array(
+    '#type' => 'item',
+    '#title' => t('Webform tokens'),
+    '#description' => theme('webform_token_help', array()),
+  );
 }
 
 /**


### PR DESCRIPTION
When enabling/disabling the Date mode feature the date for a donation series occuring on the last day of the month would result in sporadic charge dates.

The function validating each donation day was not using the next_charge value to determine the day of the charge.

This fix pulls the next_charge value from the database when evaulating the days.