### PR TITLE
Date Mode Setting Wrong Date when Transitioning Donations

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
@@ -188,12 +188,11 @@ function fundraiser_date_mode_max_records() {
  *
  * @param array $orders
  *   An array of sustainer series order records.
- *
- * @param int $new_date
+ * @param int|null $new_date
  *   Day of the month sustainers should be processed.
  *
- * @return array
- *   Returns an array of sustainer series records that have next_charge
+ * @return int[]
+ *   Returns an array of sustainer series Donation IDs that have next_charge
  *   values that will need to be updated based on the day selection.
  */
 function _fundraiser_date_mode_orders_to_change($orders, $new_date = NULL) {
@@ -225,6 +224,7 @@ function _fundraiser_date_mode_orders_to_change($orders, $new_date = NULL) {
 
     $selected_orders[] = $order['did'];
   }
+
   return $selected_orders;
 }
 
@@ -254,8 +254,10 @@ function _fundraiser_date_mode_calculate_delta($charge_time, $date) {
 /**
  * Verify all series orders fall on the same day of the month.
  *
- * @param array $series_orders
- *   Array of sustainer series order records.
+ * @param int[] $series_orders
+ *   Array of sustainer series Donation IDs.
+ * @param int|null $master_order_day
+ *   The day number of the month.
  *
  * @return bool
  *   Returns TRUE if all orders fall on the same day of the month.
@@ -285,6 +287,7 @@ function _fundraiser_date_mode_validate_order_dates($series_orders, $master_orde
       $dates[] = $date['day'];
     }
   }
+
   return count($dates) === 1 ? TRUE : FALSE;
 }
 
@@ -425,6 +428,13 @@ function fundraiser_date_mode_get_sustainer_series_data() {
 
 /**
  * Update next_charge for an entire sustainer series.
+ *
+ * @param int $time_delta
+ *   The number of seconds to shift the next_charge date by.
+ * @param int $master_did
+ *   The Donation ID of the master donation.
+ * @param int[]|int $dids
+ *   The Donation ID or Donation IDs to modify.
  */
 function fundraiser_date_mode_update_sustainer_date($time_delta, $master_did, $dids) {
   if ($time_delta < 0) {
@@ -534,12 +544,13 @@ function fundraiser_date_mode_update_date_mode_finished() {
  *   Associative array of series orders.
  */
 function _fundraiser_date_mode_alter_next_charge($date, $master_order, $series_orders) {
-  $orders_to_process = _fundraiser_date_mode_orders_to_change($series_orders, $date);
+  // This is an array of Donation IDs.
+  $dids_to_process = _fundraiser_date_mode_orders_to_change($series_orders, $date);
 
   $master_order_date = _fundraiser_date_mode_explode_date($master_order['next_charge']);
-  $orders_on_same_day = _fundraiser_date_mode_validate_order_dates($orders_to_process, $master_order_date['day']);
+  $orders_on_same_day = _fundraiser_date_mode_validate_order_dates($dids_to_process, $master_order_date['day']);
 
-  if (count($orders_to_process) == 0) {
+  if (count($dids_to_process) == 0) {
     return;
   }
   else {
@@ -549,7 +560,7 @@ function _fundraiser_date_mode_alter_next_charge($date, $master_order, $series_o
     if ($orders_on_same_day) {
       // Do mass date conversion.
       $time_delta = _fundraiser_date_mode_calculate_delta($master_order['next_charge'], $date);
-      fundraiser_date_mode_update_sustainer_date($time_delta, $master_order['master_did'], $orders_to_process);
+      fundraiser_date_mode_update_sustainer_date($time_delta, $master_order['master_did'], $dids_to_process);
     }
     else {
       // Some of the next_charge dates in this series are on different days

--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
@@ -262,8 +262,21 @@ function _fundraiser_date_mode_calculate_delta($charge_time, $date) {
  */
 function _fundraiser_date_mode_validate_order_dates($series_orders, $master_order_day = NULL) {
   $dates = array();
-  foreach ($series_orders as $order) {
-    $date = _fundraiser_date_mode_explode_date($order['next_charge']);
+  // Return FALSE if no orders.
+  if (empty($series_orders)) {
+    return FALSE;
+  }
+
+  // Pull all the next charge values for these dids.
+  $next_charges = db_select('fundraiser_sustainers', 's')
+    ->fields('s', array('did', 'next_charge'))
+    ->condition('did', $series_orders)
+    ->execute()
+    ->fetchAllKeyed();
+
+  foreach ($series_orders as $did) {
+    $date = _fundraiser_date_mode_explode_date($next_charges[$did]);
+
     // If supplied, validate order days against the master order day.
     if ($master_order_day && $master_order_day != $date['day']) {
       return FALSE;

--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
@@ -1,9 +1,9 @@
 <?php
-
 /**
  * @file
- * Primary module file for Fundraiser Date Mode. Contains required hook
- * implementations and associated helper functions.
+ * Primary module file for Fundraiser Date Mode.
+ *
+ * Contains required hook implementations and associated helper functions.
  */
 
 /**
@@ -70,7 +70,6 @@ function fundraiser_date_mode_permission() {
     ),
   );
 }
-
 
 /**
  * Implements hook_menu().
@@ -160,9 +159,9 @@ function fundraiser_date_mode_fundraiser_sustainers_recurring_next_charge_alter(
  */
 function fundraiser_date_mode_fundraiser_donation_delete($donation) {
   db_delete('fundraiser_date_mode_dates')
-  ->condition('master_did', $donation->master_did)
-  ->condition('did', $donation->did)
-  ->execute();
+    ->condition('master_did', $donation->master_did)
+    ->condition('did', $donation->did)
+    ->execute();
 }
 
 /**
@@ -235,10 +234,9 @@ function _fundraiser_date_mode_orders_to_change($orders, $new_date = NULL) {
  * arbitrary day of the month.
  *
  * @param int $charge_time
- *   Next charge timestamp
- *
+ *   Next charge timestamp.
  * @param int $date
- *   New day of the month
+ *   New day of the month.
  *
  * @return int
  *   Number of seconds (positive or negative).
@@ -538,9 +536,9 @@ function fundraiser_date_mode_update_date_mode_finished() {
  *
  * @param int $date
  *   Day of the month to move process time to.
- * @param mixed $master_order
+ * @param array $master_order
  *   Associative array containing information about the series master order.
- * @param mixed $series_orders
+ * @param array $series_orders
  *   Associative array of series orders.
  */
 function _fundraiser_date_mode_alter_next_charge($date, $master_order, $series_orders) {


### PR DESCRIPTION
When enabling/disabling the Date mode feature a donation series occuring on the last day of the month would have sporadic charge dates.

The function validating each donation day was not using the next_charge value to determine the day of the charge.

This fix pulls the next_charge value from the database when evaulating the days.
