### PR TITLE
Pagewrapper txt Extension Removal Targets First FIle Only

### DIFF
--- a/page_wrappers/page_wrappers.module
+++ b/page_wrappers/page_wrappers.module
@@ -646,13 +646,13 @@ function theme_page_wrappers_node_assignments($variables) {
 function page_wrappers_file_insert($file) {
 
   //add timestamps to files and rename js files, do not do this on clone process
-  if (arg(2) != 'clone' && isset($file->source) && ($file->source == 'page_wrappers_js_und_0' || $file->source == 'page_wrappers_css_und_0')) {
+  if (arg(2) != 'clone' && isset($file->source) && (strpos($file->source, 'page_wrappers_js_und_') === 0 || strpos($file->source, 'page_wrappers_css_und_') === 0)) {
 
     $dir = drupal_dirname($file->uri);
     $filename = _page_wrappers_add_timestamp($file->filename);
 
     // for .js files, strip off the .txt extension that gets added
-    if ($file->source == 'page_wrappers_js_und_0') {
+    if (strpos($file->source, 'page_wrappers_js_und_') === 0) {
       $filename = substr($filename, 0, strlen($filename) - 4);
     }
 


### PR DESCRIPTION
Issue:
The renaming of page wrapper js and css files to include a timestamp and remove the .txt extension was targeting only the first uploaded file.

Fix:
Adjust the code to allow for files in other deltas to also be renamed.