### PR TITLE
Change the fundraiser donation post submit hook to be an alter instead.

### DIFF
--- a/fundraiser/fundraiser.api.inc
+++ b/fundraiser/fundraiser.api.inc
@@ -195,7 +195,7 @@ function hook_fundraiser_donation_submit($form, $form_state, $donation) {
  *
  * For all modules.
  */
-function hook_fundraiser_donation_post_submit($form, $form_state, $donation) {
+function hook_fundraiser_donation_post_submit_alter(&$form, &$form_state, &$donation) {
 
 }
 

--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1645,13 +1645,13 @@ function _fundraiser_donation_submit_after_process($donation) {
 
 /**
  * Submit callback after donation submitted, but before confirmation.
+ *
+ * Provides a hook alter to allow for sub modules to change behavior after
+ * submission. Such as in cases of failures or the like.
  */
 function fundraiser_donation_post_submit(&$form, &$form_state) {
-  // And after all of that is done, provide a hook to allow for sub modules to change behavior after submission.
-  // Such as in cases of failures or the like. Return the donation object and result.
-  // We return form_state here, because we cannot pass arrays by reference in module calls.
-  // See: http://drupal.org/node/353494 for a detailed discussion of this one.
-  $form_state = module_invoke_all('fundraiser_donation_post_submit', $form, $form_state, $form_state['#donation']);
+
+  drupal_alter('fundraiser_donation_post_submit', $form, $form_state, $form_state['#donation']);
 }
 
 /**

--- a/fundraiser/modules/fundraiser_webform/fundraiser_webform.module
+++ b/fundraiser/modules/fundraiser_webform/fundraiser_webform.module
@@ -767,9 +767,9 @@ function fundraiser_webform_fundraiser_donation_submit($form, $form_state, $dona
 }
 
 /**
- * Implements hook_fundraiser_donation_post_submit().
+ * Implements hook_fundraiser_donation_post_submit_alter().
  */
-function fundraiser_webform_fundraiser_donation_post_submit($form, $form_state, $donation) {
+function fundraiser_webform_fundraiser_donation_post_submit_alter(&$form, &$form_state, &$donation) {
   // Handle behavior if it was a failure.
   if (!isset($donation->result['success']) || (isset($donation->result['success']) && $donation->result['success'] == FALSE) ) {
     // Tell webform we're not done and rebuild the form.
@@ -780,7 +780,6 @@ function fundraiser_webform_fundraiser_donation_post_submit($form, $form_state, 
     $form_state['values']['details']['finished'] = 0;
     $form_state['rebuild'] = TRUE;
   }
-  return $form_state;
 }
 
 /**

--- a/secure_prepopulate/springboard_cookie/springboard_cookie.module
+++ b/secure_prepopulate/springboard_cookie/springboard_cookie.module
@@ -18,7 +18,7 @@ function springboard_cookie_menu() {
     'access arguments' => array('access content'),
     'type' => MENU_CALLBACK,
   );
-  
+
   return $items;
 }
 
@@ -49,7 +49,7 @@ function springboard_cookie_init() {
       drupal_page_is_cacheable(FALSE);
     }
   }
-  
+
   // Make sure this client has a cookie and a client_id.
   if (variable_get('cache', FALSE) && drupal_page_is_cacheable()) {
     // Page can be cached, so send Javascript to make the client check itself for the cookie.
@@ -82,9 +82,9 @@ function springboard_cookie_user_login(&$edit, $account) {
 }
 
 /**
- * Implementation of hook_fundraiser_donation_post_submit().
+ * Implements hook_fundraiser_donation_post_submit_alter().
  */
-function springboard_cookie_fundraiser_donation_post_submit($form, $form_state, $donation) {
+function springboard_cookie_fundraiser_donation_post_submit_alter(&$form, &$form_state, &$donation) {
   // Pull user data from the new donation and tag it to the client.
   $new_data = array();
   if ($donation->uid) {
@@ -135,7 +135,7 @@ function springboard_cookie_form_alter(&$form, &$form_state, $form_id) {
     );
     $form['#validate'][] = 'springboard_cookie_settings_validate';
   }
-  
+
   // Add submission handler to Webform User-enabled webform.
   if (module_exists('webform_user')) {
     if (strpos($form_id, 'webform_client') !== FALSE && arg(2) != 'submission' && arg(4) != 'edit') {
@@ -198,7 +198,7 @@ function springboard_cookie_js_new_cookie() {
   $cookie = springboard_cookie_get_cookie();
   $serialized = serialize($cookie);
   $encrypted = secure_prepopulate_encrypt($serialized);
-  
+
   // Send it back as JSON.
   drupal_json_output(array(
     'cookie' => $encrypted,
@@ -210,13 +210,13 @@ function springboard_cookie_js_new_cookie() {
 
 /**
  * Tag the client with Springboard cookie data.
- * 
+ *
  * If the client doesn't have a Springboard cookie, one will be created, including a client ID.
- * 
+ *
  * @param array $new_data
- *   An array of name/value pairs. If a string or numeric value contradicts the existing value for a 
- *   given name, then the existing cookie will be thrown out and this data will go into a new cookie 
- *   with a new client_id. For an array value, its unique contents will be added to any existing array 
+ *   An array of name/value pairs. If a string or numeric value contradicts the existing value for a
+ *   given name, then the existing cookie will be thrown out and this data will go into a new cookie
+ *   with a new client_id. For an array value, its unique contents will be added to any existing array
  *   of the same name (and duplicate values will be ignored).
  */
 function springboard_cookie_tag_client($new_data = array()) {
@@ -236,7 +236,7 @@ function springboard_cookie_tag_client($new_data = array()) {
     else {
       // Add new data to the cookie.
       $new_cookie[$name] = $new_data[$name];
-    } 
+    }
   }
   // Make sure the cookie has a client ID.
   if (!isset($new_cookie['client_id'])) {
@@ -255,7 +255,7 @@ function springboard_cookie_tag_client($new_data = array()) {
 
 /**
  * Fetch the Springboard cookie, decrypt, and return data.
- * 
+ *
  * @return array $cookie_data
  *   An array of name/value pairs from the client cookie. Includes data added during execution of the
  *   current page request.
@@ -263,7 +263,7 @@ function springboard_cookie_tag_client($new_data = array()) {
 function springboard_cookie_get_cookie() {
   // Static-persist the cookie's data if/when it is set.
   $cookie_data = &drupal_static(__FUNCTION__);
-  
+
   // First time? Look for the cookie.
   if ($cookie_data === NULL) {
     $cookie_data = array();
@@ -282,23 +282,23 @@ function springboard_cookie_get_cookie() {
       }
     }
   }
-  
+
   // Return the cookie data.
   return $cookie_data;
 }
 
 /**
  * Set the Springboard cookie, encrypting the given data array and adding it to the HTTP response.
- * 
+ *
  * Note: If you're trying to add data to the cookie, what you want is springboard_cookie_tag_client().
- * 
+ *
  * @see springboard_cookie_tag_client()
  */
 function springboard_cookie_set_cookie($cookie_data) {
   // Update the getter's static cache.
   $static_cache = &drupal_static('springboard_cookie_get_cookie');
   $static_cache = $cookie_data;
-  
+
   // Serialize, encrypt, and add to the response.
   $serialized = serialize($cookie_data);
   $encrypted = secure_prepopulate_encrypt($serialized);


### PR DESCRIPTION
The original problem is this was a hook that was returning $form_state. So if nothing implemented the hook $form_state would get wiped out. If more than one implementation returned $form_state it would cause a recursion error because it was trying to merge $form_state into itself. So everything works fine if there's exactly one implementation that returns $form_state.

I need this change specifically because I want to change $form_state['redirect'] in a new implementation of this hook.

This changes the hook into a drupal_alter, and updates the api doc for fundraiser, and updates existing Springboard core implementations of this hook to use the alter instead. The known core implementations are fundraiser_webform and springboard_cookie. Only fundraiser_webform returned a form_state. There is also commented code in fundraiser_offline that implements the hook but I left that alone. We should probably remove that to avoid confusion if we really don't need it.
