### PR TITLE
Set the site timezone on the initial DateTime object for a sustiainer series

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -2004,6 +2004,7 @@ function _fundraiser_sustainers_create_future_orders($donation, $month, $year, $
 
   // Create a DateTime from the start timestamp.
   $previous_charge = new DateTime("@$start");
+  date_timezone_set($previous_charge, timezone_open(variable_get('date_default_timezone', @date_default_timezone_get())));
 
   // Allow other modules to modify the stop date.
   $end_date = array(


### PR DESCRIPTION
Without setting the timezone on the initial DateTime object for the series it may use the UTC timezone, which could be a day off of the sites current timezone. See http://php.net/date_default_timezone_get for more info on how php selects a timezone.

This fix explicitly sets the timezone on the DateTime object from the site's timezone setting.