### PR TITLE
Handle unix timestamps in full salesforce date/time fields.

### DIFF
--- a/salesforce/salesforce_sync/includes/salesforce_sync.sync.inc
+++ b/salesforce/salesforce_sync/includes/salesforce_sync.sync.inc
@@ -643,7 +643,12 @@ class SalesforceSync {
 
           case 'datetime':
             // Salesforce requires ISO 8601 format for dates.
-            $item->sobject->fields[$field_name] = date('c', strtotime($value));
+            if ($this->isValidTimestamp($value)) {
+              $item->sobject->fields[$field_name] = date('c', $value);
+            }
+            elseif ($value != '') {
+              $item->sobject->fields[$field_name] = date('c', strtotime($value));
+            }
             break;
 
           case 'date':


### PR DESCRIPTION
Full datetime formatting was using strtotime() to try and convert a unix timestamp to a date. This update checks to see if the value being exported is a timestamp and handles it accordingly.