### PR TITLE
Use Country Value in form_state When Rendering State (aka Zone) Field

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -797,7 +797,10 @@ function _fundraiser_commerce_zone_field_display($form, $form_state, $field) {
     // Provide a default based on the form values.
     $country_field = fundraiser_get_form_field($form['#calling_module'], $form, 'country');
     // Filter options down to just the zones available for this country.
-    if (isset($country_field['#default_value'])) {
+    if (!empty($country_id)) {
+      $default = $country_id;
+    }
+    elseif (isset($country_field['#default_value'])) {
       $default = $country_field['#default_value'];
     }
     elseif(isset($country_field['#webform_component']['value'])) {


### PR DESCRIPTION
Issue:
If a custom module re-arranges the fundraiser fields in hook_fundraiser_field_info_alter it may cause the state field to not interact correctly with the country field selection. For example, it won't switch to a textfield for countries with no pre-set zones.

Fix:
Use the value from form_state first when determining a default value from the country field.