### PR TITLE
Administrator View Showing Duplicate Users

### DIFF
--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -130,6 +130,10 @@ function springboard_admin_form_views_exposed_form_alter(&$form, &$form_state, $
         $form['date_filter']['min']['#title'] = 'Requested between';
         $form['date_filter']['max']['#title'] = 'and';
         break;
+      case "sbv_administrator_users";
+        $form['date_filter']['min']['#title'] = 'Created between';
+        $form['date_filter']['max']['#title'] = 'and';
+        break;
       // Default will be the updated date.
       default;
         $form['date_filter']['min']['#title'] = 'Last updated between';
@@ -1395,7 +1399,7 @@ function _springboard_admin_apply_treatment($user) {
  */
 function _springboard_admin_views() {
   $view_names = array(
-    'sbv_administrators',
+    'sbv_administrator_users',
     'sbv_assets',
     'sbv_contacts',
     'sbv_dblog',

--- a/springboard/modules/springboard_views/springboard_views.views_default.inc
+++ b/springboard/modules/springboard_views/springboard_views.views_default.inc
@@ -4285,22 +4285,22 @@ function springboard_views_views_default_views() {
   $handler->display->display_options['menu']['context_only_inline'] = 0;
   $views[$view->name] = $view;
 
-/**
- * View sbv_administrators
- */
+  /**
+   * View sbv_administrators
+   */
   $view = new view();
-  $view->name = 'sbv_administrators';
+  $view->name = 'sbv_administrator_users';
   $view->description = '';
   $view->tag = 'default';
-  $view->base_table = 'commerce_customer_profile';
-  $view->human_name = 'sbv_administrators';
+  $view->base_table = 'users';
+  $view->human_name = 'sbv_administrator_users';
   $view->core = 7;
   $view->api_version = '3.0';
   $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
 
   /* Display: Master */
   $handler = $view->new_display('default', 'Master', 'default');
-  $handler->display->display_options['title'] = 'Contacts';
+  $handler->display->display_options['title'] = 'Administrators';
   $handler->display->display_options['css_class'] = 'donor-table-view sbadmin-table-min sbadmin-table-min-x sb-admin-page';
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'perm';
@@ -4310,12 +4310,8 @@ function springboard_views_views_default_views() {
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'full';
   $handler->display->display_options['pager']['options']['items_per_page'] = '20';
-  $handler->display->display_options['pager']['options']['offset'] = '0';
-  $handler->display->display_options['pager']['options']['id'] = '0';
-  $handler->display->display_options['pager']['options']['quantity'] = '9';
   $handler->display->display_options['style_plugin'] = 'table';
   $handler->display->display_options['style_options']['columns'] = array(
-    'views_bulk_operations' => 'views_bulk_operations',
     'uid' => 'uid',
     'sbp_first_name' => 'sbp_first_name',
     'sbp_last_name' => 'sbp_last_name',
@@ -4327,11 +4323,6 @@ function springboard_views_views_default_views() {
   );
   $handler->display->display_options['style_options']['default'] = '-1';
   $handler->display->display_options['style_options']['info'] = array(
-    'views_bulk_operations' => array(
-      'align' => '',
-      'separator' => '',
-      'empty_column' => 0,
-    ),
     'uid' => array(
       'sortable' => 1,
       'default_sort_order' => 'asc',
@@ -4383,201 +4374,53 @@ function springboard_views_views_default_views() {
       'empty_column' => 0,
     ),
   );
-  /* Relationship: Commerce Customer Profile: Owner */
-  $handler->display->display_options['relationships']['uid']['id'] = 'uid';
-  $handler->display->display_options['relationships']['uid']['table'] = 'commerce_customer_profile';
-  $handler->display->display_options['relationships']['uid']['field'] = 'uid';
   /* Field: User: Uid */
   $handler->display->display_options['fields']['uid']['id'] = 'uid';
   $handler->display->display_options['fields']['uid']['table'] = 'users';
   $handler->display->display_options['fields']['uid']['field'] = 'uid';
-  $handler->display->display_options['fields']['uid']['relationship'] = 'uid';
   $handler->display->display_options['fields']['uid']['label'] = 'ID';
   $handler->display->display_options['fields']['uid']['link_to_user'] = FALSE;
   /* Field: User: First name */
   $handler->display->display_options['fields']['sbp_first_name']['id'] = 'sbp_first_name';
   $handler->display->display_options['fields']['sbp_first_name']['table'] = 'field_data_sbp_first_name';
   $handler->display->display_options['fields']['sbp_first_name']['field'] = 'sbp_first_name';
-  $handler->display->display_options['fields']['sbp_first_name']['relationship'] = 'uid';
-  /* Field: User: Last name */
-  $handler->display->display_options['fields']['sbp_last_name']['id'] = 'sbp_last_name';
-  $handler->display->display_options['fields']['sbp_last_name']['table'] = 'field_data_sbp_last_name';
-  $handler->display->display_options['fields']['sbp_last_name']['field'] = 'sbp_last_name';
-  $handler->display->display_options['fields']['sbp_last_name']['relationship'] = 'uid';
-  /* Field: User: E-mail */
-  $handler->display->display_options['fields']['mail']['id'] = 'mail';
-  $handler->display->display_options['fields']['mail']['table'] = 'users';
-  $handler->display->display_options['fields']['mail']['field'] = 'mail';
-  $handler->display->display_options['fields']['mail']['relationship'] = 'uid';
-  /* Field: User: Address */
-  $handler->display->display_options['fields']['sbp_address']['id'] = 'sbp_address';
-  $handler->display->display_options['fields']['sbp_address']['table'] = 'field_data_sbp_address';
-  $handler->display->display_options['fields']['sbp_address']['field'] = 'sbp_address';
-  $handler->display->display_options['fields']['sbp_address']['relationship'] = 'uid';
-  /* Field: User: City */
-  $handler->display->display_options['fields']['sbp_city']['id'] = 'sbp_city';
-  $handler->display->display_options['fields']['sbp_city']['table'] = 'field_data_sbp_city';
-  $handler->display->display_options['fields']['sbp_city']['field'] = 'sbp_city';
-  $handler->display->display_options['fields']['sbp_city']['relationship'] = 'uid';
-  /* Field: User: State/Province */
-  $handler->display->display_options['fields']['sbp_state']['id'] = 'sbp_state';
-  $handler->display->display_options['fields']['sbp_state']['table'] = 'field_data_sbp_state';
-  $handler->display->display_options['fields']['sbp_state']['field'] = 'sbp_state';
-  $handler->display->display_options['fields']['sbp_state']['relationship'] = 'uid';
-  $handler->display->display_options['fields']['sbp_state']['label'] = 'State';
-  /* Field: User: Postal Code */
-  $handler->display->display_options['fields']['sbp_zip']['id'] = 'sbp_zip';
-  $handler->display->display_options['fields']['sbp_zip']['table'] = 'field_data_sbp_zip';
-  $handler->display->display_options['fields']['sbp_zip']['field'] = 'sbp_zip';
-  $handler->display->display_options['fields']['sbp_zip']['relationship'] = 'uid';
-  $handler->display->display_options['fields']['sbp_zip']['label'] = 'Zip';
-  /* Field: User: Created date */
-  $handler->display->display_options['fields']['created']['id'] = 'created';
-  $handler->display->display_options['fields']['created']['table'] = 'users';
-  $handler->display->display_options['fields']['created']['field'] = 'created';
-  $handler->display->display_options['fields']['created']['relationship'] = 'uid';
-  $handler->display->display_options['fields']['created']['label'] = 'Created';
-  $handler->display->display_options['fields']['created']['date_format'] = 'custom';
-  $handler->display->display_options['fields']['created']['custom_date_format'] = 'm/j/y';
-  /* Field: Commerce Customer Profile: Updated date */
-  $handler->display->display_options['fields']['changed']['id'] = 'changed';
-  $handler->display->display_options['fields']['changed']['table'] = 'commerce_customer_profile';
-  $handler->display->display_options['fields']['changed']['field'] = 'changed';
-  $handler->display->display_options['fields']['changed']['label'] = 'Updated';
-  $handler->display->display_options['fields']['changed']['date_format'] = 'custom';
-  $handler->display->display_options['fields']['changed']['custom_date_format'] = 'm/j/y';
-  /* Field: Global: Custom text */
-  $handler->display->display_options['fields']['nothing']['id'] = 'nothing';
-  $handler->display->display_options['fields']['nothing']['table'] = 'views';
-  $handler->display->display_options['fields']['nothing']['field'] = 'nothing';
-  $handler->display->display_options['fields']['nothing']['label'] = '';
-  $handler->display->display_options['fields']['nothing']['alter']['text'] = '<a href="/user/[uid]/edit?destination=admin/springboard/reports/donor">Edit</a>
-  <a href="/user/[uid]/recurring_overview?destination=admin/springboard/reports/donor">Recurring gifts</a>
-  ';
-  $handler->display->display_options['fields']['nothing']['element_label_colon'] = FALSE;
-  /* Sort criterion: User: Last name (sbp_last_name) */
-  $handler->display->display_options['sorts']['sbp_last_name_value']['id'] = 'sbp_last_name_value';
-  $handler->display->display_options['sorts']['sbp_last_name_value']['table'] = 'field_data_sbp_last_name';
-  $handler->display->display_options['sorts']['sbp_last_name_value']['field'] = 'sbp_last_name_value';
-  $handler->display->display_options['sorts']['sbp_last_name_value']['relationship'] = 'uid';
-  /* Filter criterion: User: First name (sbp_first_name) */
-  $handler->display->display_options['filters']['sbp_first_name_value']['id'] = 'sbp_first_name_value';
-  $handler->display->display_options['filters']['sbp_first_name_value']['table'] = 'field_data_sbp_first_name';
-  $handler->display->display_options['filters']['sbp_first_name_value']['field'] = 'sbp_first_name_value';
-  $handler->display->display_options['filters']['sbp_first_name_value']['relationship'] = 'uid';
-  $handler->display->display_options['filters']['sbp_first_name_value']['operator'] = 'contains';
-  $handler->display->display_options['filters']['sbp_first_name_value']['exposed'] = TRUE;
-  $handler->display->display_options['filters']['sbp_first_name_value']['expose']['operator_id'] = 'sbp_first_name_value_op';
-  $handler->display->display_options['filters']['sbp_first_name_value']['expose']['label'] = 'First name';
-  $handler->display->display_options['filters']['sbp_first_name_value']['expose']['operator'] = 'sbp_first_name_value_op';
-  $handler->display->display_options['filters']['sbp_first_name_value']['expose']['identifier'] = 'sbp_first_name_value';
-  $handler->display->display_options['filters']['sbp_first_name_value']['expose']['remember_roles'] = array(
-    2 => '2',
-    1 => 0,
-    3 => 0,
-    4 => 0,
-    5 => 0,
-  );
-  /* Filter criterion: User: Last name (sbp_last_name) */
-  $handler->display->display_options['filters']['sbp_last_name_value']['id'] = 'sbp_last_name_value';
-  $handler->display->display_options['filters']['sbp_last_name_value']['table'] = 'field_data_sbp_last_name';
-  $handler->display->display_options['filters']['sbp_last_name_value']['field'] = 'sbp_last_name_value';
-  $handler->display->display_options['filters']['sbp_last_name_value']['relationship'] = 'uid';
-  $handler->display->display_options['filters']['sbp_last_name_value']['operator'] = 'contains';
-  $handler->display->display_options['filters']['sbp_last_name_value']['exposed'] = TRUE;
-  $handler->display->display_options['filters']['sbp_last_name_value']['expose']['operator_id'] = 'sbp_last_name_value_op';
-  $handler->display->display_options['filters']['sbp_last_name_value']['expose']['label'] = 'Last name';
-  $handler->display->display_options['filters']['sbp_last_name_value']['expose']['operator'] = 'sbp_last_name_value_op';
-  $handler->display->display_options['filters']['sbp_last_name_value']['expose']['identifier'] = 'sbp_last_name_value';
-  $handler->display->display_options['filters']['sbp_last_name_value']['expose']['remember_roles'] = array(
-    2 => '2',
-    1 => 0,
-    3 => 0,
-    4 => 0,
-    5 => 0,
-  );
-  /* Filter criterion: User: State/Province (sbp_state) */
-  $handler->display->display_options['filters']['sbp_state_value']['id'] = 'sbp_state_value';
-  $handler->display->display_options['filters']['sbp_state_value']['table'] = 'field_data_sbp_state';
-  $handler->display->display_options['filters']['sbp_state_value']['field'] = 'sbp_state_value';
-  $handler->display->display_options['filters']['sbp_state_value']['relationship'] = 'uid';
-  $handler->display->display_options['filters']['sbp_state_value']['exposed'] = TRUE;
-  $handler->display->display_options['filters']['sbp_state_value']['expose']['operator_id'] = 'sbp_state_value_op';
-  $handler->display->display_options['filters']['sbp_state_value']['expose']['label'] = 'State/Province';
-  $handler->display->display_options['filters']['sbp_state_value']['expose']['operator'] = 'sbp_state_value_op';
-  $handler->display->display_options['filters']['sbp_state_value']['expose']['identifier'] = 'sbp_state_value';
-  $handler->display->display_options['filters']['sbp_state_value']['expose']['remember_roles'] = array(
-    2 => '2',
-    1 => 0,
-    3 => 0,
-    4 => 0,
-    5 => 0,
-  );
-  $handler->display->display_options['filters']['sbp_state_value']['group_info']['label'] = 'State/Province (sbp_state)';
-  $handler->display->display_options['filters']['sbp_state_value']['group_info']['identifier'] = 'sbp_state_value';
-  $handler->display->display_options['filters']['sbp_state_value']['group_info']['remember'] = FALSE;
-  $handler->display->display_options['filters']['sbp_state_value']['group_info']['group_items'] = array(
-    1 => array(),
-    2 => array(),
-    3 => array(),
-  );
-
-  /* Display: Administrators */
-  $handler = $view->new_display('page', 'Administrators', 'page');
-  $handler->display->display_options['defaults']['fields'] = FALSE;
-  /* Field: User: Uid */
-  $handler->display->display_options['fields']['uid']['id'] = 'uid';
-  $handler->display->display_options['fields']['uid']['table'] = 'users';
-  $handler->display->display_options['fields']['uid']['field'] = 'uid';
-  $handler->display->display_options['fields']['uid']['relationship'] = 'uid';
-  $handler->display->display_options['fields']['uid']['label'] = 'ID';
-  $handler->display->display_options['fields']['uid']['link_to_user'] = FALSE;
-  /* Field: User: First name */
-  $handler->display->display_options['fields']['sbp_first_name']['id'] = 'sbp_first_name';
-  $handler->display->display_options['fields']['sbp_first_name']['table'] = 'field_data_sbp_first_name';
-  $handler->display->display_options['fields']['sbp_first_name']['field'] = 'sbp_first_name';
-  $handler->display->display_options['fields']['sbp_first_name']['relationship'] = 'uid';
   $handler->display->display_options['fields']['sbp_first_name']['label'] = 'First Name';
   /* Field: User: Last name */
   $handler->display->display_options['fields']['sbp_last_name']['id'] = 'sbp_last_name';
   $handler->display->display_options['fields']['sbp_last_name']['table'] = 'field_data_sbp_last_name';
   $handler->display->display_options['fields']['sbp_last_name']['field'] = 'sbp_last_name';
-  $handler->display->display_options['fields']['sbp_last_name']['relationship'] = 'uid';
   /* Field: User: E-mail */
   $handler->display->display_options['fields']['mail']['id'] = 'mail';
   $handler->display->display_options['fields']['mail']['table'] = 'users';
   $handler->display->display_options['fields']['mail']['field'] = 'mail';
-  $handler->display->display_options['fields']['mail']['relationship'] = 'uid';
   $handler->display->display_options['fields']['mail']['link_to_user'] = '0';
   /* Field: User: Created date */
   $handler->display->display_options['fields']['created']['id'] = 'created';
   $handler->display->display_options['fields']['created']['table'] = 'users';
   $handler->display->display_options['fields']['created']['field'] = 'created';
-  $handler->display->display_options['fields']['created']['relationship'] = 'uid';
   $handler->display->display_options['fields']['created']['label'] = 'Created';
   $handler->display->display_options['fields']['created']['date_format'] = 'custom';
   $handler->display->display_options['fields']['created']['custom_date_format'] = 'm/j/y';
+  $handler->display->display_options['fields']['created']['second_date_format'] = 'long';
   /* Field: User: Roles */
   $handler->display->display_options['fields']['rid']['id'] = 'rid';
   $handler->display->display_options['fields']['rid']['table'] = 'users_roles';
   $handler->display->display_options['fields']['rid']['field'] = 'rid';
-  $handler->display->display_options['fields']['rid']['relationship'] = 'uid';
   $handler->display->display_options['fields']['rid']['label'] = 'Role(s)';
   /* Field: User: Edit link */
   $handler->display->display_options['fields']['edit_node']['id'] = 'edit_node';
   $handler->display->display_options['fields']['edit_node']['table'] = 'users';
   $handler->display->display_options['fields']['edit_node']['field'] = 'edit_node';
-  $handler->display->display_options['fields']['edit_node']['relationship'] = 'uid';
   $handler->display->display_options['fields']['edit_node']['label'] = 'Action';
-  $handler->display->display_options['fields']['edit_node']['element_label_colon'] = FALSE;
   /* Field: User: Link */
   $handler->display->display_options['fields']['view_user']['id'] = 'view_user';
   $handler->display->display_options['fields']['view_user']['table'] = 'users';
   $handler->display->display_options['fields']['view_user']['field'] = 'view_user';
-  $handler->display->display_options['fields']['view_user']['relationship'] = 'uid';
   $handler->display->display_options['fields']['view_user']['label'] = 'View';
-  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
-  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Sort criterion: User: Last name (sbp_last_name) */
+  $handler->display->display_options['sorts']['sbp_last_name_value']['id'] = 'sbp_last_name_value';
+  $handler->display->display_options['sorts']['sbp_last_name_value']['table'] = 'field_data_sbp_last_name';
+  $handler->display->display_options['sorts']['sbp_last_name_value']['field'] = 'sbp_last_name_value';
   /* Filter criterion: Global: Combine fields filter */
   $handler->display->display_options['filters']['combine']['id'] = 'combine';
   $handler->display->display_options['filters']['combine']['table'] = 'views';
@@ -4600,13 +4443,11 @@ function springboard_views_views_default_views() {
     'sbp_first_name' => 'sbp_first_name',
     'sbp_last_name' => 'sbp_last_name',
     'mail' => 'mail',
-    'rid' => 'rid',
   );
   /* Filter criterion: Date: Date (users) */
   $handler->display->display_options['filters']['date_filter']['id'] = 'date_filter';
   $handler->display->display_options['filters']['date_filter']['table'] = 'users';
   $handler->display->display_options['filters']['date_filter']['field'] = 'date_filter';
-  $handler->display->display_options['filters']['date_filter']['relationship'] = 'uid';
   $handler->display->display_options['filters']['date_filter']['operator'] = 'between';
   $handler->display->display_options['filters']['date_filter']['group'] = 1;
   $handler->display->display_options['filters']['date_filter']['exposed'] = TRUE;
@@ -4628,12 +4469,16 @@ function springboard_views_views_default_views() {
   $handler->display->display_options['filters']['rid']['id'] = 'rid';
   $handler->display->display_options['filters']['rid']['table'] = 'users_roles';
   $handler->display->display_options['filters']['rid']['field'] = 'rid';
-  $handler->display->display_options['filters']['rid']['relationship'] = 'uid';
   $handler->display->display_options['filters']['rid']['value'] = array(
     3 => '3',
     4 => '4',
     5 => '5',
   );
+  $handler->display->display_options['filters']['rid']['group'] = 1;
+  $handler->display->display_options['filters']['rid']['reduce_duplicates'] = TRUE;
+
+  /* Display: Administrators */
+  $handler = $view->new_display('page', 'Administrators', 'page');
   $handler->display->display_options['path'] = 'admin/springboard/settings/administrators';
   $views[$view->name] = $view;
 


### PR DESCRIPTION
The SB admin view was based on the Commerce Customer Profile table. This was causing duplicate entries for each user with more than one customer profile.

This changes the view to be based on the user table.