### PR TITLE
Cancel Without Entering Reason

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/js/sustainer.js
+++ b/fundraiser/modules/fundraiser_sustainers/js/sustainer.js
@@ -1,26 +1,32 @@
-/* javascript functions for sustainer management page */
+/**
+ * @file
+ * Javascript functions for sustainer management page.
+ */
 Drupal.behaviors.fundraiserSustainer = {
   attach: function(context) { (function($) {
 
-  $(document).ready(function() {
-    // clear out the cancellation reason when it receives the focus for the first time
+    /* Disable submit buttons on the 3 main forms when submitting */
+    $('#fundraiser-sustainers-donation-amount-form').submit(function() {
+      $('input[type=submit]', this).attr('disabled', 'disabled');
+    });
+
+    $('#fundraiser-sustainers-billing-update-form').submit(function() {
+      $('input[type=submit]', this).attr('disabled', 'disabled');
+    });
+
+    $('#fundraiser-sustainers-cancel-form').submit(function() {
+      $('input[type=submit]', this).attr('disabled', 'disabled');
+    });
+
+    // clear out the cancellation reason when it receives the focus for the first time.
     $('#edit-reason').one('focus', function() {
       $(this).val('');
     });
 
-    /* Disable submit buttons on the 3 main forms when submitting */
-    $('#fundraiser-donation-amount-form').submit(function() {
-      $('input[type=submit]', this).attr('disabled', 'disabled');
+    // Trigger the focus so it will clear out the message if it hasn't been edited.
+    $('#fundraiser-sustainers-cancel-form input[type=submit]').click(function() {
+      $('#edit-reason').trigger('focus');
     });
-
-    $('#fundraiser-billing-update-form').submit(function() {
-      $('input[type=submit]', this).attr('disabled', 'disabled');
-    });
-
-    $('#fundraiser-cancel-form').submit(function() {
-      $('input[type=submit]', this).attr('disabled', 'disabled');
-    });
-  });
 
   })(jQuery); }
 }


### PR DESCRIPTION
Its currently possible to submit the sustainer cancel form without having changed the default text in the reason field.

This change forces that text to clear if it hasn't been edited.