### PR TITLE
386 re enabling message action loses taxonomy

### DIFF
--- a/springboard_advocacy/includes/springboard_advocacy.admin.inc
+++ b/springboard_advocacy/includes/springboard_advocacy.admin.inc
@@ -277,7 +277,7 @@ function springboard_advocacy_dashboard($path, $arg = NULL) {
       if(isset($message_types[$node->type])) {
         if(isset($node->message_ids)) {
           $messages = entity_load('sba_message', $node->message_ids);
-          if(count($messages == 1)) {
+          if(count($messages) == 1) {
             $message = array_pop($messages);
             $subject_editable = field_get_items('sba_message', $message, 'field_sba_subject_editable');
             $user_editable = field_get_items('sba_message', $message, 'field_sba_user_editable');

--- a/springboard_advocacy/modules/sba_message/sba_message.module
+++ b/springboard_advocacy/modules/sba_message/sba_message.module
@@ -53,7 +53,7 @@ function sba_message_access($op, $sba_message = NULL, $account = NULL) {
     if (arg(2) == 'messages' && arg(3) == 'add') {
       if (isset($node->message_ids)) {
         $messages = entity_load('sba_message', $node->message_ids);
-        if (count($messages == 1)) {
+        if (count($messages) == 1) {
           $message = array_pop($messages);
           $subject_editable = field_get_items('sba_message', $message, 'field_sba_subject_editable');
           $user_editable = field_get_items('sba_message', $message, 'field_sba_user_editable');

--- a/springboard_advocacy/modules/sba_message_action/sba_message_action.install
+++ b/springboard_advocacy/modules/sba_message_action/sba_message_action.install
@@ -45,6 +45,7 @@ function sba_message_action_install() {
   _sba_message_action_create_content_type();
   _sba_message_action_reorder_internal_name();
   _sba_message_action_create_example_message_action();
+  _springboard_message_action_install_taxonomy_fields();
 
 }
 
@@ -834,12 +835,11 @@ function _springboard_message_action_install_taxonomy_fields() {
   module_load_install('springboard_advocacy');
   if(function_exists('_springboard_advocacy_install_taxonomy_field_definitions')) {
     foreach (_springboard_advocacy_install_taxonomy_field_definitions() as $field_name => $field) {
-      $exists = field_info_field($field_name);
-      if (empty($exists)) {
+      if (!field_info_field('field_' . $field_name)) {
         field_create_field($field['field_config']);
       }
       // Before adding the field, check that it doesn't exist on the node type.
-      if (!field_info_instance('node', $field_name, 'sba_message_action')) {
+      if (!field_info_instance('node', 'field_' . $field_name, 'sba_message_action')) {
         field_create_instance($field['field_instance']);
       }
     }
@@ -947,9 +947,3 @@ function sba_message_action_update_7004() {
   $instance_info['required'] = 1;
   field_update_instance($instance_info);
 }
-
-//function sba_message_action_update_7005()
-//{
-//  cache_clear_all();
-//  _springboard_message_action_install_taxonomy_fields();
-//}

--- a/springboard_advocacy/springboard_advocacy.install
+++ b/springboard_advocacy/springboard_advocacy.install
@@ -181,12 +181,8 @@ function _springboard_advocacy_install_taxonomy_fields() {
 
   foreach (_springboard_advocacy_install_taxonomy_field_definitions() as $field_name => $field) {
     // If the field doesn't exist create it.
-    if (!field_info_field($field_name)) {
+    if (!field_info_field('field_' . $field_name)) {
       field_create_field($field['field_config']);
-    }
-    // Before adding the field, check that it doesn't exist on the node type.
-    if (!field_info_instance('node', $field_name, 'sba_message_action')) {
-      field_create_instance($field['field_instance']);
     }
   }
 }


### PR DESCRIPTION


Both the advocacy and message_action install files improperly referenced the taxonomy field names, omitting the "field_" prefix when checking field existence with field_info_field and field_info_instance. This caused a problem when message action module was disabled/re-enabled.

Also, the creation of the message action field instances was moved to the message action install file.

Hitching a ride in this patch is a syntax fix in two spots in which the number of existing messages was counted in order to determine whether the user-editable option should be disabled on the message add/edit page, and whether a message should be shown on the message landing page  if a message is user-editable. The bad syntax did not result a bug - everything worked as expected - but it was obviously wrong.
