### PR TITLE
Change the SB Tags role settings to be exclusive vs. inclusive

### DIFF
--- a/springboard_tag/plugins/export_ui/springboard_tag_export_ui.class.php
+++ b/springboard_tag/plugins/export_ui/springboard_tag_export_ui.class.php
@@ -59,10 +59,10 @@ class springboard_tag_export_ui extends ctools_export_ui {
     $role_options = array_map('check_plain', user_roles());
     $form['visibility']['user']['roles'] = array(
       '#type' => 'checkboxes',
-      '#title' => t('Show tag for specific user roles'),
+      '#title' => t('Exclude tag for specific user roles'),
       '#default_value' => $form_state['item']->settings['visibility']['user']['roles'],
       '#options' => $role_options,
-      '#description' => t('Show this tag only for the selected role(s). If you select no roles, the tag will be visible to all users.'),
+      '#description' => t('Exclude this tag for the selected role(s). If you select no roles, the tag will be visible to all users.'),
     );
 
     // Per-path visibility.

--- a/springboard_tag/springboard_tag.module
+++ b/springboard_tag/springboard_tag.module
@@ -213,13 +213,19 @@ function springboard_tag_springboard_tag_list_alter(&$tags) {
       }
     }
 
-    // If a tag has no roles associated, it is displayed for every role.
-    // For tags with roles associated, if none of the user's roles matches
-    // the settings from this tag, remove it from the block list.
-    if (array_filter($user['roles']) && !array_intersect($user['roles'], array_keys($account->roles))) {
-      // No match.
-      unset($tags[$key]);
-      continue;
+    // Check if the current user should not see this tag by role.
+    // For tags with roles associated, if any of the user's roles matches
+    // the settings from this tag, remove it from the tag list.
+    if (array_filter($user['roles'])) {
+      // One or more roles are selected.
+      foreach (array_keys($account->roles) as $rid) {
+        // Is the current user a member of one of these roles?
+        if (isset($user['roles'][$rid]) && $rid == $user['roles'][$rid]) {
+          // Current user is a member of a role that should be excluded from seeing this tag.
+          unset($tags[$key]);
+          continue;
+        }
+      }
     }
 
     // Limited visibility blocks must list at least one page.


### PR DESCRIPTION
This changes the SB roles setting so a user with the selected role(s) would not see the tag.