### PR TITLE
Create Sustainer Series on Cron

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.info
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.info
@@ -29,3 +29,4 @@ files[] = includes/FundraiserSustainersInsights.php
 files[] = tests/fundraiser_sustainers.test
 files[] = tests/fundraiser_sustainers_health_checks.test
 files[] = tests/fundraiser_sustainers_insights.test
+files[] = tests/fundraiser_sustainers_delayed_creation.test

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -1327,12 +1327,18 @@ function fundraiser_sustainers_edit_form($did) {
     return t('You do not have access to this recurring donation.');
   }
 
+  // Text used for various sections of the form if no more charges remain.
+  $no_remaining_message = t('There are no further charges for this recurring donation.');
+
   // If the series creation is pending let the user know.
   if (
     !empty($donation->data['fundraiser_sustainers_series_status'])
     && $donation->data['fundraiser_sustainers_series_status'] == FUNDRAISER_SUSTAINERS_SERIES_STATUS_PENDING
   ) {
     drupal_set_message(t('The recurring donation schedule for this series will be created soon.'), 'warning');
+
+    // Update the no remaining message to reflect that the series hasn't been created.
+    $no_remaining_message = t('You can manage this recurring donation when the complete schedule has been created. Please check back soon.');
   }
 
   // Grab the next to be charged for misc info.
@@ -1477,7 +1483,7 @@ function fundraiser_sustainers_edit_form($did) {
     }
   }
   elseif ($remaining_donation_count == 0) {
-    $donation_amount_form = t('There are no further charges for this recurring donation.');
+    $donation_amount_form = $no_remaining_message;
     $donation_date_form = '';
   }
   else {
@@ -1490,7 +1496,7 @@ function fundraiser_sustainers_edit_form($did) {
     $billing_update_form = drupal_render($billing_update_form_array);
   }
   elseif ($remaining_donation_count == 0) {
-    $billing_update_form = t('There are no further charges for this recurring donation.');
+    $billing_update_form = $no_remaining_message;
   }
   else {
     $billing_update_form = t('This recurring donation has been cancelled.');
@@ -1502,7 +1508,7 @@ function fundraiser_sustainers_edit_form($did) {
     $cancel_form = drupal_render($cancel_form_array);
   }
   elseif ($remaining_donation_count == 0) {
-    $cancel_form = t('There are no further charges for this recurring donation.');
+    $cancel_form = $no_remaining_message;
   }
   else {
     $cancel_form = t('This recurring donation has been cancelled. Your reason given was: %reason', array('%reason' => $cancelled));

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -17,6 +17,17 @@ define('FUNDRAISER_SUSTAINERS_FAILED_STATUS', 'failed');
 define('FUNDRAISER_SUSTAINERS_SUCCESS_STATUS', 'success');
 
 /**
+ * Status for a master donation where sustainer series is pending creation.
+ */
+define('FUNDRAISER_SUSTAINERS_SERIES_STATUS_PENDING', 'pending');
+
+/**
+ * Status for a master donation where sustainer series has completed creation.
+ */
+define('FUNDRAISER_SUSTAINERS_SERIES_STATUS_COMPLETE', 'complete');
+
+
+/**
  * Implements hook_cron().
  */
 function fundraiser_sustainers_cron() {
@@ -1316,6 +1327,14 @@ function fundraiser_sustainers_edit_form($did) {
     return t('You do not have access to this recurring donation.');
   }
 
+  // If the series creation is pending let the user know.
+  if (
+    !empty($donation->data['fundraiser_sustainers_series_status'])
+    && $donation->data['fundraiser_sustainers_series_status'] == FUNDRAISER_SUSTAINERS_SERIES_STATUS_PENDING
+  ) {
+    drupal_set_message(t('The recurring donation schedule for this series will be created soon.'), 'warning');
+  }
+
   // Grab the next to be charged for misc info.
   $remaining = _fundraiser_sustainers_get_donations_recurr_remaining($donation->did);
   $next_donation = $donation;
@@ -2410,6 +2429,8 @@ function fundraiser_sustainers_fundraiser_donation_success($donation) {
 
                 $queue->createItem($item);
 
+                // Set a flag on the donation data array and log the pending creation.
+                $donation->data['fundraiser_sustainers_series_status'] = FUNDRAISER_SUSTAINERS_SERIES_STATUS_PENDING;
                 watchdog('fundraiser_sustainers', 'Master recurring donation @did has been queued for later series creation.', array('@did' => $donation->did));
               }
               // Else, create the series now.
@@ -2417,6 +2438,7 @@ function fundraiser_sustainers_fundraiser_donation_success($donation) {
                 $expires = $expiration_func($donation->donation, $info);
                 if (isset($expires['month']) && isset($expires['year'])) {
                  _fundraiser_sustainers_create_future_orders($donation, $expires['month'], $expires['year']);
+                 $donation->data['fundraiser_sustainers_series_status'] = FUNDRAISER_SUSTAINERS_SERIES_STATUS_COMPLETE;
                 }
               }
             }
@@ -2554,7 +2576,10 @@ function _fundraiser_sustainers_create_series_queue_worker($item) {
   if (isset($expires['month']) && isset($expires['year'])) {
     _fundraiser_sustainers_create_future_orders($donation, $expires['month'], $expires['year']);
 
+    // Flag the creation process complete and log.
+    $donation->data['fundraiser_sustainers_series_status'] = FUNDRAISER_SUSTAINERS_SERIES_STATUS_COMPLETE;
     watchdog('fundraiser_sustainers', 'The recurring series for master donation @did has been created.', array('@did' => $donation->did));
+    fundraiser_donation_update($donation);
   }
 }
 

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -92,6 +92,18 @@ function fundraiser_sustainers_views_api() {
 }
 
 /**
+ * Implements hook_cron_queue_info().
+ */
+function fundraiser_sustainers_cron_queue_info() {
+  // Queue worker to create recurring series.
+  $queues['fundraiser_sustainers_create_series'] = array(
+    'worker callback' => '_fundraiser_sustainers_create_series_queue_worker',
+  );
+
+  return $queues;
+}
+
+/**
  * Implements hook_menu().
  */
 function fundraiser_sustainers_menu() {
@@ -1204,11 +1216,20 @@ function fundraiser_sustainers_form_fundraiser_admin_settings_alter(&$form, &$fo
   );
   $form['fundraiser_sustainers']['fundraiser_cron']['fundraiser_standalone_cron_enabled'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Enable standalone cron.'),
-    '#description' => t('If this option is enabled all fundraiser related cron tasks will be removed from the ' .
-      'standard cron run. These tasks will need to be cronned separately via sitename/fundraiser_cron'),
-    '#default_value' => variable_get('fundraiser_standalone_cron_enabled', 0),
+    '#title' => t('Sustainer processing on standalone cron.'),
+    '#description' => t('If this option is enabled the payment processing for recurring donations will removed from the ' .
+      'standard cron run. This task will need to be cronned separately via sitename/fundraiser_cron'),
+     '#default_value' => variable_get('fundraiser_standalone_cron_enabled', 0),
+   );
+
+  // Create series on cron option.
+  $form['fundraiser_sustainers']['fundraiser_cron']['fundraiser_sustainers_create_series_cron'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Create the recurring series on cron.'),
+    '#description' => t("Enable this option to create the recurring series using Drupal's cron queue."),
+    '#default_value' => variable_get('fundraiser_sustainers_create_series_cron', 0),
   );
+
   // CC expiration message to send when sustainer donation is almost out.
   $form['fundraiser_sustainers']['fundraiser_cc_expiration_message'] = array(
     '#type' => 'fieldset',
@@ -2377,9 +2398,26 @@ function fundraiser_sustainers_fundraiser_donation_success($donation) {
           if (isset($info['expire callback'])) {
             $expiration_func = $info['expire callback'];
             if (function_exists($expiration_func)) {
-              $expires = $expiration_func($donation->donation, $info);
-              if (isset($expires['month']) && isset($expires['year'])) {
-                _fundraiser_sustainers_create_future_orders($donation, $expires['month'], $expires['year']);
+              // The future orders can be created now or later on cron.
+              if (variable_get('fundraiser_sustainers_create_series_cron', 0)) {
+                // Load the queue.
+                $queue = DrupalQueue::get('fundraiser_sustainers_create_series');
+
+                // The queue item is a simple array with the master donation did.
+                $item = array(
+                  'did' => $donation->did,
+                );
+
+                $queue->createItem($item);
+
+                watchdog('fundraiser_sustainers', 'Master recurring donation @did has been queued for later series creation.', array('@did' => $donation->did));
+              }
+              // Else, create the series now.
+              else {
+                $expires = $expiration_func($donation->donation, $info);
+                if (isset($expires['month']) && isset($expires['year'])) {
+                 _fundraiser_sustainers_create_future_orders($donation, $expires['month'], $expires['year']);
+                }
               }
             }
           }
@@ -2499,6 +2537,25 @@ function fundraiser_sustainers_fundraiser_donation_cancel($donation) {
   );
   _fundraiser_sustainers_update_recurring($recurring);
 
+}
+
+/**
+ * Cron queue worker callback.
+ *
+ * Creates the sustainer series during cron.
+ */
+function _fundraiser_sustainers_create_series_queue_worker($item) {
+  // Load the donation.
+  $donation = fundraiser_donation_get_donation($item['did']);
+
+  // Ensure we have the expiration dates and create the series.
+  $expiration_func = $donation->gateway['expire callback'];
+  $expires = $expiration_func($donation->donation, $donation->gateway);
+  if (isset($expires['month']) && isset($expires['year'])) {
+    _fundraiser_sustainers_create_future_orders($donation, $expires['month'], $expires['year']);
+
+    watchdog('fundraiser_sustainers', 'The recurring series for master donation @did has been created.', array('@did' => $donation->did));
+  }
 }
 
 /**

--- a/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers_delayed_creation.test
+++ b/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers_delayed_creation.test
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * @file
+ * Tests for creating a sustainer series on cron instead of immediately.
+ */
+
+class FundraiserSustainersDelayedCreationTestCase extends FundraiserSetup {
+
+  /**
+   * The donation form node.
+   *
+   * @var stdClass
+   */
+  protected $node;
+
+  /**
+   * The expiration date to use for the credit card.
+   *
+   * @var DateTime
+   */
+  protected $expiration;
+
+  /**
+   * The expected number of donations to exist in the created series.
+   *
+   * @var int
+   */
+  protected $expectedSeriesCount;
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Fundraiser Sustainers Delayed Series Creation',
+      'description' => 'Test the creation of the sustainer series on cron.',
+      'group' => 'Fundraiser Sustainers',
+    );
+  }
+
+  public function setUp($additional_modules = array()) {
+    $modules = array(
+      'fundraiser_sustainers',
+      'fundraiser_commerce',
+      'encrypt',
+    );
+    parent::setUp(array_merge($modules, $additional_modules));
+    $this->node = $this->createDonationForm();
+    $this->expectedSeriesCount = 11;
+    $this->expiration = new DateTime('now +10 months');
+  }
+
+  /**
+   * Test the immediate creation of a sustainer series.
+   */
+  public function testImmediateCreation() {
+    // Disable sustainer craation via cron.
+    variable_set('fundraiser_sustainers_create_series_cron', 0);
+
+    // Submit a donation form with recurring == true.
+    $this->submitRecurringDonationForm($this->node->nid, $this->expiration);
+
+    $master_did = $this->getMaxMasterDonationId();
+
+    // Assert that the correct number of donations was created.
+    $this->assertEqual(fundraiser_sustainers_count_donations_in_series($master_did), $this->expectedSeriesCount, $this->expectedSeriesCount . ' sustainers were created.');
+
+    // Assert that the master donation has the series complete flag.
+    // @todo This isn't working for me.
+    // $master_donation = fundraiser_donation_get_donation($master_did);
+    // $this->assertEqual($master_donation->data['fundraiser_sustainers_series_status'], FUNDRAISER_SUSTAINERS_SERIES_STATUS_COMPLETE, 'Master donation has a complete series status.');
+
+    // Assert that the queue is empty.
+    $queue = DrupalQueue::get('fundraiser_sustainers_create_series');
+    $this->assertEqual($queue->numberOfItems(), 0, 'Sustainer series queue is empty.');
+
+    // @todo Visit the edit page, assert the pending message does not appear.
+
+    // Run cron.
+    $this->cronRun();
+
+    // Assert that the same number of donations in the series exists.
+    $this->assertEqual(fundraiser_sustainers_count_donations_in_series($master_did), $this->expectedSeriesCount, 'Number of sustainer in series is still correct.');
+
+    // Assert that the master donation series flag is still correct.
+    // @todo This isn't working for me.
+    // $master_donation = fundraiser_donation_get_donation($master_did);
+    // $this->assertEqual($master_donation->data['fundraiser_sustainers_series_status'], FUNDRAISER_SUSTAINERS_SERIES_STATUS_COMPLETE, 'Master donation has a complete series status.');
+
+    // @todo Visit the edit page, assert that the pending message does not appear.
+
+    // Assert that the queue is still empty.
+    $queue = DrupalQueue::get('fundraiser_sustainers_create_series');
+    $this->assertEqual($queue->numberOfItems(), 0, 'Sustainer series queue is empty.');
+  }
+
+  /**
+   * Test the delayed creation of a sustainer series.
+   */
+  public function testDelayedCreation() {
+    // Enable sustainer creation via cron.
+    variable_set('fundraiser_sustainers_create_series_cron', 1);
+
+    // Submit a donation form with recurring == true.
+    $this->submitRecurringDonationForm($this->node->nid, $this->expiration);
+
+    $master_did = $this->getMaxMasterDonationId();
+
+    // Assert that one donation/order was created.
+    $this->assertEqual(fundraiser_sustainers_count_donations_in_series($master_did), 1, 'Only one sustainer was created.');
+
+    // Assert that that donation has the pending create flag.
+    // @todo This isn't working for me.
+    // $master_donation = fundraiser_donation_get_donation($master_did);
+    // $this->assertEqual($master_donation->data['fundraiser_sustainers_series_status'], FUNDRAISER_SUSTAINERS_SERIES_STATUS_PENDING, 'Master donation has a complete series status.');
+
+    // Assert that the queue includes that donation did.
+    $queue = DrupalQueue::get('fundraiser_sustainers_create_series');
+    $this->assertEqual($queue->numberOfItems(), 1, 'Sustainer series queue has one donation ID.');
+    $item = $queue->claimItem();
+    // Assert item data has the master did.
+    $this->assertEqual($item->data['did'], $master_did, 'The donation ID in the queue matches the master donation ID.');
+    $queue->releaseItem($item);
+
+    // @todo Visit the edit page. assert the pending message exists.
+
+    // Run cron.
+    $this->cronRun();
+
+    // Assert that the right number of donation/orders is created.
+    $this->assertEqual(fundraiser_sustainers_count_donations_in_series($master_did), $this->expectedSeriesCount, $this->expectedSeriesCount . ' sustainers now exist in the series.');
+
+    // Assert that the master donation has the complete creater flag.
+    // @todo This isn't working for me.
+    // $master_donation = fundraiser_donation_get_donation($master_did);
+    // $this->assertEqual($master_donation->data['fundraiser_sustainers_series_status'], FUNDRAISER_SUSTAINERS_SERIES_STATUS_COMPLETE, 'Master donation has a complete series status.');
+
+    // Assert that the queue is empty.
+    $queue = DrupalQueue::get('fundraiser_sustainers_create_series');
+    $this->assertEqual($queue->numberOfItems(), 0, 'Sustainer series queue is empty.');
+
+    // @todo Visit the edit page, assert the pending message doesn't appear.
+
+  }
+
+  /**
+   * Fill out a donation form to create a recurring donation series.
+   *
+   * @param int $nid
+   *   Node ID of the donation form.
+   * @param DateTime $expiration
+   *   The expiration date.
+   */
+  protected function submitRecurringDonationForm($nid, DateTime $expiration) {
+    $post_config = array(
+      'submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_month]' => $expiration->format('n'),
+      'submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_year]' => $expiration->format('Y'),
+      'submitted[payment_information][recurs_monthly][recurs]' => 'recurs',
+    );
+    $this->submitDonation($nid, $post_config);
+  }
+
+  /**
+   * Get the highest master donation ID.
+   *
+   * @return int|bool
+   *   The donation ID of the most recent master donation created.
+   */
+  protected function getMaxMasterDonationId() {
+    return db_query("SELECT MAX(master_did) FROM {fundraiser_sustainers}")->fetchField();
+  }
+
+}


### PR DESCRIPTION
This adds a queue worker for creating the sustainer series on cron.

Also, there's an add admin setting for control over the cron options so an admin could choose to continue creating the series on donation submit.