### PR TITLE
Remove Salesforce Modules Requirement From SB Social

### DIFF
--- a/springboard_social/includes/sb_social.db.inc
+++ b/springboard_social/includes/sb_social.db.inc
@@ -589,15 +589,17 @@ function sb_social_update_sf_share_id($item, $record) {
  *   Returns the current sfid or 0 if none found.
  */
 function _sb_social_get_opportunity_id_from_submission_id($sid) {
-  $result = db_query('
-    SELECT
-      s.sfid
-    FROM {salesforce_sync_map} s
-    INNER JOIN {fundraiser_donation} f
-      ON f.did = s.drupal_id
-    WHERE f.sid = :sid', array(':sid' => $sid));
-  $sfid = $result->fetchField();
-  return $sfid ? $sfid : 0;
+  if (module_exists('salesforce_sync')) {
+    $result = db_query('
+      SELECT
+        s.sfid
+      FROM {salesforce_sync_map} s
+      INNER JOIN {fundraiser_donation} f
+        ON f.did = s.drupal_id
+      WHERE f.sid = :sid', array(':sid' => $sid));
+    $sfid = $result->fetchField();
+  }
+  return !empty($sfid) ? $sfid : 0;
 }
 
 /**

--- a/springboard_social/sb_social.info
+++ b/springboard_social/sb_social.info
@@ -9,8 +9,6 @@ dependencies[] = shorten
 dependencies[] = fundraiser
 dependencies[] = fundraiser_webform
 dependencies[] = market_source
-dependencies[] = salesforce_queue
-dependencies[] = salesforce_genmap
 
 files[] = tests/sb_social.test
 

--- a/springboard_social/sb_social.info
+++ b/springboard_social/sb_social.info
@@ -2,7 +2,7 @@ name = Springboard Social
 description = Integrates Springboard petitions and donation forms with the AddThis social sharing service.
 package = Jackson River Springboard - extras
 core = 7.x
-version = 7.x-4.x-social-actions-rebase
+version = 7.x-4.x
 configure = admin/config/services/springboard_social
 
 dependencies[] = shorten


### PR DESCRIPTION
This removes the salesforce modules listed as dependencies in sb_social.info, and wraps the one place where a dependency exists with a module_exists().