### PR TITLE
Missing Index Error On Paypal WPS Only Forms

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -1090,7 +1090,7 @@ function fundraiser_commerce_fundraiser_donation_create($donation) {
     $method_instance = _fundraiser_gateway_info($info['id']);
   }
 
-  $scrubbed_fields = $donation->donation['payment_fields'];
+  $scrubbed_fields = isset($donation->donation['payment_fields']) ? $donation->donation['payment_fields'] : array();
   if (isset($method_instance['scrub callback']) && function_exists($method_instance['scrub callback'])) {
     $callback = $method_instance['scrub callback'];
     $scrubbed_fields = $callback($scrubbed_fields, $donation->donation['payment_method']);
@@ -1714,7 +1714,7 @@ function fundraiser_commerce_fundraiser_donation_update($donation) {
     }
 
     // Allow the gateways to scrub the data before saving
-    $scrubbed_fields = $donation->donation['payment_fields'];
+    $scrubbed_fields = isset($donation->donation['payment_fields']) ? $donation->donation['payment_fields'] : array();
     if (isset($donation->gateway['scrub callback']) && function_exists($donation->gateway['scrub callback'])) {
       $scrubbed_fields = $donation->gateway['scrub callback']($scrubbed_fields, $donation->donation['payment_method']);
     }


### PR DESCRIPTION
The Paypal WPS payment gateway does not pass any payment fields data. This code in commerce was expecting it with each donation.

This sets the $scrubbed_fields variable to an empty array if the payment_fields array does not exist.