### PR TITLE
Sustainer Processing Improvements

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.info
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.info
@@ -29,3 +29,4 @@ files[] = includes/FundraiserSustainersInsights.php
 files[] = tests/fundraiser_sustainers.test
 files[] = tests/fundraiser_sustainers_health_checks.test
 files[] = tests/fundraiser_sustainers_insights.test
+files[] = tests/fundraiser_sustainers_processing_exception_handling.test

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.info
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.info
@@ -9,6 +9,7 @@ dependencies[] = entity
 dependencies[] = rules
 dependencies[] = date
 dependencies[] = views
+dependencies[] = views_bulk_operations
 dependencies[] = commerce
 
 files[] = includes/FundraiserSustainersHealthChecks.php

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.info
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.info
@@ -27,6 +27,7 @@ files[] = includes/FundraiserSustainersHistoricalReport.php
 files[] = includes/FundraiserSustainersInsights.php
 
 ; Testing files
+files[] = tests/fundraiser_sustainers.setup.test
 files[] = tests/fundraiser_sustainers.test
 files[] = tests/fundraiser_sustainers_health_checks.test
 files[] = tests/fundraiser_sustainers_insights.test

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3235,30 +3235,40 @@ function fundraiser_sustainers_action_info() {
  *   The fundraiser_sustainer_record entity.
  */
 function fundraiser_sustainers_unlock_sustainer_action(&$sustainer_record, $context) {
-  $replacements = array('%did' => $sustainer_record->did);
+  $replacements = array(
+    '%did' => $sustainer_record->did,
+    '%status' => $sustainer_record->gateway_resp,
+    );
+
+  $log = fundraiser_sustainers_log();
 
   switch ($sustainer_record->gateway_resp) {
     case FUNDRAISER_SUSTAINERS_PROCESSING_STATUS:
-    case FUNDRAISER_SUSTAINERS_FAILED_STATUS:
-    case FUNDRAISER_SUSTAINERS_SKIPPED_STATUS:
-    case FUNDRAISER_SUSTAINERS_CANCELED_STATUS:
       $sustainer_record->lock_id = 0;
       $sustainer_record->gateway_resp = FUNDRAISER_SUSTAINERS_RETRY_STATUS;
-      drupal_set_message(t('Unlocked sustainer ID: %did and changed status to Retry.', $replacements));
-      break;
-
-    case FUNDRAISER_SUSTAINERS_SUCCESS_STATUS:
-      drupal_set_message(t('Cannot unlock a successful sustainer. ID: %did', $replacements));
+      $log->logUnlockedDonation($sustainer_record->did, $sustainer_record->gateway_resp);
+      drupal_set_message(t('Unlocked sustainer %did and changed its status from %status to Retry.', $replacements));
       break;
 
     case FUNDRAISER_SUSTAINERS_SCHEDULED_STATUS:
+      // Fall through.
     case FUNDRAISER_SUSTAINERS_RETRY_STATUS:
-    default:
       $sustainer_record->lock_id = 0;
-      drupal_set_message(t('Unlocked sustainer with ID: %did', $replacements));
+      $log->logUnlockedDonation($sustainer_record->did);
+      drupal_set_message(t('Unlocked sustainer %did and left its status at %status', $replacements));
+      break;
+
+    case FUNDRAISER_SUSTAINERS_SUCCESS_STATUS:
+      // Fall through.
+    case FUNDRAISER_SUSTAINERS_FAILED_STATUS:
+      // Fall through.
+    case FUNDRAISER_SUSTAINERS_SKIPPED_STATUS:
+      // Fall through.
+    case FUNDRAISER_SUSTAINERS_CANCELED_STATUS:
+      // Fall through.
+    default:
+      drupal_set_message(t('Cannot unlock the sustainer %did because its status is %status', $replacements));
       break;
   }
 
-  $log = fundraiser_sustainers_log();
-  $log->logUnlockedDonation($sustainer_record->did, $sustainer_record->gateway_resp);
 }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -728,7 +728,13 @@ function fundraiser_sustainers_process_recurring_donations() {
 
   // Loop over the found orders
   foreach ($donations as $recurring) {
-    fundraiser_sustainers_process_single_recurring_donation($log, $recurring, $sustainer_key);
+    try {
+
+      fundraiser_sustainers_process_single_recurring_donation($log, $recurring, $sustainer_key);
+    }
+    catch (Exception $e) {
+      fundraiser_sustainers_processing_exception($e, $recurring);
+    }
 
   }
   if ($log['successes'] > 0 || $log['fails'] > 0) {
@@ -776,13 +782,7 @@ function fundraiser_sustainers_process_single_recurring_donation(&$log, $recurri
     // Then go through each one of these to charge.
     // Since we already created the donation (and saved any CC info at that time).
     // All we need to do is process it and respond afterwards as needed.
-    try {
-      fundraiser_donation_process($donation);
-    }
-    catch (Exception $e) {
-      watchdog_exception('fundraiser_sustainers', $e);
-      $donation->result['success'] = FALSE;
-    }
+    fundraiser_donation_process($donation);
 
     if (!isset($donation->result['message'])) {
       $donation->result['message'] = '';
@@ -3183,4 +3183,10 @@ function fundraiser_sustainers_preprocess_html(&$vars) {
     $vars['classes_array'][] = 'insights-this-month';
   }
 
+}
+
+function fundraiser_sustainers_processing_exception(Exception $e, $sustainer) {
+  $message = 'Exception thrown while processing a sustainer. Sustainer ID: %did. %type: !message in %function (line %line of %file).';
+  $variables = array('%did' => $sustainer->did);
+  watchdog_exception('fundraiser_sustainers', $e, $message, $variables);
 }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3189,6 +3189,14 @@ function fundraiser_sustainers_preprocess_html(&$vars) {
 
 }
 
+/**
+ * Log an exception during sustainer processing to watchdog.
+ *
+ * @param \Exception $e
+ *   The exception that was thrown.
+ * @param stdClass $sustainer
+ *   Part of the sustainer record for additional logging.
+ */
 function fundraiser_sustainers_processing_exception(Exception $e, $sustainer) {
   $message = 'Exception thrown while processing a sustainer. Sustainer ID: %did. %type: !message in %function (line %line of %file).';
   $variables = array('%did' => $sustainer->did);
@@ -3211,99 +3219,46 @@ function fundraiser_sustainers_action_info() {
       'triggers' => array('any'),
       'permissions' => array('administrate recurring donations'),
     ),
-    'fundraiser_sustainers_change_gateway_response_action' => array(
-      'type' => 'fundraiser_sustainer_record',
-      'label' => t('Change gateway response'),
-      'behavior' => array('changes_property'),
-      'configurable' => TRUE,
-      'vbo_configurable' => FALSE,
-      'triggers' => array('any'),
-      'permissions' => array('administrate recurring donations'),
-    ),
   );
 }
 
 /**
  * The unlock sustainer action.
  *
+ * Note that I'm including all gateway_resp cases in case this action gets used
+ * in other situations besides the stuck sustainer VBO.
+ *
+ * Also note that drupal saves the sustainer record entity on its own so that's
+ * why it's not happening here.
+ *
  * @param Entity $sustainer_record
  *   The fundraiser_sustainer_record entity.
  */
 function fundraiser_sustainers_unlock_sustainer_action(&$sustainer_record, $context) {
-  $sustainer_record->lock_id = 0;
+  $replacements = array('%did' => $sustainer_record->did);
 
-  $log = fundraiser_sustainers_log();
-  $log->logUnlockedDonation($sustainer_record->did);
-}
+  switch ($sustainer_record->gateway_resp) {
+    case FUNDRAISER_SUSTAINERS_PROCESSING_STATUS:
+    case FUNDRAISER_SUSTAINERS_FAILED_STATUS:
+    case FUNDRAISER_SUSTAINERS_SKIPPED_STATUS:
+    case FUNDRAISER_SUSTAINERS_CANCELED_STATUS:
+      $sustainer_record->lock_id = 0;
+      $sustainer_record->gateway_resp = FUNDRAISER_SUSTAINERS_RETRY_STATUS;
+      drupal_set_message(t('Unlocked sustainer ID: %did and changed status to Retry.', $replacements));
+      break;
 
-/**
- * Configuration form for the change gateway response action.
- *
- * @param array $context
- *   The context passed to the configure form.
- *
- * @return array
- *   Forms api array.
- */
-function fundraiser_sustainers_change_gateway_response_action_form($context) {
-  $form = array();
+    case FUNDRAISER_SUSTAINERS_SUCCESS_STATUS:
+      drupal_set_message(t('Cannot unlock a successful sustainer. ID: %did', $replacements));
+      break;
 
-  $default = FUNDRAISER_SUSTAINERS_PROCESSING_STATUS;
-  if (isset($context['new_gateway_response'])) {
-    $default = $context['new_gateway_response'];
+    case FUNDRAISER_SUSTAINERS_SCHEDULED_STATUS:
+    case FUNDRAISER_SUSTAINERS_RETRY_STATUS:
+    default:
+      $sustainer_record->lock_id = 0;
+      drupal_set_message(t('Unlocked sustainer with ID: %did', $replacements));
+      break;
   }
 
-  $form['new_gateway_response'] = array(
-    '#type' => 'select',
-    '#title' => t('New gateway response'),
-    '#description' => t('Choose a new gateway response.'),
-    '#options' => fundraiser_sustainers_status_options(),
-    '#default_value' => $default,
-  );
-
-  return $form;
-}
-
-/**
- * Submit handler for the configure form for the change gateway response action.
- *
- * @return array
- *   The array for the context.
- */
-function fundraiser_sustainers_change_gateway_response_action_submit($form, $form_state) {
-  return array('new_gateway_response' => $form_state['values']['new_gateway_response']);
-}
-
-/**
- * The change gateway response action.
- *
- * @param Entity $sustainer_record
- *   The sustainer record to modify.
- * @param array $context
- *   The context from the configure form submit.
- */
-function fundraiser_sustainers_change_gateway_response_action(&$sustainer_record, $context) {
-  $sustainer_record->gateway_resp = $context['new_gateway_response'];
-
   $log = fundraiser_sustainers_log();
-  $log->log(array('did' => $sustainer_record->did, 'gateway_resp' => $context['new_gateway_response']));
-}
-
-/**
- * Get a list of sustainer gateway response options for use in a form array.
- *
- * @return array
- *   The keyed array of sustainer status options.
- */
-function fundraiser_sustainers_status_options() {
-
-  return array(
-    FUNDRAISER_SUSTAINERS_PROCESSING_STATUS => 'Processing',
-    FUNDRAISER_SUSTAINERS_RETRY_STATUS => 'Retry',
-    FUNDRAISER_SUSTAINERS_FAILED_STATUS => 'Failed',
-    FUNDRAISER_SUSTAINERS_SUCCESS_STATUS => 'Success',
-    FUNDRAISER_SUSTAINERS_SKIPPED_STATUS => 'Skipped',
-    FUNDRAISER_SUSTAINERS_CANCELED_STATUS => 'Canceled',
-    FUNDRAISER_SUSTAINERS_SCHEDULED_STATUS => 'Scheduled',
-  );
+  $log->logUnlockedDonation($sustainer_record->did, $sustainer_record->gateway_resp);
 }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -776,7 +776,14 @@ function fundraiser_sustainers_process_single_recurring_donation(&$log, $recurri
     // Then go through each one of these to charge.
     // Since we already created the donation (and saved any CC info at that time).
     // All we need to do is process it and respond afterwards as needed.
-    fundraiser_donation_process($donation);
+    try {
+      fundraiser_donation_process($donation);
+    }
+    catch (Exception $e) {
+      watchdog_exception('fundraiser_sustainers', $e);
+      $donation->result['success'] = FALSE;
+    }
+
     if (!isset($donation->result['message'])) {
       $donation->result['message'] = '';
     }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3190,3 +3190,36 @@ function fundraiser_sustainers_processing_exception(Exception $e, $sustainer) {
   $variables = array('%did' => $sustainer->did);
   watchdog_exception('fundraiser_sustainers', $e, $message, $variables);
 }
+
+/**
+ * Implements hook_action_info().
+ *
+ * Add the unlock sustainer action for VBO.
+ */
+function fundraiser_sustainers_action_info() {
+  return array(
+    'fundraiser_sustainers_unlock_sustainer_action' => array(
+      'type' => 'fundraiser_sustainer_record',
+      'label' => t('Unlock sustainer'),
+      'behavior' => array('changes_property'),
+      'configurable' => FALSE,
+      'vbo_configurable' => FALSE,
+      'triggers' => array('any'),
+      'permissions' => array('administrate recurring donations'),
+    ),
+  );
+}
+
+/**
+ * The unlock sustainer action.
+ *
+ * @param Entity $sustainer_record
+ *   The fundraiser_sustainer_record entity.
+ */
+function fundraiser_sustainers_unlock_sustainer_action(&$sustainer_record, $context) {
+  $sustainer_record->lock_id = 0;
+  $sustainer_record->save();
+
+  $log = fundraiser_sustainers_log();
+  $log->logUnlockedDonation($sustainer_record->did);
+}

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -16,6 +16,10 @@ define('FUNDRAISER_SUSTAINERS_RETRY_STATUS', 'retry');
 define('FUNDRAISER_SUSTAINERS_FAILED_STATUS', 'failed');
 define('FUNDRAISER_SUSTAINERS_SUCCESS_STATUS', 'success');
 
+define('FUNDRAISER_SUSTAINERS_SKIPPED_STATUS', 'skipped');
+define('FUNDRAISER_SUSTAINERS_CANCELED_STATUS', 'canceled');
+define('FUNDRAISER_SUSTAINERS_SCHEDULED_STATUS', 'scheduled');
+
 /**
  * Implements hook_cron().
  */
@@ -3207,6 +3211,15 @@ function fundraiser_sustainers_action_info() {
       'triggers' => array('any'),
       'permissions' => array('administrate recurring donations'),
     ),
+    'fundraiser_sustainers_change_gateway_response_action' => array(
+      'type' => 'fundraiser_sustainer_record',
+      'label' => t('Change gateway response'),
+      'behavior' => array('changes_property'),
+      'configurable' => TRUE,
+      'vbo_configurable' => FALSE,
+      'triggers' => array('any'),
+      'permissions' => array('administrate recurring donations'),
+    ),
   );
 }
 
@@ -3218,8 +3231,79 @@ function fundraiser_sustainers_action_info() {
  */
 function fundraiser_sustainers_unlock_sustainer_action(&$sustainer_record, $context) {
   $sustainer_record->lock_id = 0;
-  $sustainer_record->save();
 
   $log = fundraiser_sustainers_log();
   $log->logUnlockedDonation($sustainer_record->did);
+}
+
+/**
+ * Configuration form for the change gateway response action.
+ *
+ * @param array $context
+ *   The context passed to the configure form.
+ *
+ * @return array
+ *   Forms api array.
+ */
+function fundraiser_sustainers_change_gateway_response_action_form($context) {
+  $form = array();
+
+  $default = FUNDRAISER_SUSTAINERS_PROCESSING_STATUS;
+  if (isset($context['new_gateway_response'])) {
+    $default = $context['new_gateway_response'];
+  }
+
+  $form['new_gateway_response'] = array(
+    '#type' => 'select',
+    '#title' => t('New gateway response'),
+    '#description' => t('Choose a new gateway response.'),
+    '#options' => fundraiser_sustainers_status_options(),
+    '#default_value' => $default,
+  );
+
+  return $form;
+}
+
+/**
+ * Submit handler for the configure form for the change gateway response action.
+ *
+ * @return array
+ *   The array for the context.
+ */
+function fundraiser_sustainers_change_gateway_response_action_submit($form, $form_state) {
+  return array('new_gateway_response' => $form_state['values']['new_gateway_response']);
+}
+
+/**
+ * The change gateway response action.
+ *
+ * @param Entity $sustainer_record
+ *   The sustainer record to modify.
+ * @param array $context
+ *   The context from the configure form submit.
+ */
+function fundraiser_sustainers_change_gateway_response_action(&$sustainer_record, $context) {
+  $sustainer_record->gateway_resp = $context['new_gateway_response'];
+
+  $log = fundraiser_sustainers_log();
+  $log->log(array('did' => $sustainer_record->did, 'gateway_resp' => $context['new_gateway_response']));
+}
+
+/**
+ * Get a list of sustainer gateway response options for use in a form array.
+ *
+ * @return array
+ *   The keyed array of sustainer status options.
+ */
+function fundraiser_sustainers_status_options() {
+
+  return array(
+    FUNDRAISER_SUSTAINERS_PROCESSING_STATUS => 'Processing',
+    FUNDRAISER_SUSTAINERS_RETRY_STATUS => 'Retry',
+    FUNDRAISER_SUSTAINERS_FAILED_STATUS => 'Failed',
+    FUNDRAISER_SUSTAINERS_SUCCESS_STATUS => 'Success',
+    FUNDRAISER_SUSTAINERS_SKIPPED_STATUS => 'Skipped',
+    FUNDRAISER_SUSTAINERS_CANCELED_STATUS => 'Canceled',
+    FUNDRAISER_SUSTAINERS_SCHEDULED_STATUS => 'Scheduled',
+  );
 }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3250,6 +3250,9 @@ function fundraiser_sustainers_unlock_sustainer_action(&$sustainer_record, $cont
       drupal_set_message(t('Unlocked sustainer %did and changed its status from %status to Retry.', $replacements));
       break;
 
+    // Include support for the NULL value, default value of gateway_resp.
+    case NULL:
+      $replacements['%status'] = FUNDRAISER_SUSTAINERS_SCHEDULED_STATUS;
     case FUNDRAISER_SUSTAINERS_SCHEDULED_STATUS:
       // Fall through.
     case FUNDRAISER_SUSTAINERS_RETRY_STATUS:

--- a/fundraiser/modules/fundraiser_sustainers/includes/FundraiserSustainersLog.php
+++ b/fundraiser/modules/fundraiser_sustainers/includes/FundraiserSustainersLog.php
@@ -105,13 +105,40 @@ class FundraiserSustainersLog {
    */
   public function logLockedDonations(array $dids, $lock_id) {
     foreach ($dids as $did) {
+      $this->logLockedDonation($did, $lock_id);
+    }
+  }
+
+  /**
+   * Log that a donation has been locked for processing.
+   *
+   * @param int $did
+   *   The donation ID to log as locked.
+   * @param string $lock_id
+   *   The new lock ID.
+   */
+  public function logLockedDonation($did, $lock_id) {
       $locked_log_record = array(
         'did' => $did,
         'new_state' => 'locked',
         'lock_id' => $lock_id,
       );
       $this->log($locked_log_record);
-    }
+  }
+
+  /**
+   * Log that a sustainer has been unlocked.
+   *
+   * @param int $did
+   *   The donation ID to log as unlocked.
+   */
+  public function logUnlockedDonation($did) {
+    $log_record = array(
+      'did' => $did,
+      'new_state' => 'unlocked',
+      'lock_id' => 0,
+    );
+    $this->log($log_record);
   }
 
   /**

--- a/fundraiser/modules/fundraiser_sustainers/includes/FundraiserSustainersLog.php
+++ b/fundraiser/modules/fundraiser_sustainers/includes/FundraiserSustainersLog.php
@@ -132,12 +132,16 @@ class FundraiserSustainersLog {
    * @param int $did
    *   The donation ID to log as unlocked.
    */
-  public function logUnlockedDonation($did) {
+  public function logUnlockedDonation($did, $new_state = NULL) {
     $log_record = array(
       'did' => $did,
-      'new_state' => 'unlocked',
       'lock_id' => 0,
     );
+
+    if (!is_null($new_state)) {
+      $log_record['new_state'] = $new_state;
+    }
+
     $this->log($log_record);
   }
 

--- a/fundraiser/modules/fundraiser_sustainers/includes/fundraiser_sustainers.views_default.inc
+++ b/fundraiser/modules/fundraiser_sustainers/includes/fundraiser_sustainers.views_default.inc
@@ -483,6 +483,68 @@ function fundraiser_sustainers_views_default_views() {
   $handler->display->display_options['empty']['area']['empty'] = TRUE;
   $handler->display->display_options['empty']['area']['content'] = 'No sustainers were found that require attention.';
   $handler->display->display_options['empty']['area']['format'] = 'filtered_html';
+  /* Field: Bulk operations: Fundraiser sustainer record */
+  $handler->display->display_options['fields']['views_bulk_operations']['id'] = 'views_bulk_operations';
+  $handler->display->display_options['fields']['views_bulk_operations']['table'] = 'fundraiser_sustainers';
+  $handler->display->display_options['fields']['views_bulk_operations']['field'] = 'views_bulk_operations';
+  $handler->display->display_options['fields']['views_bulk_operations']['label'] = '';
+  $handler->display->display_options['fields']['views_bulk_operations']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['display_type'] = '0';
+  $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['enable_select_all_pages'] = 1;
+  $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['force_single'] = 0;
+  $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['entity_load_capacity'] = '10';
+  $handler->display->display_options['fields']['views_bulk_operations']['vbo_operations'] = array(
+    'action::views_bulk_operations_delete_item' => array(
+      'selected' => 0,
+      'postpone_processing' => 0,
+      'skip_confirmation' => 0,
+      'override_label' => 0,
+      'label' => '',
+    ),
+    'action::views_bulk_operations_script_action' => array(
+      'selected' => 0,
+      'postpone_processing' => 0,
+      'skip_confirmation' => 0,
+      'override_label' => 0,
+      'label' => '',
+    ),
+    'action::views_bulk_operations_modify_action' => array(
+      'selected' => 0,
+      'postpone_processing' => 0,
+      'skip_confirmation' => 0,
+      'override_label' => 0,
+      'label' => '',
+      'settings' => array(
+        'show_all_tokens' => 1,
+        'display_values' => array(
+          '_all_' => '_all_',
+        ),
+      ),
+    ),
+    'action::views_bulk_operations_argument_selector_action' => array(
+      'selected' => 0,
+      'skip_confirmation' => 0,
+      'override_label' => 0,
+      'label' => '',
+      'settings' => array(
+        'url' => '',
+      ),
+    ),
+    'action::system_send_email_action' => array(
+      'selected' => 0,
+      'postpone_processing' => 0,
+      'skip_confirmation' => 0,
+      'override_label' => 0,
+      'label' => '',
+    ),
+    'action::fundraiser_sustainers_unlock_sustainer_action' => array(
+      'selected' => 1,
+      'postpone_processing' => 0,
+      'skip_confirmation' => 0,
+      'override_label' => 0,
+      'label' => '',
+    ),
+  );
   /* Field: Fundraiser sustainer record: Master donation ID */
   $handler->display->display_options['fields']['master_did_1']['id'] = 'master_did_1';
   $handler->display->display_options['fields']['master_did_1']['table'] = 'fundraiser_sustainers';

--- a/fundraiser/modules/fundraiser_sustainers/includes/fundraiser_sustainers.views_default.inc
+++ b/fundraiser/modules/fundraiser_sustainers/includes/fundraiser_sustainers.views_default.inc
@@ -494,6 +494,13 @@ function fundraiser_sustainers_views_default_views() {
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['force_single'] = 0;
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['entity_load_capacity'] = '10';
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_operations'] = array(
+    'action::fundraiser_sustainers_change_gateway_response_action' => array(
+      'selected' => 1,
+      'postpone_processing' => 0,
+      'skip_confirmation' => 0,
+      'override_label' => 0,
+      'label' => '',
+    ),
     'action::views_bulk_operations_delete_item' => array(
       'selected' => 0,
       'postpone_processing' => 0,

--- a/fundraiser/modules/fundraiser_sustainers/includes/fundraiser_sustainers.views_default.inc
+++ b/fundraiser/modules/fundraiser_sustainers/includes/fundraiser_sustainers.views_default.inc
@@ -494,13 +494,6 @@ function fundraiser_sustainers_views_default_views() {
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['force_single'] = 0;
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['entity_load_capacity'] = '10';
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_operations'] = array(
-    'action::fundraiser_sustainers_change_gateway_response_action' => array(
-      'selected' => 1,
-      'postpone_processing' => 0,
-      'skip_confirmation' => 0,
-      'override_label' => 0,
-      'label' => '',
-    ),
     'action::views_bulk_operations_delete_item' => array(
       'selected' => 0,
       'postpone_processing' => 0,

--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_date_mode/fundraiser_date_mode.module
@@ -605,7 +605,14 @@ function fundraiser_date_mode_process_queue_item($item) {
       'successes' => 0,
       'fails' => 0,
     );
-    fundraiser_sustainers_process_single_recurring_donation($log, $recurring, $sustainer_key);
+
+    try {
+      fundraiser_sustainers_process_single_recurring_donation($log, $recurring, $sustainer_key);
+    }
+    catch (Exception $e) {
+      fundraiser_sustainers_processing_exception($e, $recurring);
+    }
+
     // If we get to here the transaction has been completed.
     watchdog('fundraiser_sustainers_date_mode', 'Sustainer order id !did has finished processing.', array('!did' => $recurring->did), WATCHDOG_NOTICE);
   }

--- a/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers.setup.test
+++ b/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers.setup.test
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @file
+ * Fundraiser sustainer module setup class for testing.
+ */
+
+/**
+ * Paren
+ */
+class FundraiserSustainerSetup extends FundraiserSetup {
+
+  /**
+   * Create a sustainer key file. Required for processing sustainers.
+   *
+   * @param $key_value NULL|bool|string
+   *   The value of the sustainer key file. Defaults to FALSE; which will
+   *   create a correct key. Passing values other than FALSE, or the
+   *   correct path, will create an incorrect key.
+   */
+  public function setSustainerKey($key_value = FALSE) {
+    // If $key_value is FALSE set it to the path.
+    if ($key_value === FALSE) {
+      $key_value = trim($_SERVER['HTTP_HOST']) . rtrim(base_path(), '/');
+    }
+
+    $file_path = variable_get('file_public_path', conf_path() . '/files');
+    variable_set('encrypt_secure_key_path', $file_path);
+
+    // Delete file if it already exists.
+    if (file_exists($file_path . '/sustainer.key')) {
+      unlink($file_path . '/sustainer.key');
+    }
+
+    // Write a new sustainer key file.
+    file_put_contents($file_path . '/sustainer.key', $key_value);
+  }
+
+  /**
+   * Helper to create a fundraiser sustainer donation.
+   */
+  public function createFundraiserSustainer() {
+    // Create a node.
+    $node = $this->createDonationForm();
+    // Post to the node.
+    $month = date('n', strtotime('+1 year'));
+    $year = date('Y', strtotime('+1 year'));
+    $post['submitted[payment_information][recurs_monthly][recurs]'] = 'recurs';
+    $post['submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_month]'] = $month;
+    $post['submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_year]'] = $year;
+    $post['submitted[donor_information][mail]'] = 'fundraiser_sustainer@example.com';
+    $this->submitDonation($node->nid, $post);
+  }
+
+  /**
+   * Helper function to create a series of recurring donations.
+   */
+  public function fundraiserSustainerCreateRecurringDonation($post_config = NULL) {
+    // Create a node.
+    $created_user = $this->createFundraiserUser();
+    $this->drupalLogin($created_user);
+    $node = $this->createDonationForm();
+    // Post to the node.
+    $month = date('n', strtotime('+1 year'));
+    $year = date('Y', strtotime('+1 year'));
+    $post['submitted[payment_information][recurs_monthly][recurs]'] = 'recurs';
+    $post['submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_month]'] = $month;
+    $post['submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_year]'] = $year;
+    $post['submitted[donor_information][mail]'] = $created_user->mail;
+
+    if (!empty($post_config)) {
+      $post = array_merge($post, (array) $post_config);
+    }
+
+    $this->submitDonation($node->nid, $post);
+    // Get the master did.
+    $donations = _fundraiser_get_donations();
+    $master_did = '';
+    foreach ($donations as $donation) {
+      $master_did = $donation->did;
+      break;
+    }
+    return $master_did;
+  }
+
+  /**
+   * Helper function to check how many sustainers were processed after cron is run.
+   */
+  public function fundraiserSustainerChargeCount($master_did) {
+    $query = db_select('fundraiser_sustainers', 'f')
+      ->fields('f')
+      ->condition('master_did', $master_did, '=')
+      ->condition('gateway_resp', 'success', '=')
+      ->condition('did', $master_did, '!='); // exclude first order in series
+    return $query->countQuery()->execute()->fetchField();
+  }
+}

--- a/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers.test
+++ b/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers.test
@@ -4,13 +4,10 @@
  * Fundraiser sustainer module web tests, test sustainers.
  */
 
-// Include the setup test class.
-module_load_include('test', 'fundraiser', 'tests/fundraiser.setup');
-
 /**
  * Setup and tear down web class. Does nothing else.
  */
-class FundraiserSustainerTest extends FundraiserSetup {
+class FundraiserSustainerTest extends FundraiserSustainerSetup {
 
   /**
    * Implements getInfo(). Declares this test class to fundraiser testing.
@@ -483,84 +480,6 @@ class FundraiserSustainerTest extends FundraiserSetup {
     $sustainers_processed = $this->fundraiserSustainerChargeCount($master_did);
     // Ensure no sustainers were actually processed.
     $this->assertEqual(1, $sustainers_processed, 'Number of sustainers processed is 1.');
-  }
-
-  /**
-   * Helper to create a fundraiser sustainer donation.
-   */
-  protected function createFundraiserSustainer() {
-    // Create a node.
-    $node = $this->createDonationForm();
-    // Post to the node.
-    $month = date('n', strtotime('+1 year'));
-    $year = date('Y', strtotime('+1 year'));
-    $post['submitted[payment_information][recurs_monthly][recurs]'] = 'recurs';
-    $post['submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_month]'] = $month;
-    $post['submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_year]'] = $year;
-    $post['submitted[donor_information][mail]'] = 'fundraiser_sustainer@example.com';
-    $this->submitDonation($node->nid, $post);
-  }
-
-  /**
-   * Helper function to create a series of recurring donations.
-   */
-  private function fundraiserSustainerCreateRecurringDonation($post_config = NULL) {
-    // Create a node.
-    $created_user = $this->createFundraiserUser();
-    $this->drupalLogin($created_user);
-    $node = $this->createDonationForm();
-    // Post to the node.
-    $month = date('n', strtotime('+1 year'));
-    $year = date('Y', strtotime('+1 year'));
-    $post['submitted[payment_information][recurs_monthly][recurs]'] = 'recurs';
-    $post['submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_month]'] = $month;
-    $post['submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_year]'] = $year;
-    $post['submitted[donor_information][mail]'] = $created_user->mail;
-
-    if (!empty($post_config)) {
-      $post = array_merge($post, (array) $post_config);
-    }
-
-    $this->submitDonation($node->nid, $post);
-    // Get the master did.
-    $donations = _fundraiser_get_donations();
-    $master_did = '';
-    foreach ($donations as $donation) {
-      $master_did = $donation->did;
-      break;
-    }
-    return $master_did;
-  }
-
-  /**
-   * Helper function to check how many sustainers were processed after cron is run.
-   */
-  private function fundraiserSustainerChargeCount($master_did) {
-    $query = db_select('fundraiser_sustainers', 'f')
-      ->fields('f')
-      ->condition('master_did', $master_did, '=')
-      ->condition('gateway_resp', 'success', '=')
-      ->condition('did', $master_did, '!='); // exclude first order in series
-    return $query->countQuery()->execute()->fetchField();
-  }
-
-  /**
-   * Helper function to create a sustainer key file.
-   *
-   * @param $key_value
-   *   The value of the sustainer key file.
-   */
-  private function setSustainerKey($key_value) {
-    $file_path = variable_get('file_public_path', conf_path() . '/files');
-    variable_set('encrypt_secure_key_path', $file_path);
-
-    // Delete file if it already exists.
-    if (file_exists($file_path . '/sustainer.key')) {
-      unlink($file_path . '/sustainer.key');
-    }
-
-    // Write a new sustainer key file.
-    file_put_contents($file_path . '/sustainer.key', $key_value);
   }
 
 }

--- a/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers_processing_exception_handling.test
+++ b/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers_processing_exception_handling.test
@@ -7,7 +7,7 @@
 /**
  *
  */
-class FundraiserSustainersProcessingExceptionHandlingTestCase extends FundraiserSetup {
+class FundraiserSustainersProcessingExceptionHandlingTestCase extends FundraiserSustainerSetup {
 
   /**
    * The donation form.
@@ -43,101 +43,81 @@ class FundraiserSustainersProcessingExceptionHandlingTestCase extends Fundraiser
 
     $this->node = $this->createDonationForm();
     $this->expiration = new DateTime('now +3 months');
+
+    $this->setSustainerKey();
   }
 
   /**
-   *
+   * Confirm donations process sequentially.
    */
-  public function testExceptionHandling() {
+  public function testExceptionHandlingSuccess() {
     $series = array();
 
     // For some reaosn I get a 403 when I first visit this, but a 200
     // all other times.
     $this->drupalGet('node/' . $this->node->nid);
 
-    for ($i = 0; $i < 1; $i++) {
+    // Create three series.
+    for ($i = 0; $i < 3; $i++) {
       $this->submitRecurringDonation($this->node->nid, $this->expiration);
       $master_did = $this->getMaxMasterDid();
+
+      // Advance each series.
+      $series[$i] = array(
+        'master_did' => $master_did,
+        'advance_did' => $this->advanceCharge($master_did),
+      );
+    }
+    // Add a slight pause here so that the charge date will be in the past.
+    sleep(1);
+    $this->cronRun();
+
+    // Confirm all processed.
+    foreach ($series as $thing) {
+      $this->assertDonationIsSuccessfullyProcessed($thing['advance_did']);
+    }
+  }
+
+  /**
+   * Confirm donations process sequentially even when a catchable failure occurs.
+   */
+  public function testExceptionHandlingFailure() {
+    $series = array();
+
+    // For some reaosn I get a 403 when I first visit this, but a 200
+    // all other times.
+    $this->drupalGet('node/' . $this->node->nid);
+
+    // Create three series.
+    for ($i = 0; $i < 3; $i++) {
+      $this->submitRecurringDonation($this->node->nid, $this->expiration);
+      $master_did = $this->getMaxMasterDid();
+
+      // Advance each series.
       $series[$i] = array(
         'master_did' => $master_did,
         'advance_did' => $this->advanceCharge($master_did),
       );
     }
 
-    $this->runFundraiserCron();
+    // Add a slight pause here so that the charge date will be in the past.
+    sleep(1);
 
-    $checks = new FundraiserSustainersHealthChecks();
-    $results = $checks->checkStuckSustainers();
-    $this->assertTrue(empty($results), 'No stuck sustainers found.');
+    // Delete the order on the second donation to force an exception.
+    commerce_order_delete($series[1]['advance_did']);
 
-    foreach ($series as $thing) {
-      $this->assertDonationIsSuccessfullyProcessed($thing['advance_did']);
-    }
+    $this->cronRun();
 
-    foreach ($series as $i => $thing) {
-      $series[$i]['advance_did'] = $this->advanceCharge($series[$i]['master_did']);
-    }
-
-//    debug($series);
-//    debug(_fundraiser_sustainers_cron_get_recurring());
-//    fundraiser_sustainers_process_recurring_donations();
-//    db_query("DELETE FROM {commerce_order} WHERE order_id = :did", array(':did' => $series[1]['advance_did']));
-
-//    debug(db_query("SELECT * FROM {fundraiser_sustainers}")->fetchAllAssoc('did'));
-
-
-
-    $limit = 200;
-    $now = strtotime('now');
-    $max_processing_attempts = variable_get('fundraiser_sustainers_max_processing_attempts', 3);
-    // Lock them (faster to lock, then query, than the other way around).
-    // Since large data set returns => delay.
-    $donations = db_query('SELECT r.did FROM {fundraiser_sustainers} r ' .
-      'WHERE (r.gateway_resp IS NULL OR r.gateway_resp = :status) ' .
-      'AND r.next_charge < :now ' .
-      'AND (r.attempts < :max_attempts OR r.attempts IS NULL) ' . // If already been tried X times, Stop Trying.
-      'AND r.lock_id = 0 ' . // And not locked.
-      'LIMIT 0, ' . $limit,
-      array(':status' => FUNDRAISER_SUSTAINERS_RETRY_STATUS, ':now' => $now, ':max_attempts' => $max_processing_attempts)
-    )->fetchAllKeyed(0, 0);
-    debug($donations);
-
-
-
-    $this->runFundraiserCron();
-
-
-
-    $limit = 200;
-    $now = strtotime('now');
-    $max_processing_attempts = variable_get('fundraiser_sustainers_max_processing_attempts', 3);
-    // Lock them (faster to lock, then query, than the other way around).
-    // Since large data set returns => delay.
-    $donations = db_query('SELECT r.did FROM {fundraiser_sustainers} r ' .
-      'WHERE (r.gateway_resp IS NULL OR r.gateway_resp = :status) ' .
-      'AND r.next_charge < :now ' .
-      'AND (r.attempts < :max_attempts OR r.attempts IS NULL) ' . // If already been tried X times, Stop Trying.
-      'AND r.lock_id = 0 ' . // And not locked.
-      'LIMIT 0, ' . $limit,
-      array(':status' => FUNDRAISER_SUSTAINERS_RETRY_STATUS, ':now' => $now, ':max_attempts' => $max_processing_attempts)
-    )->fetchAllKeyed(0, 0);
-    debug($donations);
-
-
-
+    // Assert the first and third processed.
     $this->assertDonationIsSuccessfullyProcessed($series[0]['advance_did']);
-//    $this->assertDonationIsNotSuccessfullyProcessed($series[1]['advance_did']);
-//    $this->assertDonationIsSuccessfullyProcessed($series[2]['advance_did']);
-//
-//    $this->assertWatchdogContains('Exception thrown while processing a sustainer');
-//
-//    $checks = new FundraiserSustainersHealthChecks();
-//    $results = $checks->checkStuckSustainers();
-//    $dids = explode(',', $results['variables']['%dids']);
-//    $this->assertEqual(count($dids), 1, 'One stuck sustainer found.');
-//    $this->assertEqual($dids[0], $series[1]['advance_did'], 'The correct donation ID is the stuck sustainer.');
+    $this->assertDonationIsSuccessfullyProcessed($series[2]['advance_did']);
 
-    debug(db_query("SELECT * FROM {fundraiser_sustainers}")->fetchAllAssoc('did'));
+    // Assert the second failed.
+    $this->assertDonationIsNotSuccessfullyProcessed($series[1]['advance_did']);
+
+    // Assert the watchdog message was entered.
+    $watchdog_message = 'Exception thrown while processing a sustainer. Sustainer ID: %did. %type: !message in %function (line %line of %file).';
+    $this->assertWatchdogMessage($watchdog_message, $series[1]['advance_did'], 'The correct watchdog message was logged.');
   }
 
   protected function getMaxMasterDid() {
@@ -145,15 +125,13 @@ class FundraiserSustainersProcessingExceptionHandlingTestCase extends Fundraiser
   }
 
   protected function advanceCharge($master_did) {
-    $did = db_query("SELECT MIN(did) FROM {fundraiser_sustainers} WHERE master_did = :master_did AND lock_id = 0 AND gateway_resp IS NULL", array(':master_did' => $master_did))
+    $did = db_query_range("SELECT did FROM {fundraiser_sustainers} WHERE master_did = :master_did AND lock_id = 0 AND gateway_resp IS NULL ORDER BY did ASC", 0 , 1, array(':master_did' => $master_did))
       ->fetchField();
-
-//    db_query("UPDATE {fundraiser_sustainers} SET next_charge = 100, attempts = 0, gateway_resp = NULL, lock_id = 0 WHERE did = :did", array(':did' => $did));
 
     $recurring = array(
       'did' => $did,
       'new_state' => 'scheduled',
-      'next_charge' => REQUEST_TIME - 10,
+      'next_charge' => time(),
     );
 
     _fundraiser_sustainers_update_recurring($recurring);
@@ -161,32 +139,53 @@ class FundraiserSustainersProcessingExceptionHandlingTestCase extends Fundraiser
     return $did;
   }
 
-  protected function runFundraiserCron() {
-    $this->drupalGet('fundraiser_cron');
-  }
-
+  /**
+   * Assert a donation has processed.
+   *
+   * @param $did numeric
+   *   The donation id to assert.
+   *
+   * @return object
+   *   The result of the assertion.
+   */
   protected function assertDonationIsSuccessfullyProcessed($did) {
     $donation = fundraiser_donation_get_donation($did);
-    debug($donation->did . ' ' . $donation->recurring->gateway_resp . ' ' . $donation->recurring->next_charge, 'donation');
     $this->assertEqual($donation->recurring->gateway_resp, 'success', 'Donation is successfully processed.');
   }
 
+  /**
+   * Assert a donation has not processed.
+   *
+   * @param $did numeric
+   *   The donation id to assert.
+   *
+   * @return object
+   *   The result of the assertion.
+   */
   protected function assertDonationIsNotSuccessfullyProcessed($did) {
-    $donation = fundraiser_donation_get_donation($did);
+    $status = db_query("SELECT gateway_resp FROM {fundraiser_sustainers} WHERE did = :did", array(':did' => $did))
+      ->fetchField();
 
-    $this->assertNotEqual($donation->recurring->gateway_resp, 'success', 'Donation is not successfully processed.');
+    $this->assertNotEqual($status, 'success', 'Donation is not successfully processed.');
   }
 
-  protected function assertWatchdogContains($message) {
-    // Login the admin user.
-    $this->drupalLogin($this->drupalCreateUser(array('access site reports')));
-    // View the database log report.
-    $this->drupalGet('admin/reports/dblog');
-    $this->assertResponse(200);
-
-    // After filter_xss(), HTML entities should be converted to their character
-    // equivalents because assertLink() uses this string in xpath() to query the
-    // Document Object Model (DOM).
-    $this->assertLink($message);
+  /**
+   * Assert the watchdog message has been created with the correct sid variable.
+   *
+   * @param $watchdog_message string
+   *   The watchdog message to search for in the database table.
+   * @param $did numeric
+   *   The donation id to assert.
+   * @param $message string
+   *   The message to return to the test.
+   *
+   * @return object
+   *   The result of the assertion.
+   */
+  private function assertWatchdogMessage($watchdog_message, $did, $message) {
+    $db_variables = db_query_range("SELECT variables FROM {watchdog} WHERE message = :message", 0, 1, array(':message' => $watchdog_message))->fetchField();
+    $variables = unserialize($db_variables);
+    $status = (!empty($variables['%did']) && $variables['%did'] == $did) ? TRUE : FALSE;
+    return $this->assert($status, format_string('@message', array('@message' => $message)));
   }
 }

--- a/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers_processing_exception_handling.test
+++ b/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers_processing_exception_handling.test
@@ -9,7 +9,18 @@
  */
 class FundraiserSustainersProcessingExceptionHandlingTestCase extends FundraiserSetup {
 
+  /**
+   * The donation form.
+   *
+   * @var stdClass
+   */
   protected $node;
+
+  /**
+   * The credit card expiration date.
+   *
+   * @var \DateTime
+   */
   protected $expiration;
 
   /**
@@ -26,11 +37,8 @@ class FundraiserSustainersProcessingExceptionHandlingTestCase extends Fundraiser
   /**
    * Implements setUp().
    */
-  public function setUp() {
-    $additional_modules = array(
-      'fundraiser_commerce',
-      'fundraiser_sustainers',
-    );
+  public function setUp($additional_modules = array()) {
+    $additional_modules[] = 'fundraiser_sustainers';
     parent::setUp($additional_modules);
 
     $this->node = $this->createDonationForm();
@@ -41,12 +49,13 @@ class FundraiserSustainersProcessingExceptionHandlingTestCase extends Fundraiser
    *
    */
   public function testExceptionHandling() {
-
     $series = array();
 
+    // For some reaosn I get a 403 when I first visit this, but a 200
+    // all other times.
     $this->drupalGet('node/' . $this->node->nid);
 
-    for ($i = 0; $i < 3; $i++) {
+    for ($i = 0; $i < 1; $i++) {
       $this->submitRecurringDonation($this->node->nid, $this->expiration);
       $master_did = $this->getMaxMasterDid();
       $series[$i] = array(
@@ -69,22 +78,66 @@ class FundraiserSustainersProcessingExceptionHandlingTestCase extends Fundraiser
       $series[$i]['advance_did'] = $this->advanceCharge($series[$i]['master_did']);
     }
 
+//    debug($series);
+//    debug(_fundraiser_sustainers_cron_get_recurring());
+//    fundraiser_sustainers_process_recurring_donations();
 //    db_query("DELETE FROM {commerce_order} WHERE order_id = :did", array(':did' => $series[1]['advance_did']));
+
+//    debug(db_query("SELECT * FROM {fundraiser_sustainers}")->fetchAllAssoc('did'));
+
+
+
+    $limit = 200;
+    $now = strtotime('now');
+    $max_processing_attempts = variable_get('fundraiser_sustainers_max_processing_attempts', 3);
+    // Lock them (faster to lock, then query, than the other way around).
+    // Since large data set returns => delay.
+    $donations = db_query('SELECT r.did FROM {fundraiser_sustainers} r ' .
+      'WHERE (r.gateway_resp IS NULL OR r.gateway_resp = :status) ' .
+      'AND r.next_charge < :now ' .
+      'AND (r.attempts < :max_attempts OR r.attempts IS NULL) ' . // If already been tried X times, Stop Trying.
+      'AND r.lock_id = 0 ' . // And not locked.
+      'LIMIT 0, ' . $limit,
+      array(':status' => FUNDRAISER_SUSTAINERS_RETRY_STATUS, ':now' => $now, ':max_attempts' => $max_processing_attempts)
+    )->fetchAllKeyed(0, 0);
+    debug($donations);
+
+
 
     $this->runFundraiserCron();
 
+
+
+    $limit = 200;
+    $now = strtotime('now');
+    $max_processing_attempts = variable_get('fundraiser_sustainers_max_processing_attempts', 3);
+    // Lock them (faster to lock, then query, than the other way around).
+    // Since large data set returns => delay.
+    $donations = db_query('SELECT r.did FROM {fundraiser_sustainers} r ' .
+      'WHERE (r.gateway_resp IS NULL OR r.gateway_resp = :status) ' .
+      'AND r.next_charge < :now ' .
+      'AND (r.attempts < :max_attempts OR r.attempts IS NULL) ' . // If already been tried X times, Stop Trying.
+      'AND r.lock_id = 0 ' . // And not locked.
+      'LIMIT 0, ' . $limit,
+      array(':status' => FUNDRAISER_SUSTAINERS_RETRY_STATUS, ':now' => $now, ':max_attempts' => $max_processing_attempts)
+    )->fetchAllKeyed(0, 0);
+    debug($donations);
+
+
+
     $this->assertDonationIsSuccessfullyProcessed($series[0]['advance_did']);
-    $this->assertDonationIsNotSuccessfullyProcessed($series[1]['advance_did']);
-    $this->assertDonationIsSuccessfullyProcessed($series[2]['advance_did']);
+//    $this->assertDonationIsNotSuccessfullyProcessed($series[1]['advance_did']);
+//    $this->assertDonationIsSuccessfullyProcessed($series[2]['advance_did']);
+//
+//    $this->assertWatchdogContains('Exception thrown while processing a sustainer');
+//
+//    $checks = new FundraiserSustainersHealthChecks();
+//    $results = $checks->checkStuckSustainers();
+//    $dids = explode(',', $results['variables']['%dids']);
+//    $this->assertEqual(count($dids), 1, 'One stuck sustainer found.');
+//    $this->assertEqual($dids[0], $series[1]['advance_did'], 'The correct donation ID is the stuck sustainer.');
 
-    $this->assertWatchdogContains('Exception thrown while processing a sustainer');
-
-    $checks = new FundraiserSustainersHealthChecks();
-    $results = $checks->checkStuckSustainers();
-    $dids = explode(',', $results['variables']['%dids']);
-    $this->assertEqual(count($dids), 1, 'One stuck sustainer found.');
-    $this->assertEqual($dids[0], $series[1]['advance_did'], 'The correct donation ID is the stuck sustainer.');
-
+    debug(db_query("SELECT * FROM {fundraiser_sustainers}")->fetchAllAssoc('did'));
   }
 
   protected function getMaxMasterDid() {
@@ -95,7 +148,15 @@ class FundraiserSustainersProcessingExceptionHandlingTestCase extends Fundraiser
     $did = db_query("SELECT MIN(did) FROM {fundraiser_sustainers} WHERE master_did = :master_did AND lock_id = 0 AND gateway_resp IS NULL", array(':master_did' => $master_did))
       ->fetchField();
 
-    db_query("UPDATE {fundraiser_sustainers} SET next_charge = 1 WHERE did = :did", array(':did' => $did));
+//    db_query("UPDATE {fundraiser_sustainers} SET next_charge = 100, attempts = 0, gateway_resp = NULL, lock_id = 0 WHERE did = :did", array(':did' => $did));
+
+    $recurring = array(
+      'did' => $did,
+      'new_state' => 'scheduled',
+      'next_charge' => REQUEST_TIME - 10,
+    );
+
+    _fundraiser_sustainers_update_recurring($recurring);
 
     return $did;
   }
@@ -106,14 +167,14 @@ class FundraiserSustainersProcessingExceptionHandlingTestCase extends Fundraiser
 
   protected function assertDonationIsSuccessfullyProcessed($did) {
     $donation = fundraiser_donation_get_donation($did);
-    debug($donation->did . ' ' . $donation->status . ' ' . $donation->recurring->next_charge, 'donation');
-    $this->assertEqual($donation->status, 'payment_received', 'Donation is successfully processed.');
+    debug($donation->did . ' ' . $donation->recurring->gateway_resp . ' ' . $donation->recurring->next_charge, 'donation');
+    $this->assertEqual($donation->recurring->gateway_resp, 'success', 'Donation is successfully processed.');
   }
 
   protected function assertDonationIsNotSuccessfullyProcessed($did) {
     $donation = fundraiser_donation_get_donation($did);
 
-    $this->assertNotEqual($donation->status, 'payment_received', 'Donation is not successfully processed.');
+    $this->assertNotEqual($donation->recurring->gateway_resp, 'success', 'Donation is not successfully processed.');
   }
 
   protected function assertWatchdogContains($message) {

--- a/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers_processing_exception_handling.test
+++ b/fundraiser/modules/fundraiser_sustainers/tests/fundraiser_sustainers_processing_exception_handling.test
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @file
+ * Fundraiser sustainer tests for failed sustainer processing.
+ */
+
+/**
+ *
+ */
+class FundraiserSustainersProcessingExceptionHandlingTestCase extends FundraiserSetup {
+
+  protected $node;
+  protected $expiration;
+
+  /**
+   * Implements getInfo(). Declares this test class to fundraiser testing.
+   */
+  public static function getInfo() {
+    return array(
+      'name' => 'Fundraiser sustainers processing exception handling',
+      'description' => 'Tests fundraiser sustainers failed processing.',
+      'group' => 'Fundraiser Sustainers',
+    );
+  }
+
+  /**
+   * Implements setUp().
+   */
+  public function setUp() {
+    $additional_modules = array(
+      'fundraiser_commerce',
+      'fundraiser_sustainers',
+    );
+    parent::setUp($additional_modules);
+
+    $this->node = $this->createDonationForm();
+    $this->expiration = new DateTime('now +3 months');
+  }
+
+  /**
+   *
+   */
+  public function testExceptionHandling() {
+
+    $series = array();
+
+    $this->drupalGet('node/' . $this->node->nid);
+
+    for ($i = 0; $i < 3; $i++) {
+      $this->submitRecurringDonation($this->node->nid, $this->expiration);
+      $master_did = $this->getMaxMasterDid();
+      $series[$i] = array(
+        'master_did' => $master_did,
+        'advance_did' => $this->advanceCharge($master_did),
+      );
+    }
+
+    $this->runFundraiserCron();
+
+    $checks = new FundraiserSustainersHealthChecks();
+    $results = $checks->checkStuckSustainers();
+    $this->assertTrue(empty($results), 'No stuck sustainers found.');
+
+    foreach ($series as $thing) {
+      $this->assertDonationIsSuccessfullyProcessed($thing['advance_did']);
+    }
+
+    foreach ($series as $i => $thing) {
+      $series[$i]['advance_did'] = $this->advanceCharge($series[$i]['master_did']);
+    }
+
+//    db_query("DELETE FROM {commerce_order} WHERE order_id = :did", array(':did' => $series[1]['advance_did']));
+
+    $this->runFundraiserCron();
+
+    $this->assertDonationIsSuccessfullyProcessed($series[0]['advance_did']);
+    $this->assertDonationIsNotSuccessfullyProcessed($series[1]['advance_did']);
+    $this->assertDonationIsSuccessfullyProcessed($series[2]['advance_did']);
+
+    $this->assertWatchdogContains('Exception thrown while processing a sustainer');
+
+    $checks = new FundraiserSustainersHealthChecks();
+    $results = $checks->checkStuckSustainers();
+    $dids = explode(',', $results['variables']['%dids']);
+    $this->assertEqual(count($dids), 1, 'One stuck sustainer found.');
+    $this->assertEqual($dids[0], $series[1]['advance_did'], 'The correct donation ID is the stuck sustainer.');
+
+  }
+
+  protected function getMaxMasterDid() {
+    return db_query("SELECT max(master_did) FROM {fundraiser_sustainers}")->fetchField();
+  }
+
+  protected function advanceCharge($master_did) {
+    $did = db_query("SELECT MIN(did) FROM {fundraiser_sustainers} WHERE master_did = :master_did AND lock_id = 0 AND gateway_resp IS NULL", array(':master_did' => $master_did))
+      ->fetchField();
+
+    db_query("UPDATE {fundraiser_sustainers} SET next_charge = 1 WHERE did = :did", array(':did' => $did));
+
+    return $did;
+  }
+
+  protected function runFundraiserCron() {
+    $this->drupalGet('fundraiser_cron');
+  }
+
+  protected function assertDonationIsSuccessfullyProcessed($did) {
+    $donation = fundraiser_donation_get_donation($did);
+    debug($donation->did . ' ' . $donation->status . ' ' . $donation->recurring->next_charge, 'donation');
+    $this->assertEqual($donation->status, 'payment_received', 'Donation is successfully processed.');
+  }
+
+  protected function assertDonationIsNotSuccessfullyProcessed($did) {
+    $donation = fundraiser_donation_get_donation($did);
+
+    $this->assertNotEqual($donation->status, 'payment_received', 'Donation is not successfully processed.');
+  }
+
+  protected function assertWatchdogContains($message) {
+    // Login the admin user.
+    $this->drupalLogin($this->drupalCreateUser(array('access site reports')));
+    // View the database log report.
+    $this->drupalGet('admin/reports/dblog');
+    $this->assertResponse(200);
+
+    // After filter_xss(), HTML entities should be converted to their character
+    // equivalents because assertLink() uses this string in xpath() to query the
+    // Document Object Model (DOM).
+    $this->assertLink($message);
+  }
+}

--- a/fundraiser/tests/fundraiser.setup.test
+++ b/fundraiser/tests/fundraiser.setup.test
@@ -504,6 +504,24 @@ abstract class FundraiserSetup extends DrupalWebTestCase {
   }
 
   /**
+   * Submit a recurring donation to a donation form.
+   *
+   * @param int $nid
+   *   The node ID of the donation form.
+   * @param \DateTime $expiration
+   *   The expiration date of the credit card.
+   */
+  protected function submitRecurringDonation($nid, DateTime $expiration) {
+    $post_config = array(
+      'submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_month]' => $expiration->format('n'),
+      'submitted[payment_information][payment_fields][credit][expiration_date][card_expiration_year]' => $expiration->format('Y'),
+      'submitted[payment_information][recurs_monthly][recurs]' => 'recurs',
+    );
+
+    $this->submitDonation($nid, $post_config);
+  }
+
+  /**
    * Create a standard post.
    */
   protected function submitDonation($nid, $post_config = '') {


### PR DESCRIPTION
@dbarbar I made some changes to the test to get the sustainers processing.

Initially the sustainers needed a sustainer key.

But, then I found it impossible to process both the success and failure cron runs in the same test, so I broke out the success and failure tests into separate classes and now they both complete.