### PR TITLE
Reload the Donation Object Before Rendering the Confirmation Email

### DIFF
--- a/webform_confirmations/webform_confirmations.module
+++ b/webform_confirmations/webform_confirmations.module
@@ -525,7 +525,6 @@ function _webform_confirmation_send_confirmation_mail_helper($settings, $donatio
   $params['settings']['html_message'] = token_replace($params['settings']['html_message'], $token_set);
   $params['settings']['text_message'] = token_replace($params['settings']['text_message'], $token_set);
   $params['subject'] = token_replace($params['subject'], $token_set, array('clear' => TRUE));
-  debug($params['settings']['html_message']);
   drupal_mail('email_wrappers', 'wf_submission', $message['to'], user_preferred_language($account), $params);
 }
 

--- a/webform_confirmations/webform_confirmations.module
+++ b/webform_confirmations/webform_confirmations.module
@@ -297,15 +297,15 @@ function webform_confirmations_fundraiser_donation_success($donation) {
 
     if ($settings) {
       foreach ($settings as $mail_config) {
-
         if (isset($mail_config['extra']['send_on_donation_success']) && $mail_config['extra']['send_on_donation_success'] === TRUE) {
+          // Reload the donation to be sure it has the latest information.
+          $donation = fundraiser_donation_get_donation($donation->did);
           _webform_confirmation_send_confirmation_mail($mail_config, $donation);
         }
       }
     }
   }
 }
-
 
 /**
  * Implements hook_fundraiser_donation_decline().
@@ -318,6 +318,8 @@ function webform_confirmations_fundraiser_donation_decline($donation) {
     if ($settings) {
       foreach ($settings as $mail_config) {
         if (isset($mail_config['extra']['send_on_donation_decline']) && $mail_config['extra']['send_on_donation_decline'] === TRUE) {
+          // Reload the donation to be sure it has the latest information.
+          $donation = fundraiser_donation_get_donation($donation->did);
           _webform_confirmation_send_confirmation_mail($mail_config, $donation);
         }
       }
@@ -523,6 +525,7 @@ function _webform_confirmation_send_confirmation_mail_helper($settings, $donatio
   $params['settings']['html_message'] = token_replace($params['settings']['html_message'], $token_set);
   $params['settings']['text_message'] = token_replace($params['settings']['text_message'], $token_set);
   $params['subject'] = token_replace($params['subject'], $token_set, array('clear' => TRUE));
+  debug($params['settings']['html_message']);
   drupal_mail('email_wrappers', 'wf_submission', $message['to'], user_preferred_language($account), $params);
 }
 


### PR DESCRIPTION
Issue:
In one instance a change to the amount value was not being displayed by the [donation:amount] token.

Fix:
Reload the donation object before rendering and sending the email.