### PR TITLE
Fixed show/hide states array bug on Fundraiser form

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -1037,8 +1037,8 @@ function fundraiser_sustainers_fundraiser_donation_form($form, $form_state) {
         'invisible' => array(),
       );
       foreach ($supporting_gateways as $supporting_gateway) {
-        $selector = ':input[name*=payment_method],value="' . $supporting_gateway . '"';
-        $recurs_monthly_field['#states']['invisible'][$selector] = array('!value' => $supporting_gateway);
+        $selector = ':input[name*=payment_method]';
+        $recurs_monthly_field['#states']['visible'][$selector][] = array('value' => $supporting_gateway);
       }
     }
   }


### PR DESCRIPTION
This seems to be a ghost from a problem I worked on fixing last year. In any case, the JS was broken on donation forms with recurring options, and this branch fixes that.

Specifically, all #states arrays were broken on donation forms before this fix.