### PR TITLE
Donation-series admin error showed wrong amount on subsequent orders

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.admin.inc
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.admin.inc
@@ -84,7 +84,7 @@ function fundraiser_sustainers_admin_view($did) {
         $row[] = $this_donation->did;
       }
 
-      $row[] = $donation->donation['amount_formatted'];
+      $row[] = $this_donation->donation['amount_formatted'];
       $row[] = date('m/d/y', $this_donation->recurring->next_charge);
       if (arg(4) == 'recurring' && arg(6) == 'view') {
         $row[] = $this_donation->recurring->sustainer_key;


### PR DESCRIPTION
If a first order was for a particular amount, and then the donation amount changed, the admin edit screen (i.e. /admin/commerce/orders/<order id>/recurring/edit) did not reflect this change. It showed all donation amounts as being equal to the first, "master" donation. This is because it was using the variable $donation instead of using $this_donation.