### PR TITLE
Reload Donation Object when Queuing a Failed Sustainer

### DIFF
--- a/salesforce/salesforce_donation/salesforce_donation.module
+++ b/salesforce/salesforce_donation/salesforce_donation.module
@@ -295,9 +295,13 @@ function salesforce_donation_fundraiser_sustainers_donation_fail($donation) {
        $stage = $salesforce_name;
     }
   }
+
+  // If a failed stage is mapped, re-queue the failed transaction for export.
   if (isset($stage)) {
+    // Reload donation to be sure to get the most recent data.
+    $donation = fundraiser_donation_get_donation($donation->did, TRUE);
     $donation->recurring->sf_stagename = $stage;
-    // If a failed stage is mapped, re-queue the failed transaction for export.
+
     salesforce_genmap_send_object_to_queue('salesforce_donation', 'update', $donation->node, $donation->did, $donation, 'donation');
   }
   else {


### PR DESCRIPTION
Issue:
When a sustainer fails it is missing the transaction date value.

Fix:
This change reloads the donation object before it is queued to SF for syncing. This ensures the latest changes to the object will be used when the values are mapped.