### PR TITLE
7.x 4.8 beta 518 add springboard tag to head

### DIFF
--- a/springboard_tag/springboard_tag.module
+++ b/springboard_tag/springboard_tag.module
@@ -1,4 +1,4 @@
-  <?php
+<?php
 
 /**
  * Implements hook_permission()
@@ -82,6 +82,7 @@ function springboard_tag_page_alter(&$page) {
   if (empty($tags)) {
     return;
   }
+
   foreach ($tags as $tag) {
     switch ($tag->settings['placement']) {
       case 'after body tag' :
@@ -91,21 +92,22 @@ function springboard_tag_page_alter(&$page) {
         $content[] = _springboard_tag_generate_tag($tag->tag);
         break;
     }
+  }
 
-    if (!empty($after_body)) {
-      // Add a post render function, and the tags.
-      $page['#post_render'][] = '_springboard_tag_post_render';
-      $page['#springboard_tag_after_body'] = implode("\n", $after_body);
-    }
+  if (!empty($after_body)) {
+    // Add a post render function, and the tags.
+    $page['#post_render'][] = '_springboard_tag_post_render';
+    $page['#springboard_tag_after_body'] = implode("\n", $after_body);
+  }
 
-    if (!empty($content)) {
-      // Add the content tags.
-      $page['content']['springboard_tag'] = array(
-        '#markup' => implode("\n", $content),
-      );
-    }
+  if (!empty($content)) {
+    // Add the content tags.
+    $page['content']['springboard_tag'] = array(
+      '#markup' => implode("\n", $content),
+    );
   }
 }
+
 
 /**
  * Implements hook_html_head_alter

--- a/springboard_tag/springboard_tag.module
+++ b/springboard_tag/springboard_tag.module
@@ -183,14 +183,18 @@ function _springboard_tag_generate_tag($snippet) {
  * Load the tags for a page request.
  */
 function _springboard_tag_load_tags() {
-  // Load all the configured tags.
-  ctools_include('export');
-  $tags = ctools_export_crud_load_all('springboard_tag');
+  $tags = &drupal_static(__FUNCTION__);
 
-  usort($tags, '_springboard_tag_load_tags_sort');
+  if (!isset($tags)) {
+    // Load all the configured tags.
+    ctools_include('export');
+    $tags = ctools_export_crud_load_all('springboard_tag');
 
-  // Allow modules to modify the tag list.
-  drupal_alter('springboard_tag_list', $tags);
+    usort($tags, '_springboard_tag_load_tags_sort');
+
+    // Allow modules to modify the tag list.
+    drupal_alter('springboard_tag_list', $tags);
+  }
 
   return $tags;
 }

--- a/springboard_tag/springboard_tag.module
+++ b/springboard_tag/springboard_tag.module
@@ -136,7 +136,7 @@ function springboard_tag_html_head_alter(&$head_content) {
   }
 }
 
-  /**
+/**
  * Add the after body tags to the page HTML.
  */
 function _springboard_tag_post_render(&$children, $elements) {

--- a/springboard_tag/springboard_tag.module
+++ b/springboard_tag/springboard_tag.module
@@ -82,7 +82,6 @@ function springboard_tag_page_alter(&$page) {
   if (empty($tags)) {
     return;
   }
-
   foreach ($tags as $tag) {
     switch ($tag->settings['placement']) {
       case 'after body tag' :
@@ -108,13 +107,12 @@ function springboard_tag_page_alter(&$page) {
   }
 }
 
-
-  /**
-   * Implements hook_html_head_alter
-   *
-   * Add springboard tags to the head tag.
-   */
-  function springboard_tag_html_head_alter(&$head_content) {
+/**
+ * Implements hook_html_head_alter
+ *
+ * Add springboard tags to the head tag.
+ */
+function springboard_tag_html_head_alter(&$head_content) {
   // Load the tags for this page.
   $tags = _springboard_tag_load_tags();
   if (empty($tags)) {

--- a/springboard_tag/springboard_tag.module
+++ b/springboard_tag/springboard_tag.module
@@ -1,4 +1,4 @@
-<?php
+  <?php
 
 /**
  * Implements hook_permission()
@@ -53,6 +53,7 @@ function springboard_tag_springboard_admin_admin_menu_items_alter(&$items) {
  */
 function _springboard_tag_placement_options() {
   return array(
+    'head' => 'In the head tag',
     'after body tag' => 'Directly after the opening body tag',
     'content' => 'Main content',
   );
@@ -91,23 +92,51 @@ function springboard_tag_page_alter(&$page) {
         $content[] = _springboard_tag_generate_tag($tag->tag);
         break;
     }
+
+    if (!empty($after_body)) {
+      // Add a post render function, and the tags.
+      $page['#post_render'][] = '_springboard_tag_post_render';
+      $page['#springboard_tag_after_body'] = implode("\n", $after_body);
+    }
+
+    if (!empty($content)) {
+      // Add the content tags.
+      $page['content']['springboard_tag'] = array(
+        '#markup' => implode("\n", $content),
+      );
+    }
+  }
+}
+
+
+  /**
+   * Implements hook_html_head_alter
+   *
+   * Add springboard tags to the head tag.
+   */
+  function springboard_tag_html_head_alter(&$head_content) {
+  // Load the tags for this page.
+  $tags = _springboard_tag_load_tags();
+  if (empty($tags)) {
+    return;
   }
 
-  if (!empty($after_body)) {
-    // Add a post render function, and the tags.
-    $page['#post_render'][] = '_springboard_tag_post_render';
-    $page['#springboard_tag_after_body'] = implode("\n", $after_body);
+  foreach ($tags as $tag) {
+    switch ($tag->settings['placement']) {
+      case 'head' :
+        $head[] = _springboard_tag_generate_tag($tag->tag);
+        break;
+    }
   }
-
-  if (!empty($content)) {
+  if (!empty($head)) {
     // Add the content tags.
-    $page['content']['springboard_tag'] = array(
-      '#markup' => implode("\n", $content),
+    $head_content['springboard_tag'] = array(
+      '#markup' => "\n" . implode("\n", $head) . "\n",
     );
   }
 }
 
-/**
+  /**
  * Add the after body tags to the page HTML.
  */
 function _springboard_tag_post_render(&$children, $elements) {


### PR DESCRIPTION
Adds an option to add springboard tags to the page head element.