### PR TITLE
PHP Notice in Goals When no Donations Exist

### DIFF
--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -3150,8 +3150,8 @@ function fundraiser_webform_token_selector_blacklist_alter(&$tokens) {
  */
 function fundraiser_get_total_donations_by_nids($nids, $start = FALSE, $end = FALSE) {
   $total_donations = module_invoke_all('fundraiser_get_total_donations_by_nids', $nids, $start, $end);
-  // Use the first implementation called.  There should only be one anyway.
-  return $total_donations[0];
+  $total = isset($total_donations[0]) ? $total_donations[0] : FALSE;
+  return $total;
 }
 
 /**


### PR DESCRIPTION
Fix:
Returns false for fundraiser_get_total_donations_by_nids return when result is empty.