### PR TITLE
Adding admin menu alias for upsell preview to avoid use of admin UI

### DIFF
--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -943,6 +943,17 @@ function springboard_admin_springboard_admin_alias_patterns() {
         'replacement' => FALSE,  // don't redirect node/123 to anything, even for Admin UI users
       ),
     ),
+    // Upsell preview.
+    'node/%/fundraiser_upsell_preview' => array(
+      'path' => array(
+        'regex' => '|^/node/([0-9]+)/fundraiser_upsell(.*)$|',
+        'replacement' => 'node/$1/fundriaser_upsell$2',
+      ),
+      'alias' => array(
+        'regex' => '|^springboard/node/([0-9]+)/fundraiser_upsell(.*)$|',
+        'replacement' => FALSE,
+      ),
+    ),
     // Webform A/B Associated Webforms page.
     'node/%/webforms' => array(
       'path' => array(


### PR DESCRIPTION
Thanks to our admin menu path rewriting, the Upsell Preview tab on donation forms is currently redirected to /springboard/node/%/sustainer_upsell_preview, which causes the form's page wrapper to not be applied, thus making the Preview completely unhelpful for styling or preview of what the actually modal will look like.

This patch creates a new entry in the admin menu aliases that makes the paths relevant to the upsell preview exempt from path rewrites.

Assembla ticket no. 596

This replaces Pull Request #797.