### PR TITLE
Removed check_plain from the webform confirmation page title field wh…

### DIFF
--- a/webform_confirmations/webform_confirmations.module
+++ b/webform_confirmations/webform_confirmations.module
@@ -282,7 +282,7 @@ function webform_confirmations_form_webform_configure_form_alter(&$form, &$form_
  */
 function _webform_confirmations_submit($form, &$form_state) {
   $confirmation['nid'] = $form_state['values']['nid'];
-  $confirmation['confirmation_page_title'] = check_plain($form_state['values']['confirmation']['confirmation_page_title']);
+  $confirmation['confirmation_page_title'] = $form_state['values']['confirmation']['confirmation_page_title'];
   _webform_confirmations_update($confirmation);
 }
 


### PR DESCRIPTION
…en it is set during submission to fix double-escape bug.