### PR TITLE
Update webform_confirmations and email_wrappers to load non-cached donation object

### DIFF
--- a/email_wrappers/email_wrappers.module
+++ b/email_wrappers/email_wrappers.module
@@ -527,7 +527,8 @@ function email_wrappers_mail_alter(&$message) {
       $sid = $params['submission']->sid;
       if ($resend) {
         if (module_exists('fundraiser_webform')) {
-          $donation = _fundraiser_webform_get_donation_by_sid($sid);
+          // Reload donation to make sure we have the latest information for tokens, etc
+          $donation = _fundraiser_webform_get_donation_by_sid($sid, TRUE);
           $params['donation'] = $donation;  //needed for subject line in email_wrappers_mail
           $params['message']['params']['donation'] = $donation;  //needed for body in email_wrappers_render_email_body
         }

--- a/fundraiser/modules/fundraiser_webform/fundraiser_webform.module
+++ b/fundraiser/modules/fundraiser_webform/fundraiser_webform.module
@@ -1216,11 +1216,11 @@ function _fundraiser_webform_get_nonfieldset_keys($field_info = NULL, $fields = 
 /**
  * Helper function, get a donation object given a sid.
  */
-function _fundraiser_webform_get_donation_by_sid($sid) {
+function _fundraiser_webform_get_donation_by_sid($sid, $refresh = FALSE) {
   $did = db_query('SELECT did FROM {fundraiser_donation} WHERE sid = :sid',
     array(':sid' => $sid))->fetchCol();
   if (isset($did[0])) {
-    $donation = fundraiser_donation_get_donation($did[0]);
+    $donation = fundraiser_donation_get_donation($did[0], $refresh);
     if ($donation) {
       return $donation;
     }

--- a/webform_confirmations/webform_confirmations.module
+++ b/webform_confirmations/webform_confirmations.module
@@ -299,7 +299,7 @@ function webform_confirmations_fundraiser_donation_success($donation) {
       foreach ($settings as $mail_config) {
         if (isset($mail_config['extra']['send_on_donation_success']) && $mail_config['extra']['send_on_donation_success'] === TRUE) {
           // Reload the donation to be sure it has the latest information.
-          $donation = fundraiser_donation_get_donation($donation->did);
+          $donation = fundraiser_donation_get_donation($donation->did, TRUE);
           _webform_confirmation_send_confirmation_mail($mail_config, $donation);
         }
       }


### PR DESCRIPTION
Changes to:

* email_wrappers
* fundraiser_webform
* webform_confirmations to bypass cached donation object loading. This fixes an issue where some tokens are not replaced correctly in email wrappers.