### PR TITLE
Track message action conversions in webform a/b

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/sba_message_action.module
+++ b/springboard_advocacy/modules/sba_message_action/sba_message_action.module
@@ -1140,3 +1140,16 @@ function sba_message_action_webform_ab_valid_webforms($webform_types) {
     return $forms;
   }
 }
+
+/**
+ * Implements hook_webform_ab_validate_conversion().
+ *
+ * Just return TRUE here. If you want to get fancy with checking what actually
+ * happened with the messages before determining if it was an actual conversion,
+ * this is where you would do it.
+ */
+function sba_message_action_webform_ab_validate_conversion($webform_types, $test_node, $form_state) {
+  if ($webform_types == 'sba_message_action') {
+    return TRUE;
+  }
+}

--- a/webform_ab/plugins/win_conditions/total_conversions.inc
+++ b/webform_ab/plugins/win_conditions/total_conversions.inc
@@ -69,5 +69,5 @@ function webform_ab_total_conversions_config_summary($config) {
  *   Webform A/B Test node
  */
 function webform_ab_total_conversions_check_win($config, $webform_details, $test_node) {
-  return ($webform_details['conversions'] >= $config['conversions']);
+  return isset($webform_details['conversions']) ? $webform_details['conversions'] >= $config['conversions'] : 0;
 }

--- a/webform_ab/plugins/win_conditions/total_conversions.inc
+++ b/webform_ab/plugins/win_conditions/total_conversions.inc
@@ -69,5 +69,5 @@ function webform_ab_total_conversions_config_summary($config) {
  *   Webform A/B Test node
  */
 function webform_ab_total_conversions_check_win($config, $webform_details, $test_node) {
-  return isset($webform_details['conversions']) ? $webform_details['conversions'] >= $config['conversions'] : 0;
+  return isset($webform_details['conversions']) ? $webform_details['conversions'] >= $config['conversions'] : FALSE;
 }


### PR DESCRIPTION
Implement hook_webform_ab_validate_conversion() in message action module to track conversions. Also fixes an undefined array index when a form has no conversions yet.