### PR TITLE
Added a variable to uniquely identify a Springboard installation

### DIFF
--- a/springboard/springboard.drush.inc
+++ b/springboard/springboard.drush.inc
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @file
+ * Drush commands for Springboard.
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function springboard_drush_command() {
+  $items = array();
+
+  $items['set-springboard-client-id'] = array(
+    'callback' => 'springboard_set_client_id',
+    'description' => 'Sets the client ID of this Springboard instance.',
+  );
+
+  return $items;
+}
+
+function springboard_set_client_id($client_id) {
+  variable_set('springboard_client_id', $client_id);
+}


### PR DESCRIPTION
This change adds a drush command to set the value of a 'springboard_client_id' variable.

This came up as a requirement during the data warehousing discussion.