### PR TITLE
Added schema cache clear after creating fundraiser_sustainers_series table in update hook.

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
@@ -799,6 +799,8 @@ function fundraiser_sustainers_update_7012() {
   db_create_table('fundraiser_sustainers_series', $fundraiser_sustainers_series_schema);
 
   _fundraiser_sustainers_create_sustainers_series_mapping();
+
+  cache_clear_all('schema', 'cache', TRUE);
 }
 
 /**


### PR DESCRIPTION
This resolved problems migrating existing sustainer series via the update hook fundraiser_sustainers_update_7013()

Doesn't look like there's a problem with update hooks running out of order as there's already a hook_update_dependencies() in salesforce_npsp.install where I would have added one.