### PR TITLE
Added forced cache refresh for fundraiser_sustainers_series schema to migration update hook.

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
@@ -799,6 +799,8 @@ function fundraiser_sustainers_update_7012() {
   db_create_table('fundraiser_sustainers_series', $fundraiser_sustainers_series_schema);
 
   _fundraiser_sustainers_create_sustainers_series_mapping();
+
+  cache_clear_all('schema', 'cache', TRUE);
 }
 
 /**

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
@@ -846,7 +846,7 @@ function fundraiser_sustainers_update_7013(&$sandbox) {
       'updated' => $time,
       );
 
-   db_insert('fundraiser_sustainers_series')
+    db_insert('fundraiser_sustainers_series')
        ->fields($fundraiser_sustainers_series_data)
        ->execute();
 

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
@@ -808,6 +808,9 @@ function fundraiser_sustainers_update_7012() {
  */
 function fundraiser_sustainers_update_7013(&$sandbox) {
   if (!isset($sandbox['progress'])) {
+    // Force schema cache refresh for fundraiser_sustainers_series table.
+    drupal_get_schema('fundraiser_sustainers_series', TRUE);
+
     $sandbox['progress'] = 0;
     $sandbox['current_did'] = 0;
     $sandbox['max'] = db_query('SELECT COUNT(did) FROM {fundraiser_sustainers} WHERE `master_did` = `did`')->fetchField();

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
@@ -818,7 +818,7 @@ function fundraiser_sustainers_update_7013(&$sandbox) {
 
   // Get fundraiser sustainers records that have matching master donation ID
   // and donation ID fields.
-  $results = db_query('SELECT `master_did` FROM {fundraiser_sustainers} WHERE `master_did` = `did` AND `master_did` > :current_did ORDER BY `master_did` ASC LIMIT 0,10',
+  $results = db_query('SELECT `master_did` FROM {fundraiser_sustainers} WHERE `master_did` = `did` AND `master_did` > :current_did ORDER BY `master_did` ASC LIMIT 0, 40',
       array(
         ':current_did' => $sandbox['current_did'],
       ))->fetchAll();
@@ -836,15 +836,19 @@ function fundraiser_sustainers_update_7013(&$sandbox) {
           ))->fetchField();
 
     // Create a new fundraiser sustainers series entity.
+    $time = time();
     $fundraiser_sustainers_series_data = array(
       'did' => $donation['did'],
       'uid' => $donation['uid'],
       'amount' => $donation['amount'],
       'installments' => $installments,
+      'created' => $time,
+      'updated' => $time,
       );
 
-    $fundraiser_sustainers_series = entity_create('fundraiser_sustainers_series', $fundraiser_sustainers_series_data);
-    $fundraiser_sustainers_series->save();
+   db_insert('fundraiser_sustainers_series')
+       ->fields($fundraiser_sustainers_series_data)
+       ->execute();
 
     $sandbox['progress']++;
     $sandbox['current_did'] = $row->master_did;

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
@@ -818,7 +818,7 @@ function fundraiser_sustainers_update_7013(&$sandbox) {
 
   // Get fundraiser sustainers records that have matching master donation ID
   // and donation ID fields.
-  $results = db_query('SELECT `master_did` FROM {fundraiser_sustainers} WHERE `master_did` = `did` AND `master_did` > :current_did ORDER BY `master_did` ASC LIMIT 0, 40',
+  $results = db_query('SELECT `master_did` FROM {fundraiser_sustainers} WHERE `master_did` = `did` AND `master_did` > :current_did ORDER BY `master_did` ASC LIMIT 0, 100',
       array(
         ':current_did' => $sandbox['current_did'],
       ))->fetchAll();

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -473,6 +473,12 @@ function fundraiser_sustainers_salesforce_queue_create_item_alter(&$item) {
         '!last' => $user_wrapper->sbp_last_name->value(),
         '!date' => gmdate('Y-m-d H:i:s\Z', $date),
       ));
+
+      if ($item['operation'] == 'CREATE') {
+        // Set installments to zero for new objects to prevent NPSP creating
+        // two sets of related opportunities.
+        $item['sobject']->fields['npe03__Installments__c'] = 0;
+      }
     }
   }
 }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -474,9 +474,9 @@ function fundraiser_sustainers_salesforce_queue_create_item_alter(&$item) {
         '!date' => gmdate('Y-m-d H:i:s\Z', $date),
       ));
 
-      if ($item['operation'] == 'CREATE') {
-        // Set installments to zero for new objects to prevent NPSP creating
-        // two sets of related opportunities.
+      if (empty(_salesforce_sync_get_rmid($item))) {
+        // Set installments to zero for unsyncned objects to prevent NPSP
+        // creating two sets of related opportunities.
         $item['sobject']->fields['npe03__Installments__c'] = 0;
       }
     }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -683,6 +683,13 @@ function fundraiser_sustainers_salesforce_sync_complete_item($item, $result) {
         $donation = fundraiser_donation_get_donation($item->drupal_id, TRUE);
         salesforce_genmap_send_object_to_queue('fundraiser_sustainers', 'update',
           $donation->node, $donation->did, $donation, 'recurring_donation');
+
+        // Re-queue the fundraiser sustainers series entity for this donation
+        // to send the correct installments value to Salesforce.
+        $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $item->drupal_id);
+        if (!empty($fundraiser_sustainers_series)) {
+          salesforce_mapping_send_entity_to_queue($fundraiser_sustainers_series, 'fundraiser_sustainers_series', 'UPDATE');
+        }
       }
     }
   }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -475,7 +475,7 @@ function fundraiser_sustainers_salesforce_queue_create_item_alter(&$item) {
       ));
 
       if (empty(_salesforce_sync_get_rmid($item))) {
-        // Set installments to zero for unsyncned objects to prevent NPSP
+        // Set installments to zero for unsynced objects to prevent NPSP
         // creating two sets of related opportunities.
         $item['sobject']->fields['npe03__Installments__c'] = 0;
       }

--- a/fundraiser/modules/fundraiser_upsell/modules/fundraiser_upsell_salesforce/fundraiser_upsell_salesforce.module
+++ b/fundraiser/modules/fundraiser_upsell/modules/fundraiser_upsell_salesforce/fundraiser_upsell_salesforce.module
@@ -665,7 +665,7 @@ function fundraiser_upsell_salesforce_get_donation_sfid($did) {
 function fundraiser_upsell_salesforce_get_recurring_donation_sfid($did) {
   $map = salesforce_sync_load_map(array(
       'module' => 'fundraiser_sustainers',
-      'delta' => 'recurring_donation',
+      'delta' => 'fundraiser_sustainers_series',
       'drupal_id' => $did,
       'object_type' => 'npe03__Recurring_Donation__c',
     ));

--- a/salesforce/salesforce_npsp/salesforce_npsp.install
+++ b/salesforce/salesforce_npsp/salesforce_npsp.install
@@ -720,3 +720,19 @@ function salesforce_npsp_update_7002(&$sandbox) {
     return t('Fundraiser sustainers series entities have been updated with NPSP-specific data.');
   }
 }
+
+/**
+ * Updates npe03__Recurring_Donation__c Salesforce sync map records.
+ */
+function salesforce_npsp_update_7003() {
+  $salesforce_sync_map_data = array(
+    'delta' => 'fundraiser_sustainers_series',
+  );
+
+  db_update('salesforce_sync_map')
+      ->fields($salesforce_sync_map_data)
+      ->condition('object_type', 'npe03__Recurring_Donation__c', '=')
+      ->execute();
+
+  return t('Fundraiser sustainers series entities have been updated with NPSP-specific data.');
+}

--- a/salesforce/salesforce_npsp/salesforce_npsp.install
+++ b/salesforce/salesforce_npsp/salesforce_npsp.install
@@ -683,24 +683,31 @@ function salesforce_npsp_update_7002(&$sandbox) {
 
   $results = db_query('SELECT `did` FROM {fundraiser_sustainers_series} WHERE `did` > :current_did ORDER BY `did` ASC LIMIT 0, 100', array(
     ':current_did' => $sandbox['current_did'],
-      ))->fetchAll();
+    ))->fetchAll();
 
   foreach ($results as $row) {
-    // Get the last and next donation dates.
-    $dates = db_query('SELECT `d`.`created`, `s`.`next_charge` FROM {fundraiser_donation} `d` JOIN {fundraiser_sustainers} `s` ON `d`.`did` = `s`.`did` WHERE `d`.`did` = :did', array(
-      ':did' => $row->did,
-        ))->fetchAssoc();
+    // Get the next charge date.
+    $next_charge = db_query('SELECT `next_charge` from {fundraiser_sustainers} WHERE `master_did` = :master_did AND `attempts` = 0 ORDER BY `did` ASC LIMIT 1', array(
+      ':master_did' => $row->did,
+      ))->fetchField();
 
-    // Get the last sustainer log timestamp, if available.
-    $log_timestamp = db_query('SELECT `timestamp` FROM {fundraiser_sustainers_log} WHERE `did` = :did ORDER BY `timestamp` DESC LIMIT 1', array(
-      ':did' => $row->did,
+    // Get the last charge date.
+    $last_charge = db_query('SELECT `next_charge` from {fundraiser_sustainers} WHERE `master_did` = :master_did AND `attempts` > 0 ORDER BY `did` DESC LIMIT 1', array(
+      ':master_did' => $row->did,
+      ))->fetchField();
+
+    // If no sustainer charges, default to the master donation creation date.
+    if (empty($last_charge)) {
+      $last_charge = db_query('SELECT `created` from {fundraiser_donation} WHERE `did` = :did', array(
+        ':did' => $row->did,
         ))->fetchField();
+    }
 
     // Update existing fundraiser sustainers series entity.
     $fundraiser_sustainers_series_data = array(
       // Last payment date is the last logged date or sustainer creation date.
-      'npsp_last_payment_date' => date('Y-m-d H:i:s', !empty($log_timestamp) ? $log_timestamp : $dates['created']),
-      'npsp_next_payment_date' => date('Y-m-d H:i:s', $dates['next_charge']),
+      'npsp_last_payment_date' => date('Y-m-d H:i:s', $last_charge),
+      'npsp_next_payment_date' => date('Y-m-d H:i:s', $next_charge),
       'npsp_installment_period' => 'Monthly',
       'npsp_schedule_type' => 'Multiply By',
     );

--- a/salesforce/salesforce_npsp/salesforce_npsp.install
+++ b/salesforce/salesforce_npsp/salesforce_npsp.install
@@ -687,7 +687,7 @@ function salesforce_npsp_update_7002(&$sandbox) {
 
   foreach ($results as $row) {
     // Get the next charge date.
-    $next_charge = db_query('SELECT `next_charge` from {fundraiser_sustainers} WHERE `master_did` = :master_did AND `attempts` = 0 AND `gateway_resp` = NULL ORDER BY `did` ASC LIMIT 1', array(
+    $next_charge = db_query('SELECT `next_charge` from {fundraiser_sustainers} WHERE `master_did` = :master_did AND `attempts` = 0 AND `gateway_resp` IS NULL ORDER BY `did` ASC LIMIT 1', array(
       ':master_did' => $row->did,
       ))->fetchField();
 

--- a/salesforce/salesforce_npsp/salesforce_npsp.install
+++ b/salesforce/salesforce_npsp/salesforce_npsp.install
@@ -681,7 +681,7 @@ function salesforce_npsp_update_7002(&$sandbox) {
     $sandbox['max'] = db_query('SELECT COUNT(did) FROM {fundraiser_sustainers_series}')->fetchField();
   }
 
-  $results = db_query('SELECT `did` FROM {fundraiser_sustainers_series} WHERE `did` > :current_did ORDER BY `did` ASC LIMIT 0, 40', array(
+  $results = db_query('SELECT `did` FROM {fundraiser_sustainers_series} WHERE `did` > :current_did ORDER BY `did` ASC LIMIT 0, 100', array(
     ':current_did' => $sandbox['current_did'],
       ))->fetchAll();
 

--- a/salesforce/salesforce_npsp/salesforce_npsp.install
+++ b/salesforce/salesforce_npsp/salesforce_npsp.install
@@ -14,6 +14,11 @@ function salesforce_npsp_update_dependencies() {
     'fundraiser_sustainers' => 7012,
   );
 
+  // Base Fundraiser Sustainers Series migration must be complete.
+  $dependencies['salesforce_npsp'][7002] = array(
+    'fundraiser_sustainers' => 7013,
+  );
+
   return $dependencies;
 }
 
@@ -663,5 +668,55 @@ function salesforce_npsp_update_7001() {
   $mapping = salesforce_mapping_load('fundraiser_sustainers_series');
   if (!empty($mapping)) {
     entity_delete('salesforce_mapping', $mapping->salesforce_mapping_id);
+  }
+}
+
+/**
+ * Migrates NPSP-specific data to fundraiser sustainer series entities.
+ */
+function salesforce_npsp_update_7002(&$sandbox) {
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['current_did'] = 0;
+    $sandbox['max'] = db_query('SELECT COUNT(did) FROM {fundraiser_sustainers_series}')->fetchField();
+  }
+
+  $results = db_query('SELECT `did` FROM {fundraiser_sustainers_series} WHERE `did` > :current_did ORDER BY `did` ASC LIMIT 0, 40', array(
+    ':current_did' => $sandbox['current_did'],
+      ))->fetchAll();
+
+  foreach ($results as $row) {
+    // Get the last and next donation dates.
+    $dates = db_query('SELECT `d`.`created`, `s`.`next_charge` FROM {fundraiser_donation} `d` JOIN {fundraiser_sustainers} `s` ON `d`.`did` = `s`.`did` WHERE `d`.`did` = :did', array(
+      ':did' => $row->did,
+        ))->fetchAssoc();
+
+    // Get the last sustainer log timestamp, if available.
+    $log_timestamp = db_query('SELECT `timestamp` FROM {fundraiser_sustainers_log} WHERE `did` = :did ORDER BY `timestamp` DESC LIMIT 1', array(
+      ':did' => $row->did,
+        ))->fetchField();
+
+    // Update existing fundraiser sustainers series entity.
+    $fundraiser_sustainers_series_data = array(
+      // Last payment date is the last logged date or sustainer creation date.
+      'npsp_last_payment_date' => date('Y-m-d H:i:s', !empty($log_timestamp) ? $log_timestamp : $dates['created']),
+      'npsp_next_payment_date' => date('Y-m-d H:i:s', $dates['next_charge']),
+      'npsp_installment_period' => 'Monthly',
+      'npsp_schedule_type' => 'Multiply By',
+    );
+
+    db_update('fundraiser_sustainers_series')
+        ->fields($fundraiser_sustainers_series_data)
+        ->condition('did', $row->did, '=')
+        ->execute();
+
+    $sandbox['progress'] ++;
+    $sandbox['current_did'] = $row->master_did;
+  }
+
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+
+  if ($sandbox['#finished'] >= 1) {
+    return t('Fundraiser sustainers series entities have been updated with NPSP-specific data.');
   }
 }

--- a/salesforce/salesforce_npsp/salesforce_npsp.install
+++ b/salesforce/salesforce_npsp/salesforce_npsp.install
@@ -734,5 +734,5 @@ function salesforce_npsp_update_7003() {
       ->condition('object_type', 'npe03__Recurring_Donation__c', '=')
       ->execute();
 
-  return t('Fundraiser sustainers series entities have been updated with NPSP-specific data.');
+  return t('Salesforce sync map records for npe03__Recurring_Donation__c objects have been updated.');
 }

--- a/salesforce/salesforce_npsp/salesforce_npsp.install
+++ b/salesforce/salesforce_npsp/salesforce_npsp.install
@@ -687,9 +687,16 @@ function salesforce_npsp_update_7002(&$sandbox) {
 
   foreach ($results as $row) {
     // Get the next charge date.
-    $next_charge = db_query('SELECT `next_charge` from {fundraiser_sustainers} WHERE `master_did` = :master_did AND `attempts` = 0 ORDER BY `did` ASC LIMIT 1', array(
+    $next_charge = db_query('SELECT `next_charge` from {fundraiser_sustainers} WHERE `master_did` = :master_did AND `attempts` = 0 AND `gateway_resp` = NULL ORDER BY `did` ASC LIMIT 1', array(
       ':master_did' => $row->did,
       ))->fetchField();
+
+    // If no unattempted sustainer charges, default to most recent date.
+    if (empty($next_charge)) {
+      $next_charge = db_query('SELECT `next_charge` from {fundraiser_sustainers} WHERE `master_did` = :master_did ORDER BY `did` DESC LIMIT 1', array(
+        ':master_did' => $row->did,
+        ))->fetchField();
+    }
 
     // Get the last charge date.
     $last_charge = db_query('SELECT `next_charge` from {fundraiser_sustainers} WHERE `master_did` = :master_did AND `attempts` > 0 ORDER BY `did` DESC LIMIT 1', array(

--- a/salesforce/salesforce_npsp/salesforce_npsp.install
+++ b/salesforce/salesforce_npsp/salesforce_npsp.install
@@ -711,7 +711,7 @@ function salesforce_npsp_update_7002(&$sandbox) {
         ->execute();
 
     $sandbox['progress'] ++;
-    $sandbox['current_did'] = $row->master_did;
+    $sandbox['current_did'] = $row->did;
   }
 
   $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);

--- a/salesforce/salesforce_npsp/salesforce_npsp.module
+++ b/salesforce/salesforce_npsp/salesforce_npsp.module
@@ -188,8 +188,12 @@ function salesforce_npsp_fundraiser_donation_success($donation) {
   $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $donation->did);
 
   if (!empty($fundraiser_sustainers_series)) {
+    $next_charge = db_query('SELECT `next_charge` FROM {fundraiser_sustainers} WHERE `master_did` = :did AND `attempts` = 0 ORDER BY `did` ASC LIMIT 1', array(
+      ':did' => $donation->did,
+        ))->fetchField();
+
     $fundraiser_sustainers_series->npsp_last_payment_date = date('Y-m-d H:i:s');
-    $fundraiser_sustainers_series->npsp_next_payment_date = date('Y-m-d H:i:s', $donation->recurring->next_charge);
+    $fundraiser_sustainers_series->npsp_next_payment_date = date('Y-m-d H:i:s', $next_charge);
     $fundraiser_sustainers_series->npsp_installment_period = 'Monthly';
     $fundraiser_sustainers_series->npsp_schedule_type = 'Multiply By';
 

--- a/salesforce/salesforce_npsp/salesforce_npsp.module
+++ b/salesforce/salesforce_npsp/salesforce_npsp.module
@@ -100,10 +100,10 @@ function salesforce_npsp_salesforce_genmap_map_fields_alter(&$fields, $context) 
     $donation = $context['object'];
     // Add a field if this is a recurring object.
     if ($donation->donation['recurs_monthly'] == TRUE && !empty($donation->master_did) ) {
-      $fields['npe03__Recurring_Donation__c'] = '[npe03__Recurring_Donation__c:recurring_donation:' . $donation->master_did . ']';
+      $fields['npe03__Recurring_Donation__c'] = '[npe03__Recurring_Donation__c:fundraiser_sustainers_series:' . $donation->master_did . ']';
     }
     if ($donation->donation['recurs_monthly'] == TRUE && empty($donation->master_did) ) {
-      $fields['npe03__Recurring_Donation__c'] = '[npe03__Recurring_Donation__c:recurring_donation:' . $donation->did . ']';
+      $fields['npe03__Recurring_Donation__c'] = '[npe03__Recurring_Donation__c:fundraiser_sustainers_series:' . $donation->did . ']';
     }
   }
 }


### PR DESCRIPTION
Shouldn't really be needed if `drush cc all` is being run; just added as an extra precaution.