### PR TITLE
re #626 - adding entity label callback for salesforce_queue_item entity

### DIFF
--- a/salesforce/salesforce_queue/salesforce_queue.module
+++ b/salesforce/salesforce_queue/salesforce_queue.module
@@ -89,6 +89,7 @@ function salesforce_queue_entity_info() {
   return array(
     'salesforce_queue_item' => array(
       'label' => t('Salesforce queue item'),
+      'label callback' => '_salesforce_queue_item_label',
       'entity class' => 'Entity',
       'base table' => 'salesforce_queue',
       'entity keys' => array(
@@ -443,4 +444,8 @@ function salesforce_queue_get_queue_names() {
 
   ksort($queue_names);
   return $queue_names;
+}
+
+function _salesforce_queue_item_label($entity, $entity_type) {
+  return t('Salesforce Queue Item #@id', array('@id' => $entity->item_id));
 }

--- a/salesforce/salesforce_queue/salesforce_queue.module
+++ b/salesforce/salesforce_queue/salesforce_queue.module
@@ -447,5 +447,5 @@ function salesforce_queue_get_queue_names() {
 }
 
 function _salesforce_queue_item_label($entity, $entity_type) {
-  return t('Salesforce Queue Item #@id', array('@id' => $entity->item_id));
+  return t('Salesforce Queue Item #@id (@delta:@drupal_id:@object_type)', array('@id' => $entity->item_id, '@delta' => $entity->delta, '@drupal_id' => $entity->drupal_id, '@object_type' => $entity->object_type));
 }


### PR DESCRIPTION
For Assembla ticket 626

Added an entity label callback for the salesforce_queue_item entity to resolve the issue with VBO having no label to display when confirming entities to be operated upon. Currently, the label I am using is "Salesforce Queue Item #[queue ID]" - this could probably be better/include more information. I will update the pull request if/when I get further instructions on how to change the label.