### PR TITLE
Ensure cancellation reason syncs to Salesforce

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -2349,6 +2349,16 @@ function fundraiser_sustainers_fundraiser_donation_get_donation($donation) {
       $donation->close_date = date('Y-m-d', $donation->recurring->next_charge);
     }
     $donation->donation['recurs_monthly'] = TRUE;
+
+    // This is a bit of a workaround because of a problem with how $donation->status_charged is
+    // implemented. That property can currently mean 2 different things. First it is used as an
+    // indicator of whether the tranaction has been charged (aka, payment received). It is also
+    // used as an indicator of whether an order can be charged based on status. This causes
+    // canceled donations to follow the same processing as a charged sustainer payment.
+    if ($donation->status == 'canceled' && $donation->status_charged) {
+      $donation->status_charged = 0;
+    }
+
   }
   else {
     $donation->donation['recurs_monthly'] = FALSE;

--- a/salesforce/salesforce_donation/salesforce_donation.module
+++ b/salesforce/salesforce_donation/salesforce_donation.module
@@ -289,6 +289,7 @@ function salesforce_donation_fundraiser_refund_success($refund) {
  * Recurring donations that have been canceled should be added to the queue.
  */
 function salesforce_donation_fundraiser_donation_cancel($donation) {
+  $donation = fundraiser_donation_get_donation($donation->did);
   $donation->status = 'canceled';
   salesforce_genmap_send_object_to_queue('salesforce_donation', 'update', $donation->node, $donation->did, $donation, 'donation');
 }

--- a/salesforce/salesforce_donation/salesforce_donation.module
+++ b/salesforce/salesforce_donation/salesforce_donation.module
@@ -289,7 +289,13 @@ function salesforce_donation_fundraiser_refund_success($refund) {
  * Recurring donations that have been canceled should be added to the queue.
  */
 function salesforce_donation_fundraiser_donation_cancel($donation) {
+  // It's necessary at this point to invoke the fundraiser_donation_get_donation
+  // hook, but we don't want to load the sustainer data from the database and
+  // overwrite unsaved data. Cache the recurring property in a variable here.
+  $recurring = $donation->recurring;
   $donation = fundraiser_donation_get_donation($donation->did);
+  $donation->recurring = $recurring;
+
   $donation->status = 'canceled';
   salesforce_genmap_send_object_to_queue('salesforce_donation', 'update', $donation->node, $donation->did, $donation, 'donation');
 }

--- a/salesforce/salesforce_donation/salesforce_donation.module
+++ b/salesforce/salesforce_donation/salesforce_donation.module
@@ -605,6 +605,12 @@ function salesforce_donation_salesforce_genmap_map_fields(stdClass $donation, En
     }
   }
 
+  // If the donation was canceled append the reason because it's not
+  // currently mappable.
+  if ($donation->status == 'canceled' && !empty($donation->recurring)) {
+    $fields['Cancellation_Reason__c'] = $donation->recurring->cancellation_reason;
+  }
+
   return $fields;
 }
 

--- a/salesforce/salesforce_donation/salesforce_donation.module
+++ b/salesforce/salesforce_donation/salesforce_donation.module
@@ -289,7 +289,6 @@ function salesforce_donation_fundraiser_refund_success($refund) {
  * Recurring donations that have been canceled should be added to the queue.
  */
 function salesforce_donation_fundraiser_donation_cancel($donation) {
-  $donation = fundraiser_donation_get_donation($donation->did);
   $donation->status = 'canceled';
   salesforce_genmap_send_object_to_queue('salesforce_donation', 'update', $donation->node, $donation->did, $donation, 'donation');
 }


### PR DESCRIPTION
Also includes a workaround to prevent canceled donations from following the same logic path as processed sustainer payments.