### PR TITLE
Performance improvements for page wrapper node operations

### DIFF
--- a/page_wrappers/page_wrappers.admin.inc
+++ b/page_wrappers/page_wrappers.admin.inc
@@ -109,6 +109,35 @@ function page_wrappers_settings_form($form, $form_state) {
       '#default_value' => variable_get('page_wrappers_filter_by_og', FALSE),
     );
   }
+  
+  // Settings for caching on page wrapper node operations.
+  $form['page_wrappers_cache_settings'] = array(
+    '#type' => 'fieldset',
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#title' => t('Cache settings'),
+    '#tree' => FALSE,
+  );
+  $form['page_wrappers_cache_settings']['page_wrappers_skip_full_cache_clear'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Bypass drupal_flush_all_caches().'),
+    '#description' => t('Enabling this option will use a subset of drupal_flush_all_caches() routines during page wrapper node operations.'),
+    '#default_value' => variable_get('page_wrappers_skip_full_cache_clear', FALSE),
+  );
+  // Get a list of all potential contrib cache tables.
+  $hook_cache_tables = module_invoke_all('flush_caches');
+  $form['page_wrappers_cache_settings']['page_wrapper_cache_tables_exclude'] = array(
+    '#type' => 'checkboxes',
+    '#states' => array(
+      'visible' => array(
+        ':input[name="page_wrappers_skip_full_cache_clear"]' => array('checked' => TRUE),
+      ),
+    ),
+    '#title' => t('Exclude cache tables.'),
+    '#options' => drupal_map_assoc($hook_cache_tables),
+    '#default_value' => variable_get('page_wrapper_cache_tables_exclude', array()),
+    '#description' => t('Cache tables selected above <b>will not be flushed</b> during page wrapper node operations.'),
+  );
 
   $form['#validate'][] = 'page_wrappers_settings_form_validate';
 

--- a/page_wrappers/page_wrappers.module
+++ b/page_wrappers/page_wrappers.module
@@ -237,7 +237,7 @@ function page_wrappers_node_update($node) {
       ->execute();
 
     // Nuke caches so page wrapper is applied to itself by the theme layer.
-    drupal_flush_all_caches();
+    _page_wrappers_flush_caches();
   }
   elseif (_page_wrappers_enabled_type($node)) {
     db_delete('node_page_wrappers')
@@ -273,7 +273,7 @@ function page_wrappers_node_insert($node) {
       ->execute();
 
     // Nuke caches so page wrapper is applied to itself by the theme layer.
-    drupal_flush_all_caches();
+    _page_wrappers_flush_caches();
   }
 }
 
@@ -1054,7 +1054,7 @@ function page_wrappers_clone_node_alter(&$node, $context) {
     }
 
     //need to clear caches for theme updates
-    drupal_flush_all_caches();
+    _page_wrappers_flush_caches();
   }
 }
 
@@ -1309,4 +1309,50 @@ function page_wrappers_check() {
   }
 
   return array('node' => $node, 'wrapper' => $wrapper);
+}
+
+/**
+ * Flush caches on page wrapper node operations.
+ */
+function _page_wrappers_flush_caches() {
+  $skip_full_cache_clear = variable_get('page_wrappers_skip_full_cache_clear', FALSE);
+  // @see https://api.drupal.org/api/drupal/includes%21common.inc/function/drupal_flush_all_caches/7
+  // Below we skip rebuilding menu and module data, etc.
+  if ($skip_full_cache_clear) {
+    // Change query-strings on css/js files to enforce reload for all users.
+    _drupal_flush_css_js();
+    
+    drupal_clear_css_cache();
+    drupal_clear_js_cache();
+    
+    // Rebuild the theme data. 
+    system_rebuild_theme_data();
+    drupal_theme_rebuild();
+    
+    // Don't clear cache_form - in-progress form submissions may break.
+    // Ordered so clearing the page cache will always be the last action.
+    $core = array('cache_filter', 'cache_page');
+    $cache = cache_get('page_wrappers_cache_tables');
+    
+    // cache the module_invoke_all() which can be expensive on sites with lots of enabled modules.
+    if (empty($cache)) {
+      $hook_tables = module_invoke_all('flush_caches');
+      // Cache until next full cache clear.
+      cache_set('page_wrappers_cache_tables', $hook_tables);
+    }
+    else {
+      $hook_tables = $cache->data;
+    }
+    $cache_tables = array_merge($hook_tables, $core);
+    
+    // Retrieve any additional cache tables that should be excluded from flushing.
+    $exclude_tables = variable_get('page_wrapper_cache_tables_exclude', array());
+    $cache_tables = array_diff($cache_tables, $exclude_tables);
+    foreach ($cache_tables as $table) {
+      cache_clear_all('*', $table, TRUE);
+    }
+  }
+  else {
+    drupal_flush_all_caches();
+  }
 }


### PR DESCRIPTION
On large sites with many contrib modules enabled and large amounts of cached data doing a full cache clear via drupal_flush_all_caches() after page wrapper node changes can cause performance issues. These changes allow bypassing drupal_flush_all_caches() after page wrapper node operations to limit the caches cleared and avoid rebuilding module data, etc.

* Adds configuration option to admin/config/content/page-wrappers to bypass Drupal's full cache clear during creation/cloning/updates to page wrapper nodes.
* Additional options for specifying contrib module cache tables to exclude from clearing.

