### PR TITLE
Disabled multiple state selection when mapping Salesforce stages to donation states.

### DIFF
--- a/salesforce/salesforce_donation/salesforce_donation.module
+++ b/salesforce/salesforce_donation/salesforce_donation.module
@@ -74,7 +74,7 @@ function salesforce_donation_settings($form, &$form_state) {
     $form['sf_donation_stages']['sf_donation_' . $stage] = array(
       '#title' => t('@stage Stage:', array('@stage' => $stage)),
       '#type' => 'select',
-      '#multiple' => TRUE,
+      '#multiple' => FALSE,
       '#options' => $available_statuses,
       '#default_value' => isset($mapped_stages[$stage]) ? $mapped_stages[$stage] : '',
     );


### PR DESCRIPTION
When mapping donation states to Salesforce opportunity stages (/admin/config/salesforce/salesforce-donation), the select fields currently allow multiple stages to be selected, but should only allow one.

When the state mapping form is [submitted here](https://github.com/JacksonRiver/springboard_modules/blob/7.x-4.x/salesforce/salesforce_donation/salesforce_donation.module#L135), the mapping data is stored in the variable `salesforce_donation_mapped_stages` in this format:

```
a:7:{s:11:"Prospecting";a:0:{}s:7:"Pledged";a:1:{s:22:"pending_future_payment";s:22:"pending_future_payment";}s:6:"Posted";a:1:{s:16:"payment_received";s:16:"payment_received";}s:9:"Withdrawn";a:1:{s:8:"canceled";s:8:"canceled";}s:11:"Closed Lost";a:1:{s:6:"failed";s:6:"failed";}s:4:"Void";a:0:{}s:13:"Auto Canceled";a:1:{s:13:"auto_canceled";s:13:"auto_canceled";}}
```

This pull request causes the data to be stored in this format:

```
a:7:{s:11:"Prospecting";s:1:"0";s:7:"Pledged";s:22:"pending_future_payment";s:6:"Posted";s:16:"payment_received";s:9:"Withdrawn";s:8:"canceled";s:11:"Closed Lost";s:6:"failed";s:4:"Void";s:1:"0";s:13:"Auto Canceled";s:13:"auto_canceled";}
```

The corrected format matches the format of the default values provided by [salesforce_donation_default_stage_map()](https://github.com/JacksonRiver/springboard_modules/blob/7.x-4.x/salesforce/salesforce_donation/salesforce_donation.module#L121).

The following functions do not work correctly if the mapping form is submitted without this fix:

* [salesforce_donation_fundraiser_sustainers_donation_fail()](https://github.com/JacksonRiver/springboard_modules/blob/7.x-4.x/salesforce/salesforce_donation/salesforce_donation.module#L310)
  * [Fails here](https://github.com/JacksonRiver/springboard_modules/blob/7.x-4.x/salesforce/salesforce_donation/salesforce_donation.module#L313)
* [salesforce_donation_salesforce_genmap_map_fields()](https://github.com/JacksonRiver/springboard_modules/blob/7.x-4.x/salesforce/salesforce_donation/salesforce_donation.module#L408)
  * [Fails here](https://github.com/JacksonRiver/springboard_modules/blob/7.x-4.x/salesforce/salesforce_donation/salesforce_donation.module#L472)

Without this fix, everything will work as long as the form has not been submitted and the [default values](https://github.com/JacksonRiver/springboard_modules/blob/7.x-4.x/salesforce/salesforce_donation/salesforce_donation.module#L121) are used.