### PR TITLE
7.x 4.x quicksign webform integration component

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form_layouts.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form_layouts.inc
@@ -128,10 +128,10 @@ function sba_message_action_preprocess_two_column_body_right(&$vars) {
 function sba_message_action_build_preprocess(&$vars) {
 
   $vars['quicksign'] = '';
-  if (module_exists('sba_quicksign') && sba_quicksign_is_enabled($vars['element']['#node'])) {
-    $quicksign = drupal_get_form('sba_quicksign_form');
-    $vars['quicksign'] = drupal_render($quicksign);
-  }
+//  if (module_exists('sba_quicksign') && sba_quicksign_is_enabled($vars['element']['#node'])) {
+//    $quicksign = drupal_get_form('sba_quicksign_form');
+//    $vars['quicksign'] = drupal_render($quicksign);
+//  }
 
   $vars['participants'] = '';
   $view = views_get_view('recent_action_participants');

--- a/springboard_advocacy/modules/sba_quicksign/components/quicksign.inc
+++ b/springboard_advocacy/modules/sba_quicksign/components/quicksign.inc
@@ -37,48 +37,4 @@ function _webform_edit_quicksign($component) {
 }
 
 
-/**
- * Implements _webform_render_component().
- */
-//function _webform_render_quicksign($component, $value = NULL, $filter = TRUE) {
-//  global $user;
-//
-//  $node = isset($component['nid']) ? node_load($component['nid']) : NULL;
-//  $settings = isset($node->nid) ? sba_quicksign_settings($node->nid) : array();
-//
-//  $element = array(
-//    '#type' => 'markup',
-//    '#title' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
-//    '#title_display' => FALSE,
-//    '#weight' => $component['weight'],
-//    '#description' => '',
-//    '#collapsible' => FALSE,
-//    '#attributes' => array('class' => array('webform-component-quicksign')),
-//    '#pre_render' => array(),
-//    '#translatable' => array('title', 'description'),
-//  );
-//
-//
-//  // Add an e-mail class for identifying the difference from normal textfields.
-//  $element['#attributes']['class'][] = 'quicksign';
-//
-//  return $element;
-//}
-
-
-/**
- * Implements _webform_display_component().
- */
-function _webform_display_quicksign($component, $value, $format = 'html') {
-
-  return array(
-    '#title' => $component['name'],
-    '#weight' => $component['weight'],
-    '#theme' => 'webform_display_quicksign',
-    '#theme_wrappers' => $format == 'html' ? array('webform_element') : array('webform_element_text'),
-    '#format' => $format,
-    '#value' => isset($value[0]) ? $value[0] : '',
-    '#translatable' => array('title'),
-  );
-}
 

--- a/springboard_advocacy/modules/sba_quicksign/components/quicksign.inc
+++ b/springboard_advocacy/modules/sba_quicksign/components/quicksign.inc
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @file
+ * Webform module quicksign component.
+ */
+
+/**
+ * Implements _webform_defaults_component().
+ */
+function _webform_defaults_quicksign() {
+  return array(
+    'name' => '',
+    'form_key' => 'sba_quicksign',
+    'pid' => 0,
+    'weight' => 0,
+    'value' => '',
+    'mandatory' => 0,
+    'extra' => array(
+      'width' => '',
+      'unique' => 0,
+      'disabled' => 0,
+      'title_display' => 0,
+      'description' => '',
+      'attributes' => array(),
+      'private' => FALSE,
+    ),
+  );
+}
+
+/**
+ * Implements _webform_edit_component().
+ */
+function _webform_edit_quicksign($component) {
+
+  return array();
+}
+
+
+/**
+ * Implements _webform_render_component().
+ */
+function _webform_render_quicksign($component, $value = NULL, $filter = TRUE) {
+  global $user;
+
+  $node = isset($component['nid']) ? node_load($component['nid']) : NULL;
+
+  $form = sba_quicksign_form();
+
+  $settings = isset($node->nid) ? sba_quicksign_settings($node->nid) : array();
+
+  $element = array(
+    '#type' => 'fieldset',
+    '#title' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
+    '#title_display' => $component['extra']['title_display'] ? $component['extra']['title_display'] : NULL,
+    '#weight' => $component['weight'],
+    '#description' => $filter ? _webform_filter_descriptions($component['extra']['description'], $node) : $component['extra']['description'],
+    '#collapsible' => FALSE,
+    '#attributes' => array('class' => array('webform-component-fieldset')),
+    '#pre_render' => array('webform_fieldset_prerender', 'webform_element_title_display'),
+    '#translatable' => array('title', 'description'),
+  );
+
+
+  // Add an e-mail class for identifying the difference from normal textfields.
+  $element['#attributes']['class'][] = 'quicksign';
+
+  return $element;
+}
+
+
+/**
+ * Implements _webform_display_component().
+ */
+function _webform_display_quicksign($component, $value, $format = 'html') {
+
+  return array(
+    '#title' => $component['name'],
+    '#weight' => $component['weight'],
+    '#theme' => 'webform_display_quicksign',
+    '#theme_wrappers' => $format == 'html' ? array('webform_element') : array('webform_element_text'),
+    '#format' => $format,
+    '#value' => isset($value[0]) ? $value[0] : '',
+    '#translatable' => array('title'),
+  );
+}
+

--- a/springboard_advocacy/modules/sba_quicksign/components/quicksign.inc
+++ b/springboard_advocacy/modules/sba_quicksign/components/quicksign.inc
@@ -40,33 +40,30 @@ function _webform_edit_quicksign($component) {
 /**
  * Implements _webform_render_component().
  */
-function _webform_render_quicksign($component, $value = NULL, $filter = TRUE) {
-  global $user;
-
-  $node = isset($component['nid']) ? node_load($component['nid']) : NULL;
-
-  $form = sba_quicksign_form();
-
-  $settings = isset($node->nid) ? sba_quicksign_settings($node->nid) : array();
-
-  $element = array(
-    '#type' => 'fieldset',
-    '#title' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
-    '#title_display' => $component['extra']['title_display'] ? $component['extra']['title_display'] : NULL,
-    '#weight' => $component['weight'],
-    '#description' => $filter ? _webform_filter_descriptions($component['extra']['description'], $node) : $component['extra']['description'],
-    '#collapsible' => FALSE,
-    '#attributes' => array('class' => array('webform-component-fieldset')),
-    '#pre_render' => array('webform_fieldset_prerender', 'webform_element_title_display'),
-    '#translatable' => array('title', 'description'),
-  );
-
-
-  // Add an e-mail class for identifying the difference from normal textfields.
-  $element['#attributes']['class'][] = 'quicksign';
-
-  return $element;
-}
+//function _webform_render_quicksign($component, $value = NULL, $filter = TRUE) {
+//  global $user;
+//
+//  $node = isset($component['nid']) ? node_load($component['nid']) : NULL;
+//  $settings = isset($node->nid) ? sba_quicksign_settings($node->nid) : array();
+//
+//  $element = array(
+//    '#type' => 'markup',
+//    '#title' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
+//    '#title_display' => FALSE,
+//    '#weight' => $component['weight'],
+//    '#description' => '',
+//    '#collapsible' => FALSE,
+//    '#attributes' => array('class' => array('webform-component-quicksign')),
+//    '#pre_render' => array(),
+//    '#translatable' => array('title', 'description'),
+//  );
+//
+//
+//  // Add an e-mail class for identifying the difference from normal textfields.
+//  $element['#attributes']['class'][] = 'quicksign';
+//
+//  return $element;
+//}
 
 
 /**

--- a/springboard_advocacy/modules/sba_quicksign/css/sba-quicksign.css
+++ b/springboard_advocacy/modules/sba_quicksign/css/sba-quicksign.css
@@ -1,0 +1,15 @@
+#webform-component-sba-quicksign {
+    margin-bottom: 20px;
+    border: 1px solid #ccc;
+    padding:16px;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    -moz-border-radius: 4px;
+    -webkit-border-radius: 4px;
+    border-radius: 4px;
+}
+
+.quicksign-label {
+    font-size: 16px;
+}

--- a/springboard_advocacy/modules/sba_quicksign/css/sba-quicksign.css
+++ b/springboard_advocacy/modules/sba_quicksign/css/sba-quicksign.css
@@ -17,3 +17,11 @@
 .quicksign-label {
     font-size: 16px;
 }
+.quicksign-description {
+    font-weight: lighter;
+}
+
+#edit-quicksign-description-format.collapsed {
+    height: 30px;
+    padding:0;
+}

--- a/springboard_advocacy/modules/sba_quicksign/css/sba-quicksign.css
+++ b/springboard_advocacy/modules/sba_quicksign/css/sba-quicksign.css
@@ -17,7 +17,7 @@
 .quicksign-label {
     font-size: 16px;
 }
-.quicksign-description {
+.node-form-quicksign-description {
     font-weight: lighter;
 }
 

--- a/springboard_advocacy/modules/sba_quicksign/css/sba-quicksign.css
+++ b/springboard_advocacy/modules/sba_quicksign/css/sba-quicksign.css
@@ -10,6 +10,10 @@
     border-radius: 4px;
 }
 
+#your-information-wrapper #webform-component-sba-quicksign,
+#user-information-wrapper #webform-component-sba-quicksign{
+    width: 99.25%;
+}
 .quicksign-label {
     font-size: 16px;
 }

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.install
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.install
@@ -39,14 +39,6 @@ function sba_quicksign_schema() {
         'type' => 'varchar',
         'length' => 255,
       ),
-      'show_submit_button' => array(
-        'description' => 'Boolean, submit button is enabled',
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'size' => 'tiny',
-        'not null' => TRUE,
-        'default' => 0,
-      ),
       'submit_button_text' => array(
         'description' => 'Submit button text.',
         'type' => 'varchar',
@@ -123,15 +115,5 @@ function sba_quicksign_update_7001() {
 
   if (module_exists('springboard_petition_quicksign')) {
     module_disable(array('springboard_petition_quicksign'));
-  }
-}
-
-/**
- * Add show submit button checkbox field.
- */
-function sba_quicksign_update_7002() {
-  $schema = module_invoke('sba_quicksign', 'schema');
-  if (db_field_exists('sba_quicksign', 'show_submit_button') == FALSE) {
-    db_add_field('sba_quicksign', 'show_submit_button', $schema['sba_quicksign']['fields']['show_submit_button']);
   }
 }

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.install
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.install
@@ -39,6 +39,14 @@ function sba_quicksign_schema() {
         'type' => 'varchar',
         'length' => 255,
       ),
+      'show_submit_button' => array(
+        'description' => 'Boolean, submit button is enabled',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
       'submit_button_text' => array(
         'description' => 'Submit button text.',
         'type' => 'varchar',
@@ -118,4 +126,12 @@ function sba_quicksign_update_7001() {
   }
 }
 
-
+/**
+ * Add show submit button checkbox field.
+ */
+function sba_quicksign_update_7002() {
+  $schema = module_invoke('sba_quicksign', 'schema');
+  if (db_field_exists('sba_quicksign', 'show_submit_button') == FALSE) {
+    db_add_field('sba_quicksign', 'show_submit_button', $schema['sba_quicksign']['fields']['show_submit_button']);
+  }
+}

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -627,11 +627,13 @@ function sba_quicksign_element_process_text_format($element) {
     $parents = array_flip($element['#array_parents']);
     if (isset($parents['sba_quicksign'])) {
       $prefix = isset($element['format']['#prefix']) ? $element['format']['#prefix'] : '';
-      $element['format']['#prefix'] = $element['#description'] . $prefix;
+      $element['format']['#prefix'] = '<div class="quicksign-description">' . $element['#description'] . '</div>' . $prefix;
       unset($element['#description']);
       $element['format']['#collapsible'] = TRUE;
       $element['format']['#collapsed'] = TRUE;
       $element['format']['#title'] = t('Text format');
+      $element['#attached']['css'][] = drupal_get_path('module', 'sba_quicksign') . '/css/sba-quicksign.css';
+
     }
   }
   return $element;

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -259,6 +259,23 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
       '#default_value' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : 'Already a supporter?',
     );
 
+    $form['sba_quicksign']['show_submit_button'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Use a separate submit button'),
+      '#description' => t('Useful if the quicksign field is placed at the top of the form.'),
+      '#default_value' => isset($settings['show_submit_button']) ? $settings['show_submit_button'] : 1,
+    );
+
+    $form['sba_quicksign']['quicksign_button_text'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Submit button text'),
+      '#description' => t('Change the text on the quick sign form submit button.'),
+      '#default_value' => isset($settings['quicksign_button_text']) ? $settings['quicksign_button_text'] : t('Sign now'),
+      '#states' => array(
+        'visible' => array(':input[name="show_submit_button"]' => array('checked' => TRUE)),
+        ),
+    );
+
     $default_desc = $node->type == 'sba_message_action' ? t('If we already have your information, just enter your email address and click to send this message now.') : t('If we already have your information, just enter your email address and click to sign this petition now.');
     $form['sba_quicksign']['quicksign_description'] = array(
       '#type' => 'text_format',
@@ -268,13 +285,7 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
       '#format' => isset($settings['quicksign_description_format']) ? $settings['quicksign_description_format'] : NULL,
     );
 
-    $default = $node->type == 'sba_message_action' ? t('Sign now') : t('Sign now');
-    $form['sba_quicksign']['quicksign_button_text'] = array(
-      '#type' => 'textfield',
-      '#title' => t('Submit button text'),
-      '#description' => t('Change the text on the quick sign form submit button.'),
-      '#default_value' => isset($settings['quicksign_button_text']) ? $settings['quicksign_button_text'] : $default,
-    );
+
     // No validation or submit handlers, we'll handle this during
     // hook_node_insert() and hook_node_update().
   }
@@ -347,6 +358,7 @@ function sba_quicksign_save($node) {
     'form_label' => $node->quicksign_label,
     'form_description' => $node->quicksign_description['value'],
     'form_description_format' => $node->quicksign_description['format'],
+    'show_submit_button' => $node->show_submit_button,
     'submit_button_text' => $node->quicksign_button_text,
   );
   drupal_write_record('sba_quicksign', $record);
@@ -400,6 +412,7 @@ function sba_quicksign_settings($nid) {
       form_label AS quicksign_label,
       form_description AS quicksign_description,
       form_description_format AS quicksign_description_format,
+      show_submit_button AS show_submit_button,
       submit_button_text AS quicksign_button_text
      FROM {sba_quicksign}
      WHERE nid = :nid;', array(':nid' => $nid));
@@ -475,7 +488,6 @@ function sba_quicksign_insert_components($node, $op) {
     'weight' => -100,
     'email' => 0,
     'extra' => array(
-      'description' => '',
       'attributes' => array(),
       'private' => FALSE,
     ),
@@ -501,4 +513,42 @@ function sba_quicksign_insert_components($node, $op) {
 
 function sba_quicksign_delete_components($node, $cid) {
   webform_component_delete($node, $node->webform['components'][$cid]);
+}
+
+function sba_quicksign_form_webform_component_edit_form_alter(&$form, &$form_state, $form_id) {
+  if ($form['form_key']['#default_value'] == 'sba_quicksign') {
+    $form['form_key']['#disabled'] = TRUE;
+    $form['form_key']['#description'] = '';
+    $form['name']['#access'] = FALSE;
+    $form['extra']['description']['#access'] = FALSE;
+    $form['display']['#access'] = FALSE;
+    $form['actions']['#access'] = FALSE;
+  }
+}
+function sba_quicksign_form_webform_components_form_alter(&$form, &$form_state, $form_id) {
+  foreach ($form['#node']->webform['components'] as $key => $component) {
+    if ($component['form_key'] == 'sba_quicksign') {
+      unset($form['add']['type']['#options']['quicksign']);
+    }
+  }
+}
+
+/**
+ * Implements hook_element_info_alter().
+ */
+function sba_quicksign_element_info_alter(&$type) {
+  $type['text_format']['#process'][] = 'sba_quicksign_element_process_text_format';
+}
+
+function sba_quicksign_element_process_text_format($element) {
+  if (in_array('quicksign_description', $element['#parents'])) {
+    $prefix = isset($element['format']['#prefix']) ? $element['format']['#prefix'] : '';
+    $element['format']['#prefix'] = $element['#description'] . $prefix;
+    unset($element['#description']);
+    $element['format']['#collapsible'] = TRUE;
+    $element['format']['#collapsed'] = TRUE;
+    //$element['format']['#suffix'] = '<div class="text-format-spacer">&nbsp;</div>';
+    $element['format']['#title'] = t('Text format');
+  }
+  return $element;
 }

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -91,9 +91,9 @@ function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
               $quicksign_field['children'] = sba_quicksign_form();
               $quicksign_field['children']['#weight'] = 1001;
               $form['#attached']['css'][] = drupal_get_path('module', 'sba_quicksign') . '/css/sba-quicksign.css';
+              array_unshift($form['#validate'], 'sba_quicksign_form_validate');
             }
           }
-          array_unshift($form['#validate'], 'sba_quicksign_form_validate');
         }
       }
       else {
@@ -158,7 +158,8 @@ function sba_quicksign_form() {
  */
 function sba_quicksign_form_validate(&$form, &$form_state) {
 
-  if (in_array('sba_quicksign', $form_state['clicked_button']['#parents'])) {
+  $parents = array_flip($form_state['clicked_button']['#parents']);
+  if (isset($parents['sba_quicksign'])) {
     $_SESSION['quicksign_show'] = TRUE;
     // Make webform believe that we clicked the webform submit button.
     $form_state['values']['op'] = $form['actions']['submit']['#value'];
@@ -248,7 +249,9 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
     _sba_quicksign_build_values($form, $form_state, $node, $profile);
   }
   else {
+    // Quicksign button was not clicked.
     unset($_SESSION['sba_quicksign']);
+    unset($form_state['values']['submitted']['sba_quicksign']);
   }
 }
 

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -246,7 +246,7 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
     if ($missing_fields || $missing_non_profile_fields) {
       $_SESSION['sba_quicksign']['profile'] = $profile;
 
-      drupal_set_message(t("Unfortunately, we don't have enough information. Please complete the form below."));
+      drupal_set_message(t("Unfortunately, we don't have enough information on file to submit this form. Please complete the form below."));
       $_SESSION['quicksign_show'] = FALSE;
       //drupal_redirect_form($form_state);
     }

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -50,7 +50,7 @@ function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
           // profile values from prior submission.
           $profile = !empty($_SESSION['sba_quicksign']['profile']) ? $_SESSION['sba_quicksign']['profile'] : FALSE;
           if ($profile) {
-            sba_quicksign_form_defaults($form, $form_state, $node, $profile);
+            //sba_quicksign_form_defaults($form, $form_state, $node, $profile);
             if (count($_SESSION['sba_quicksign']['profile']) > 1) {
               $form['#after_build'][] = 'sba_quicksign_after_build';
             }
@@ -286,48 +286,6 @@ function sba_quicksign_after_build($form, $form_state) {
 }
 
 /**
- * Populate a webform with defaults from the user profile.
- *
- * @param mixed $form
- *   Webform FAPI array.
- * @param object $node
- *   Webform Node object.
- * @param array|bool $user_data
- *   User profile data to use during substitution.
- */
-function sba_quicksign_form_defaults(&$form, &$form_state, $node, $user_data) {
-  $components = $node->webform['components'];
-  $component_hierarchy = __webform_user_parse_components($node->nid, $components);
-  $map = webform_user_user_map($node->nid);
-  // Map each profile field if there's a matching component field.
-  foreach ($map as $webform_field => $profile_field) {
-    if (array_key_exists($webform_field, $component_hierarchy)) {
-      $form_field = &_webform_user_find_field($form, $component_hierarchy[$webform_field]);
-      if (isset($user_data[$webform_field])) {
-        $profile_value = $user_data[$webform_field];
-        // Set the value.
-        switch ($form_field['#type']) {
-          case 'date':
-            $form_field['#default_value'] = $profile_value;
-            break;
-
-          case 'checkboxes':
-            if ($profile_value) {
-              $form_field['#default_value'] = array($profile_field);
-            }
-            break;
-
-          default:
-            $form_field['#default_value'] = check_plain($profile_value);
-            break;
-        }
-      }
-      // End if webform empty with a profile field value.
-    } // End if field is in component hierarchy.
-  }
-}
-
-/**
  * Implements hook_node_insert().
  */
 function sba_quicksign_node_insert($node) {
@@ -363,9 +321,7 @@ function sba_quicksign_node_update($node) {
         sba_quicksign_delete_components($node, $cid);
       }
     }
-
   }
-
 }
 
 /**

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -1,5 +1,29 @@
 <?php
 
+
+function sba_quicksign_webform_component_info() {
+  $components = array();
+  $components['quicksign'] = array(
+    'label' => t('Quicksign'),
+    'description' => FALSE,
+    'features' => array(
+      'csv' => FALSE,
+      'email' => FALSE,
+      'email_address' => FALSE,
+      'email_name' => FALSE,
+      'required' => FALSE,
+      'title_display' => TRUE,
+      'title_inline' => FALSE,
+      'conditional' => FALSE,
+      'group' => FALSE,
+      'spam_analysis' => FALSE,
+      'attachment' => FALSE,
+    ),
+    'file' => 'components/quicksign.inc',
+  );
+  return $components;
+}
+
 /**
  * Implements hook_views_api().
  */
@@ -33,13 +57,16 @@ function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
             unset($_SESSION['sba_quicksign']);
           }
           else {
-            $form['quicksign'] = sba_quicksign_form();
-            $form['quicksign']['#weight'] = 1001;
+            $form['submitted']['sba_quicksign']['quicksign'] = sba_quicksign_form();
+            $form['submitted']['sba_quicksign']['quicksign']['#weight'] = 1001;
             array_unshift($form['#validate'], 'sba_quicksign_form_validate');
           }
         }
       }
     }
+  }
+  else {
+    $form['submitted']['sba_quicksign']['#access'] = FALSE;
   }
 }
 
@@ -53,24 +80,6 @@ function sba_quicksign_form() {
   $description_format = isset($settings['quicksign_description_format']) ? $settings['quicksign_description_format'] : NULL;
 
   $form = array();
-
-  if ($node->type != 'springboard_petition') {
-    $form['qsign'] = array(
-      '#type' => 'fieldset',
-      '#title' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
-    );
-  }
-  else {
-    $form['qsign'] = array(
-      '#type' => 'container',
-    );
-    $form['qsign']['quicksign_label'] = array(
-      '#markup' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
-      '#prefix' => '<h2 class="quicksign-label">',
-      '#suffix' => '</h2>',
-    );
-  }
-
   $form['qsign']['quicksign_description'] = array(
     '#markup' => isset($settings['quicksign_description']) ? check_markup($settings['quicksign_description'], $description_format) : '',
     '#prefix' => '<div class="quicksign-description">',
@@ -324,6 +333,7 @@ function sba_quicksign_form_defaults(&$form, &$form_state, $node, $user_data) {
 function sba_quicksign_node_insert($node) {
   if (sba_quicksign_is_quicksign_type($node->type) && isset($node->quicksign_enabled)) {
     sba_quicksign_save($node);
+    sba_quicksign_insert_components($node, 'insert');
   }
 }
 
@@ -331,8 +341,29 @@ function sba_quicksign_node_insert($node) {
  * Implements hook_node_update().
  */
 function sba_quicksign_node_update($node) {
-  if (sba_quicksign_is_quicksign_type($node->type) && isset($node->quicksign_enabled)) {
-    sba_quicksign_save($node);
+  if (sba_quicksign_is_quicksign_type($node->type)) {
+    $has_component = FALSE;
+    $cid = NULL;
+    foreach ($node->webform['components'] as $key => $component) {
+      if ($component['form_key'] == 'sba_quicksign') {
+        $has_component = TRUE;
+        $cid = $key;
+      }
+    }
+
+    if (isset($node->quicksign_enabled)) {
+
+      sba_quicksign_save($node);
+
+      if (!empty($node->quicksign_enabled) && !$has_component) {
+        sba_quicksign_insert_components($node, 'update');
+      }
+
+      if (empty($node->quicksign_enabled) && $has_component) {
+        sba_quicksign_delete_components($node, $cid);
+      }
+    }
+
   }
 
 }
@@ -474,4 +505,44 @@ function sba_quicksign_is_quicksign_type($type) {
     $quicksign = TRUE;
   }
   return $quicksign;
+}
+
+function sba_quicksign_insert_components($node, $op) {
+  module_load_include('inc', 'webform', 'includes/webform.components');
+
+  $fields[] = array(
+    'nid' => $node->nid,
+    'form_key' => 'sba_quicksign',
+    'pid' => 0,
+    'name' => t('Quicksign'),
+    'type' => 'fieldset',
+    'weight' => -100,
+    'email' => 0,
+    'extra' => array(
+      'description' => '',
+      'attributes' => array(),
+      'private' => FALSE,
+    ),
+  );
+
+
+  $exclude = array();
+  $exclude[] = 'sba_quicksign';
+
+  // Add the component to the Webform.
+  foreach ($fields as $field) {
+    // Don't insert fields if cloning.
+    if ($op == 'insert') {
+      if (!isset($node->map) || (isset($node->map) && !in_array($field['form_key'], $node->map) && !in_array($field['form_key'], $exclude))) {
+        webform_component_insert($field);
+      }
+    }
+    else {
+      webform_component_insert($field);
+    }
+  }
+}
+
+function sba_quicksign_delete_components($node, $cid) {
+  webform_component_delete($node, $node->webform['components'][$cid]);
 }

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -3,7 +3,7 @@
 
 function sba_quicksign_webform_component_info() {
   $components = array();
-  $components['quicksign'] = array(
+  $components['sba_quicksign'] = array(
     'label' => t('Quicksign'),
     'description' => FALSE,
     'features' => array(
@@ -38,12 +38,12 @@ function sba_quicksign_views_api() {
  */
 function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
   global $user;
-  if (empty($user->uid)) {
     if (strpos($form_id, 'webform_client') !== FALSE && arg(2) != 'submission' && arg(4) != 'edit') {
       // Quicksign content type.
       if (isset($form['#node']) && sba_quicksign_is_quicksign_type($form['#node']->type)) {
         $node = $form['#node'];
-        // Quicksign enabled.
+        if (empty($user->uid) || user_access('create ' . $node->type . ' content')) {
+          // Quicksign enabled.
         if (sba_quicksign_is_enabled($node)) {
           // Check for errors in quicksign form submission
           // If present attempt to set Webform fields with
@@ -57,8 +57,9 @@ function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
             unset($_SESSION['sba_quicksign']);
           }
           else {
-            $form['submitted']['sba_quicksign']['quicksign'] = sba_quicksign_form();
-            $form['submitted']['sba_quicksign']['quicksign']['#weight'] = 1001;
+            $form['submitted']['sba_quicksign']['children'] = sba_quicksign_form();
+            $form['submitted']['sba_quicksign']['children']['#weight'] = 1001;
+            $form['#attached']['css'][] = drupal_get_path('module', 'sba_quicksign') . '/css/sba-quicksign.css';
             array_unshift($form['#validate'], 'sba_quicksign_form_validate');
           }
         }
@@ -80,6 +81,12 @@ function sba_quicksign_form() {
   $description_format = isset($settings['quicksign_description_format']) ? $settings['quicksign_description_format'] : NULL;
 
   $form = array();
+
+  $form['qsign']['label'] = array(
+    '#markup' => isset($settings['quicksign_label']) ? check_plain($settings['quicksign_label']) : '',
+    '#prefix' => '<div class="quicksign-label-container"><label class="quicksign-label">',
+    '#suffix' => '</label></div>',
+  );
   $form['qsign']['quicksign_description'] = array(
     '#markup' => isset($settings['quicksign_description']) ? check_markup($settings['quicksign_description'], $description_format) : '',
     '#prefix' => '<div class="quicksign-description">',
@@ -118,8 +125,7 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
   $form_state['values']['op'] = $form['actions']['submit']['#value'];
 
   // Validate mail field.
-  $mail = isset($form_state['values']['quicksign_mail']) ? $form_state['values']['quicksign_mail'] : FALSE;
-
+  $mail = isset($form_state['values']['submitted']['sba_quicksign']['children']['qsign']['quicksign_mail']) ? $form_state['values']['submitted']['sba_quicksign']['children']['qsign']  ['quicksign_mail'] : FALSE;
   if (!$mail) {
     return;
   }
@@ -129,7 +135,7 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
     return;
   }
 
-  $node = node_load($form_state['values']['nid']);
+  $node = node_load($form_state['values']['details']['nid']);
   // Load user profile from email.
   $account = user_load_by_mail($mail);
   // No profile available.
@@ -483,8 +489,8 @@ function sba_quicksign_insert_components($node, $op) {
     'nid' => $node->nid,
     'form_key' => 'sba_quicksign',
     'pid' => 0,
-    'name' => t('Quicksign'),
-    'type' => 'fieldset',
+    'name' => $node->quicksign_label,
+    'type' => 'markup',
     'weight' => -100,
     'email' => 0,
     'extra' => array(
@@ -492,7 +498,6 @@ function sba_quicksign_insert_components($node, $op) {
       'private' => FALSE,
     ),
   );
-
 
   $exclude = array();
   $exclude[] = 'sba_quicksign';
@@ -518,19 +523,15 @@ function sba_quicksign_delete_components($node, $cid) {
 function sba_quicksign_form_webform_component_edit_form_alter(&$form, &$form_state, $form_id) {
   if ($form['form_key']['#default_value'] == 'sba_quicksign') {
     $form['form_key']['#disabled'] = TRUE;
-    $form['form_key']['#description'] = '';
+    $form['form_key']['#description'] = t('This field can only be edited on the quicksign tab on the node edit form.');
     $form['name']['#access'] = FALSE;
-    $form['extra']['description']['#access'] = FALSE;
+    $form['value']['#access'] = FALSE;
     $form['display']['#access'] = FALSE;
     $form['actions']['#access'] = FALSE;
   }
 }
 function sba_quicksign_form_webform_components_form_alter(&$form, &$form_state, $form_id) {
-  foreach ($form['#node']->webform['components'] as $key => $component) {
-    if ($component['form_key'] == 'sba_quicksign') {
-      unset($form['add']['type']['#options']['quicksign']);
-    }
-  }
+    unset($form['add']['type']['#options']['sba_quicksign']);
 }
 
 /**

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -54,10 +54,22 @@ function sba_quicksign_form() {
 
   $form = array();
 
-  $form['qsign'] = array(
-    '#type' => 'fieldset',
-    '#title' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
-  );
+  if ($node->type != 'springboard_petition') {
+    $form['qsign'] = array(
+      '#type' => 'fieldset',
+      '#title' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
+    );
+  }
+  else {
+    $form['qsign'] = array(
+      '#type' => 'container',
+    );
+    $form['qsign']['quicksign_label'] = array(
+      '#markup' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
+      '#prefix' => '<h2 class="quicksign-label">',
+      '#suffix' => '</h2>',
+    );
+  }
 
   $form['qsign']['quicksign_description'] = array(
     '#markup' => isset($settings['quicksign_description']) ? check_markup($settings['quicksign_description'], $description_format) : '',

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -1,7 +1,21 @@
 <?php
 
-
 /**
+ * Implements hook_webform_component_info().
+ *
+ * The quicksign form component is just a markup field, with
+ * child elements as if it were a fieldset. The child elements are
+ * form altered into it, rather than being actual webform components.
+ * This allows the quicksign field to be positioned on the form using
+ * the webform component UI.
+ *
+ * The original quicksign module implemented a separate form on the same page,
+ * which did a drupal_form_submit() of the original webform if validation
+ * succeeded. The problem with that is it could not recognize the existence of
+ * non-webform-user form components, or of non-webform-components which may
+ * have been form altered into the webform, and would lose those
+ * values on submit.
+ *
  * @return array
  */
 function sba_quicksign_webform_component_info() {
@@ -42,36 +56,57 @@ function sba_quicksign_views_api() {
 function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
   global $user;
   if (strpos($form_id, 'webform_client') !== FALSE && arg(2) != 'submission' && arg(4) != 'edit') {
-    // Quicksign content type.
     if (isset($form['#node']) && sba_quicksign_is_quicksign_type($form['#node']->type)) {
       $node = $form['#node'];
       if (empty($user->uid) || user_access('create ' . $node->type . ' content')) {
-        // Quicksign enabled.
         if (sba_quicksign_is_enabled($node)) {
-          // Check for errors in quicksign form submission
-          // If present attempt to set Webform fields with
-          // profile values from prior submission.
+
+          $components = $node->webform['components'];
+          $component_hierarchy = __webform_user_parse_components($node->nid, $components);
+
           $profile = !empty($_SESSION['sba_quicksign']['profile']) ? $_SESSION['sba_quicksign']['profile'] : FALSE;
+
           if ($profile) {
-            //sba_quicksign_form_defaults($form, $form_state, $node, $profile);
-            if (count($_SESSION['sba_quicksign']['profile']) > 1) {
-              $form['#after_build'][] = 'sba_quicksign_after_build';
+            $form['#after_build'][] = 'sba_quicksign_after_build';
+            // The original quicksign module pre-populated webforms if partial profile info
+            // was found after a validation failure.
+            // That has been removed due to potential for abuse.
+            // sba_quicksign_form_defaults($form, $form_state, $node, $profile);
+
+            $reload_mail = '';
+            if (!empty($_SESSION['sba_quicksign']['profile']['mail'])) {
+              $reload_mail = $_SESSION['sba_quicksign']['profile']['mail'];
             }
+            else if(!empty($_SESSION['sba_quicksign']['quickmail'])) {
+              $reload_mail = $_SESSION['sba_quicksign']['quickmail'];
+            }
+            $email_field = &_webform_user_find_field($form, $component_hierarchy['mail']);
+            $email_field['#default_value'] = $reload_mail;
+
             unset($_SESSION['sba_quicksign']);
           }
           else {
-            $form['submitted']['sba_quicksign']['children'] = sba_quicksign_form();
-            $form['submitted']['sba_quicksign']['children']['#weight'] = 1001;
-            $form['#attached']['css'][] = drupal_get_path('module', 'sba_quicksign') . '/css/sba-quicksign.css';
-            array_unshift($form['#validate'], 'sba_quicksign_form_validate');
+            if (!isset($_SESSION['quicksign_show']) || $_SESSION['quicksign_show'] == TRUE) {
+              $quicksign_field = &_webform_user_find_field($form, $component_hierarchy['sba_quicksign']);
+              $quicksign_field['children'] = sba_quicksign_form();
+              $quicksign_field['children']['#weight'] = 1001;
+              $form['#attached']['css'][] = drupal_get_path('module', 'sba_quicksign') . '/css/sba-quicksign.css';
+            }
           }
+          array_unshift($form['#validate'], 'sba_quicksign_form_validate');
         }
+      }
+      else {
+        // Don't display the quicksign form to logged in users.
+        $form['submitted']['sba_quicksign']['#access'] = FALSE;
       }
     }
   }
-  else {
-    $form['submitted']['sba_quicksign']['#access'] = FALSE;
-  }
+}
+
+function sba_quicksign_after_build($form, $form_state) {
+  $form['#attached']['js'][] = drupal_get_path('module', 'sba_quicksign') . '/js/sba_quicksign.js';
+  return $form;
 }
 
 /**
@@ -115,7 +150,6 @@ function sba_quicksign_form() {
   return $form;
 }
 
-
 /**
  * Validation callback for quicksign form.
  *
@@ -123,87 +157,98 @@ function sba_quicksign_form() {
  * @param $form_state
  */
 function sba_quicksign_form_validate(&$form, &$form_state) {
+
   if (in_array('sba_quicksign', $form_state['clicked_button']['#parents'])) {
+    $_SESSION['quicksign_show'] = TRUE;
+    // Make webform believe that we clicked the webform submit button.
+    $form_state['values']['op'] = $form['actions']['submit']['#value'];
 
-
-  // Make webform believe that we clicked the webform submit button.
-  $form_state['values']['op'] = $form['actions']['submit']['#value'];
-
-  // Validate mail field.
-  $mail = isset($form_state['values']['submitted']['sba_quicksign']['children']['qsign']['quicksign_mail']) ? $form_state['values']['submitted']['sba_quicksign']['children']['qsign']  ['quicksign_mail'] : FALSE;
-  if (!$mail) {
-    return;
-  }
-
-  if (!valid_email_address($mail)) {
-    form_set_error('quicksign_mail', t('The quicksign email address entered is not valid.'));
-    return;
-  }
-
-  $node = node_load($form_state['values']['details']['nid']);
-  // Load user profile from email.
-  $account = user_load_by_mail($mail);
-  // No profile available.
-  if (!$account) {
-    $_SESSION['sba_quicksign']['profile']['mail'] = $mail;
-    drupal_set_message(t("We're sorry, we did not find an account with the email address !mail. Please fill out the full form. Next time you will be able to submit using just your email address.", array('!mail' => $mail)));
-    drupal_redirect_form($form_state);
-  }
-
-  // Compile list of webform required fields.
-  $required_fields = sba_quicksign_get_required_fields($node);
-  // Compare profile to required fields via the Webform User field map.
-  $map = webform_user_user_map($node->nid);
-  $required_non_profile_fields = array_diff($required_fields, $map);
-  $missing_non_profile_fields = FALSE;
-  foreach ($required_non_profile_fields as $form_key) {
-    if (empty($form_state['values']['submitted'][$form_key])) {
-      $missing_non_profile_fields = TRUE;
-    }
-  }
-
-  $missing_fields = FALSE;
-  $profile = array();
-  $count_profile_required = 0;
-  foreach ($map as $webform_field => $profile_field) {
-
-    if (in_array($webform_field, $required_fields)) {
-      $count_profile_required++;
+    // Validate mail field.
+    $mail = isset($form_state['values']['submitted']['sba_quicksign']['children']['qsign']['quicksign_mail']) ? $form_state['values']['submitted']['sba_quicksign']['children']['qsign']  ['quicksign_mail'] : FALSE;
+    if (!$mail) {
+      return;
     }
 
-    if (!empty($form_state['values']['submitted'][$profile_field])) {
-      $profile[$webform_field] = $form_state['values']['submitted'][$profile_field];
+    if (!valid_email_address($mail)) {
+      form_set_error('quicksign_mail', t('The quicksign email address entered is not valid.'));
+      return;
     }
     else {
-      if ($webform_field != 'mail') {
-        $items = field_get_items('user', $account, $profile_field);
-        $profile[$webform_field] = !empty($items[0]['value']) ? $items[0]['value'] : FALSE;
+      $_SESSION['sba_quicksign']['quickmail'] = $mail;
+    }
+
+    $node = node_load($form_state['values']['details']['nid']);
+    // Load user profile from email.
+    $account = user_load_by_mail($mail);
+    // No profile available.
+    if (!$account) {
+      $_SESSION['sba_quicksign']['profile']['mail'] = $mail;
+      $_SESSION['quicksign_show'] = FALSE;
+      drupal_set_message(t("We're sorry, we did not find an account with the email address !mail. Please fill out the full form. Next time you will be able to submit using just your email address.", array('!mail' => $mail)));
+      drupal_redirect_form($form_state);
+    }
+
+    // Compile list of webform required fields.
+    $required_fields = sba_quicksign_get_required_fields($node);
+    // Compare profile to required fields via the Webform User field map.
+    $map = webform_user_user_map($node->nid);
+    $required_non_profile_fields = array_diff($required_fields, $map);
+    $missing_non_profile_fields = FALSE;
+    foreach ($required_non_profile_fields as $form_key) {
+      if (empty($form_state['values']['submitted'][$form_key])) {
+        $missing_non_profile_fields = TRUE;
       }
-      else {
-        // Special handling for mail
-        $profile['mail'] = $mail;
-      }
+    }
+
+    $missing_fields = FALSE;
+    $profile = array();
+    $count_profile_required = 0;
+    foreach ($map as $webform_field => $profile_field) {
 
       if (in_array($webform_field, $required_fields)) {
-        if (empty($profile[$webform_field])) {
-          // One or more required fields are missing.
-          $profile[$webform_field] = '';
-          $missing_fields = TRUE;
+        $count_profile_required++;
+      }
+
+      if (!empty($form_state['values']['submitted'][$profile_field])) {
+        $profile[$webform_field] = $form_state['values']['submitted'][$profile_field];
+      }
+      else {
+        if ($webform_field != 'mail') {
+          $items = field_get_items('user', $account, $profile_field);
+          $profile[$webform_field] = !empty($items[0]['value']) ? $items[0]['value'] : FALSE;
+        }
+        else {
+          // Special handling for mail
+          $profile['mail'] = $mail;
+        }
+
+        if (in_array($webform_field, $required_fields)) {
+          if (empty($profile[$webform_field])) {
+            // One or more required fields are missing.
+            $profile[$webform_field] = '';
+            $missing_fields = TRUE;
+          }
         }
       }
     }
-  }
-  if ($missing_fields || $missing_non_profile_fields) {
-    $_SESSION['sba_quicksign']['profile'] = $profile;
-    drupal_set_message(t("Unfortunately, we don't have enough information. Please complete the form below."));
-    drupal_redirect_form($form_state);
-  }
+    if ($missing_fields || $missing_non_profile_fields) {
+      $_SESSION['sba_quicksign']['profile'] = $profile;
 
-  // If everything has gone smoothly to this point package up the
-  // loaded profile and pass it off for use during the submit callback.
-  $form_state['node'] = $node;
-  $_SESSION['sba_quicksign'] = TRUE;
-  _sba_quicksign_build_values($form, $form_state, $node, $profile);
+      drupal_set_message(t("Unfortunately, we don't have enough information. Please complete the form below."));
+      $_SESSION['quicksign_show'] = FALSE;
+      drupal_redirect_form($form_state);
+    }
+
+    $_SESSION['quicksign_show'] = TRUE;
+
+    // If everything has gone smoothly to this point package up the
+    // loaded profile and pass it off for use during the submit callback.
+    $form_state['node'] = $node;
+    $_SESSION['sba_quicksign'] = TRUE;
+    _sba_quicksign_build_values($form, $form_state, $node, $profile);
+  }
+  else {
+    unset($_SESSION['sba_quicksign']);
   }
 }
 
@@ -220,6 +265,8 @@ function _sba_quicksign_build_values(&$form, &$form_state, $node, $profile) {
     $form_state['complete form']['submitted'][$key]['#value'] = $value;
   }
   unset($_SESSION['sba_quicksign']);
+  unset($_SESSION['quicksign_show']);
+
 }
 
 /**
@@ -284,21 +331,11 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
       '#default_value' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : 'Already a supporter?',
     );
 
-    $form['sba_quicksign']['show_submit_button'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Use a separate submit button'),
-      '#description' => t('Useful if the quicksign field is placed at the top of the form.'),
-      '#default_value' => isset($settings['show_submit_button']) ? $settings['show_submit_button'] : 1,
-    );
-
     $form['sba_quicksign']['quicksign_button_text'] = array(
       '#type' => 'textfield',
       '#title' => t('Submit button text'),
       '#description' => t('Change the text on the quick sign form submit button.'),
       '#default_value' => isset($settings['quicksign_button_text']) ? $settings['quicksign_button_text'] : t('Sign now'),
-      '#states' => array(
-        'visible' => array(':input[name="show_submit_button"]' => array('checked' => TRUE)),
-      ),
     );
 
     $default_desc = $node->type == 'sba_message_action' ? t('If we already have your information, just enter your email address and click to send this message now.') : t('If we already have your information, just enter your email address and click to sign this petition now.');
@@ -309,19 +346,9 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
       '#default_value' => isset($settings['quicksign_description']) ? $settings['quicksign_description'] : $default_desc,
       '#format' => isset($settings['quicksign_description_format']) ? $settings['quicksign_description_format'] : NULL,
     );
-
   }
 }
 
-/**
- * @param $form
- * @param $form_state
- * @return mixed
- */
-function sba_quicksign_after_build($form, $form_state) {
-  $form['#attached']['js'][] = drupal_get_path('module', 'sba_quicksign') . '/js/sba_quicksign.js';
-  return $form;
-}
 
 /**
  * Implements hook_node_insert().
@@ -391,7 +418,6 @@ function sba_quicksign_save($node) {
     'form_label' => $node->quicksign_label,
     'form_description' => $node->quicksign_description['value'],
     'form_description_format' => $node->quicksign_description['format'],
-    'show_submit_button' => $node->show_submit_button,
     'submit_button_text' => $node->quicksign_button_text,
   );
   drupal_write_record('sba_quicksign', $record);
@@ -447,7 +473,6 @@ function sba_quicksign_settings($nid) {
       form_label AS quicksign_label,
       form_description AS quicksign_description,
       form_description_format AS quicksign_description_format,
-      show_submit_button AS show_submit_button,
       submit_button_text AS quicksign_button_text
      FROM {sba_quicksign}
      WHERE nid = :nid;', array(':nid' => $nid));
@@ -604,7 +629,6 @@ function sba_quicksign_element_process_text_format($element) {
     unset($element['#description']);
     $element['format']['#collapsible'] = TRUE;
     $element['format']['#collapsed'] = TRUE;
-    //$element['format']['#suffix'] = '<div class="text-format-spacer">&nbsp;</div>';
     $element['format']['#title'] = t('Text format');
   }
   return $element;

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -84,7 +84,7 @@ function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
             unset($_SESSION['sba_quicksign']);
           }
           else {
-            if (!isset($_SESSION['quicksign_show']) || $_SESSION['quicksign_show'] == TRUE || $_SESSION['quicksign_show'] == FALSE) {
+            if (!isset($_SESSION['quicksign_show']) || $_SESSION['quicksign_show'] == TRUE) {
               $quicksign_field = &_webform_user_find_field($form, $component_hierarchy['sba_quicksign']);
               $quicksign_field['children'] = sba_quicksign_form();
               $quicksign_field['children']['#weight'] = 1001;
@@ -161,16 +161,24 @@ function sba_quicksign_form() {
  */
 function sba_quicksign_form_validate(&$form, &$form_state) {
   $parents = array_flip($form_state['triggering_element']['#parents']);
-  if (isset($parents['sba_quicksign'])) {
+  $node = node_load($form_state['values']['details']['nid']);
+  $components = $node->webform['components'];
+  $component_hierarchy = __webform_user_parse_components($node->nid, $components);
+  $qsign_value =_sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy['sba_quicksign']);
+  $quicksign_field = &_webform_user_find_field($form, $component_hierarchy['sba_quicksign']);
+
+  if (!isset($parents['sba_quicksign'])) {
+      // Quicksign button was not clicked.
+      if (isset($_SESSION['sba_quicksign'])) {
+        unset($_SESSION['sba_quicksign']);
+      }
+      form_set_value($quicksign_field, '', $form_state);
+  }
+  else {
     $_SESSION['quicksign_show'] = TRUE;
     // Make webform believe that we clicked the webform submit button.
     $form_state['values']['op'] = $form['actions']['submit']['#value'];
-    $node = node_load($form_state['values']['details']['nid']);
-    $components = $node->webform['components'];
-    $component_hierarchy = __webform_user_parse_components($node->nid, $components);
     // Validate mail field.
-    $qsign_value = _sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy['sba_quicksign']);
-
     $mail = isset($qsign_value['children']['qsign']['quicksign_mail']) ? $qsign_value['children']['qsign']['quicksign_mail'] : FALSE;
     if (!$mail) {
       return;
@@ -202,7 +210,7 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
     $missing_non_profile_fields = FALSE;
 
     foreach ($required_non_profile_fields as $form_key) {
-     $field =  _sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy[$form_key]);
+     $field = _sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy[$form_key]);
       if (empty($field)) {
         $missing_non_profile_fields = TRUE;
       }
@@ -211,7 +219,7 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
     $missing_fields = FALSE;
     $profile = array();
     foreach ($map as $webform_field => $profile_field) {
-      $field_value = _sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy[$webform_field]);
+      $field_value =_sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy[$webform_field]);
       if (!empty($field_value)) {
         $profile[$webform_field] = $field_value;
       }
@@ -249,11 +257,6 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
     $form_state['node'] = $node;
     $_SESSION['sba_quicksign'] = TRUE;
     _sba_quicksign_build_values($form, $form_state, $node, $profile);
-  }
-  else {
-    // Quicksign button was not clicked.
-    unset($_SESSION['sba_quicksign']);
-    unset($qsign_value);
   }
 }
 

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -1,6 +1,9 @@
 <?php
 
 
+/**
+ * @return array
+ */
 function sba_quicksign_webform_component_info() {
   $components = array();
   $components['sba_quicksign'] = array(
@@ -38,12 +41,12 @@ function sba_quicksign_views_api() {
  */
 function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
   global $user;
-    if (strpos($form_id, 'webform_client') !== FALSE && arg(2) != 'submission' && arg(4) != 'edit') {
-      // Quicksign content type.
-      if (isset($form['#node']) && sba_quicksign_is_quicksign_type($form['#node']->type)) {
-        $node = $form['#node'];
-        if (empty($user->uid) || user_access('create ' . $node->type . ' content')) {
-          // Quicksign enabled.
+  if (strpos($form_id, 'webform_client') !== FALSE && arg(2) != 'submission' && arg(4) != 'edit') {
+    // Quicksign content type.
+    if (isset($form['#node']) && sba_quicksign_is_quicksign_type($form['#node']->type)) {
+      $node = $form['#node'];
+      if (empty($user->uid) || user_access('create ' . $node->type . ' content')) {
+        // Quicksign enabled.
         if (sba_quicksign_is_enabled($node)) {
           // Check for errors in quicksign form submission
           // If present attempt to set Webform fields with
@@ -120,6 +123,8 @@ function sba_quicksign_form() {
  * @param $form_state
  */
 function sba_quicksign_form_validate(&$form, &$form_state) {
+  if (in_array('sba_quicksign', $form_state['clicked_button']['#parents'])) {
+
 
   // Make webform believe that we clicked the webform submit button.
   $form_state['values']['op'] = $form['actions']['submit']['#value'];
@@ -149,10 +154,23 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
   $required_fields = sba_quicksign_get_required_fields($node);
   // Compare profile to required fields via the Webform User field map.
   $map = webform_user_user_map($node->nid);
+  $required_non_profile_fields = array_diff($required_fields, $map);
+  $missing_non_profile_fields = FALSE;
+  foreach ($required_non_profile_fields as $form_key) {
+    if (empty($form_state['values']['submitted'][$form_key])) {
+      $missing_non_profile_fields = TRUE;
+    }
+  }
+
   $missing_fields = FALSE;
   $profile = array();
-
+  $count_profile_required = 0;
   foreach ($map as $webform_field => $profile_field) {
+
+    if (in_array($webform_field, $required_fields)) {
+      $count_profile_required++;
+    }
+
     if (!empty($form_state['values']['submitted'][$profile_field])) {
       $profile[$webform_field] = $form_state['values']['submitted'][$profile_field];
     }
@@ -166,17 +184,18 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
         $profile['mail'] = $mail;
       }
 
-      if (in_array($webform_field, $required_fields) && empty($profile[$webform_field])) {
-        // One or more required fields are missing.
-        $profile[$webform_field] = '';
-        $missing_fields = TRUE;
+      if (in_array($webform_field, $required_fields)) {
+        if (empty($profile[$webform_field])) {
+          // One or more required fields are missing.
+          $profile[$webform_field] = '';
+          $missing_fields = TRUE;
+        }
       }
     }
   }
-
-  if ($missing_fields) {
+  if ($missing_fields || $missing_non_profile_fields) {
     $_SESSION['sba_quicksign']['profile'] = $profile;
-    drupal_set_message(t("Unfortunately, we don't have enough information. Please complete the additional forms below. Next time you will be able to sign using just your email address."));
+    drupal_set_message(t("Unfortunately, we don't have enough information. Please complete the form below."));
     drupal_redirect_form($form_state);
   }
 
@@ -185,7 +204,7 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
   $form_state['node'] = $node;
   $_SESSION['sba_quicksign'] = TRUE;
   _sba_quicksign_build_values($form, $form_state, $node, $profile);
-
+  }
 }
 
 /**
@@ -197,8 +216,8 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
 function _sba_quicksign_build_values(&$form, &$form_state, $node, $profile) {
   $quick_values = sba_quicksign_values_tree_build($profile, $node->webform['components'], $tree, 0);
   foreach ($quick_values as $key => $value) {
-      form_set_value($form['submitted'][$key],  $value, $form_state);
-      $form_state['complete form']['submitted'][$key]['#value'] = $value;
+    form_set_value($form['submitted'][$key],  $value, $form_state);
+    $form_state['complete form']['submitted'][$key]['#value'] = $value;
   }
   unset($_SESSION['sba_quicksign']);
 }
@@ -279,7 +298,7 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
       '#default_value' => isset($settings['quicksign_button_text']) ? $settings['quicksign_button_text'] : t('Sign now'),
       '#states' => array(
         'visible' => array(':input[name="show_submit_button"]' => array('checked' => TRUE)),
-        ),
+      ),
     );
 
     $default_desc = $node->type == 'sba_message_action' ? t('If we already have your information, just enter your email address and click to send this message now.') : t('If we already have your information, just enter your email address and click to sign this petition now.');
@@ -291,12 +310,14 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
       '#format' => isset($settings['quicksign_description_format']) ? $settings['quicksign_description_format'] : NULL,
     );
 
-
-    // No validation or submit handlers, we'll handle this during
-    // hook_node_insert() and hook_node_update().
   }
 }
 
+/**
+ * @param $form
+ * @param $form_state
+ * @return mixed
+ */
 function sba_quicksign_after_build($form, $form_state) {
   $form['#attached']['js'][] = drupal_get_path('module', 'sba_quicksign') . '/js/sba_quicksign.js';
   return $form;
@@ -327,13 +348,10 @@ function sba_quicksign_node_update($node) {
     }
 
     if (isset($node->quicksign_enabled)) {
-
       sba_quicksign_save($node);
-
       if (!empty($node->quicksign_enabled) && !$has_component) {
         sba_quicksign_insert_components($node, 'update');
       }
-
       if (empty($node->quicksign_enabled) && $has_component) {
         sba_quicksign_delete_components($node, $cid);
       }
@@ -350,6 +368,9 @@ function sba_quicksign_node_delete($node) {
   }
 }
 
+/**
+ * @param $component
+ */
 function sba_quicksign_webform_component_delete($component) {
   if ($component['form_key'] == 'sba_quicksign') {
     sba_quicksign_delete($component['nid']);
@@ -384,8 +405,8 @@ function sba_quicksign_save($node) {
  */
 function sba_quicksign_delete($nid) {
   db_delete('sba_quicksign')
-            ->condition('nid', $nid, '=')
-            ->execute();
+    ->condition('nid', $nid, '=')
+    ->execute();
 }
 
 /**
@@ -413,6 +434,8 @@ function sba_quicksign_is_enabled($node) {
 }
 
 /**
+ * Grab the node's quicksign settings.
+ *
  * @param $nid
  * @return mixed
  */
@@ -442,9 +465,6 @@ function sba_quicksign_settings($nid) {
  */
 function sba_quicksign_get_required_fields($node) {
   $required_fields = array();
-  // TODO: we may need to convert to rendering component form api arrays
-  // and then processing those, will need to test all commonly available
-  // component types to confirm this approach works.
   if (is_object($node) && isset($node->webform['components'])) {
     foreach ($node->webform['components'] as $cid => $component) {
       if ($component['type'] != 'hidden' && $component['mandatory'] == 1) {
@@ -488,6 +508,12 @@ function sba_quicksign_is_quicksign_type($type) {
   return $quicksign;
 }
 
+/**
+ * Insert a quicksign component.
+ *
+ * @param $node
+ * @param $op
+ */
 function sba_quicksign_insert_components($node, $op) {
   module_load_include('inc', 'webform', 'includes/webform.components');
 
@@ -495,7 +521,7 @@ function sba_quicksign_insert_components($node, $op) {
     'nid' => $node->nid,
     'form_key' => 'sba_quicksign',
     'pid' => 0,
-    'name' => $node->quicksign_label,
+    'name' => 'Quicksign Form',
     'type' => 'markup',
     'weight' => -100,
     'email' => 0,
@@ -522,10 +548,22 @@ function sba_quicksign_insert_components($node, $op) {
   }
 }
 
+/**
+ * Delete the quicksign component when the quicksign option
+ * is unchecked on the node add/edit form.
+ *
+ * @param $node
+ * @param $cid
+ */
 function sba_quicksign_delete_components($node, $cid) {
   webform_component_delete($node, $node->webform['components'][$cid]);
 }
 
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Disable editing of our faux-component.
+ */
 function sba_quicksign_form_webform_component_edit_form_alter(&$form, &$form_state, $form_id) {
   if ($form['form_key']['#default_value'] == 'sba_quicksign') {
     $form['form_key']['#disabled'] = TRUE;
@@ -536,8 +574,14 @@ function sba_quicksign_form_webform_component_edit_form_alter(&$form, &$form_sta
     $form['actions']['#access'] = FALSE;
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Make sure that quicksign can only be added from the node add/edit form.
+ */
 function sba_quicksign_form_webform_components_form_alter(&$form, &$form_state, $form_id) {
-    unset($form['add']['type']['#options']['sba_quicksign']);
+  unset($form['add']['type']['#options']['sba_quicksign']);
 }
 
 /**
@@ -547,6 +591,12 @@ function sba_quicksign_element_info_alter(&$type) {
   $type['text_format']['#process'][] = 'sba_quicksign_element_process_text_format';
 }
 
+/**
+ * Collapse the quicksign description formatter fieldset.
+ *
+ * @param $element
+ * @return mixed
+ */
 function sba_quicksign_element_process_text_format($element) {
   if (in_array('quicksign_description', $element['#parents'])) {
     $prefix = isset($element['format']['#prefix']) ? $element['format']['#prefix'] : '';

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -10,6 +10,36 @@ function sba_quicksign_views_api() {
 }
 
 /**
+ * Implements hook_form_alter().
+ */
+function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
+  if (strpos($form_id, 'webform_client') !== FALSE && arg(2) != 'submission' && arg(4) != 'edit') {
+    // Quicksign content type.
+    if (isset($form['#node']) && sba_quicksign_is_quicksign_type($form['#node']->type)) {
+      $node = $form['#node'];
+      // Quicksign enabled.
+      if (sba_quicksign_is_enabled($node)) {
+        // Check for errors in quicksign form submission
+        // If present attempt to set Webform fields with
+        // profile values from prior submission.
+        $profile = !empty($_SESSION['sba_quicksign']['profile']) ? $_SESSION['sba_quicksign']['profile'] : FALSE;
+        if ($profile) {
+          sba_quicksign_form_defaults($form, $node, $profile);
+          if(count($_SESSION['sba_quicksign']['profile']) > 1 ) {
+            $form['#after_build'][] = 'sba_quicksign_after_build';
+          }
+          unset($_SESSION['sba_quicksign']);
+        }
+
+        $form['quicksign'] = sba_quicksign_form();
+        $form['quicksign']['#weight'] = 1001;
+        array_unshift($form['#validate'], 'sba_quicksign_form_validate');
+      }
+    }
+  }
+}
+
+/**
  * Quick sign form.
  */
 function sba_quicksign_form() {
@@ -19,22 +49,11 @@ function sba_quicksign_form() {
   $description_format = isset($settings['quicksign_description_format']) ? $settings['quicksign_description_format'] : NULL;
 
   $form = array();
-  if ($node->type != 'springboard_petition') {
-    $form['qsign'] = array(
-      '#type' => 'fieldset',
-      '#title' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
-    );
-  }
-  else {
-    $form['qsign'] = array(
-      '#type' => 'container',
-    );
-    $form['qsign']['quicksign_label'] = array(
-      '#markup' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
-      '#prefix' => '<h2 class="quicksign-label">',
-      '#suffix' => '</h2>',
-    );
-  }
+
+  $form['qsign'] = array(
+    '#type' => 'fieldset',
+    '#title' => isset($settings['quicksign_label']) ? $settings['quicksign_label'] : '',
+  );
 
   $form['qsign']['quicksign_description'] = array(
     '#markup' => isset($settings['quicksign_description']) ? check_markup($settings['quicksign_description'], $description_format) : '',
@@ -58,8 +77,6 @@ function sba_quicksign_form() {
     '#value' => isset($settings['quicksign_button_text']) ? check_plain($settings['quicksign_button_text']) : '',
   );
 
-  $form['#validate'][] = 'sba_quicksign_form_validate';
-  $form['#submit'][] = 'sba_quicksign_form_submit';
   return $form;
 }
 
@@ -71,10 +88,19 @@ function sba_quicksign_form() {
  * @param $form_state
  */
 function sba_quicksign_form_validate(&$form, &$form_state) {
+
+  // Make webform believe that we clicked the webform submit button.
+  $form_state['values']['op'] = $form['actions']['submit']['#value'];
+
   // Validate mail field.
   $mail = isset($form_state['values']['quicksign_mail']) ? $form_state['values']['quicksign_mail'] : FALSE;
+
+  if (!$mail) {
+    return;
+  }
+
   if (!valid_email_address($mail)) {
-    form_set_error('quicksign_mail', t('The email addressed entered is not valid.'));
+    form_set_error('quicksign_mail', t('The quicksign email address entered is not valid.'));
     return;
   }
 
@@ -94,20 +120,22 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
   $map = webform_user_user_map($node->nid);
   $missing_fields = FALSE;
   $profile = array();
+
   foreach ($map as $webform_field => $profile_field) {
-    if ($webform_field != 'mail') {
-      $items = field_get_items('user', $account, $profile_field);
-      $profile[$webform_field] = !empty($items[0]['value']) ? $items[0]['value'] : FALSE;
+    if (!empty($form_state['values']['submitted'][$profile_field])) {
+      $profile[$webform_field] = $form_state['values']['submitted'][$profile_field];
     }
     else {
-    // Special handling for mail
-      $profile['mail'] = $mail;
-    }
-    if (in_array($webform_field, $required_fields) && empty($profile[$webform_field])) {
-      if (!empty($items[0]['value'])) {
-        $profile[$webform_field] = $items[0]['value'];
+      if ($webform_field != 'mail') {
+        $items = field_get_items('user', $account, $profile_field);
+        $profile[$webform_field] = !empty($items[0]['value']) ? $items[0]['value'] : FALSE;
       }
       else {
+        // Special handling for mail
+        $profile['mail'] = $mail;
+      }
+
+      if (in_array($webform_field, $required_fields) && empty($profile[$webform_field])) {
         // One or more required fields are missing.
         $profile[$webform_field] = '';
         $missing_fields = TRUE;
@@ -129,25 +157,56 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
   // If everything has gone smoothly to this point package up the
   // loaded profile and pass it off for use during the submit callback.
   $form_state['node'] = $node;
-  $form_state['sba_quicksign']['profile'] = $profile;
-  // No validation errors, set quicksign flag in session so we can pick this up
-  // in webform submission insert hook.
   $_SESSION['sba_quicksign'] = TRUE;
+  _sba_quicksign_build_values($form, $form_state, $node, $profile);
+
 }
 
+/**
+ * @param $form
+ * @param $original_form_state
+ * @param $node
+ * @param $submission
+ */
+function _sba_quicksign_build_values(&$form, &$form_state, $node, $profile) {
+  $quick_values = sba_quicksign_values_tree_build($profile, $node->webform['components'], $tree, 0);
+  foreach ($quick_values as $key => $value) {
+      form_set_value($form['submitted'][$key],  $value, $form_state);
+      $form_state['complete form']['submitted'][$key]['#value'] = $value;
+  }
+  unset($_SESSION['sba_quicksign']);
+}
 
 /**
- * Submit callback for quicksign form.
+ * Build the webform submission tree.
  *
- * @param $form
- * @param $form_state
+ * @param $profile
+ *   Associative array of webform component form keys and their values.
+ * @param $src
+ *   Webform components organized by component id.
+ * @param $tree
+ *   Output storage.
+ * @param $parent
+ *   Parent component (if any).
+ *
+ * @return mixed
+ *   Returns the submitted values in a tree structure that Webform can parse.
  */
-function sba_quicksign_form_submit($form, &$form_state) {
-  $node = $form_state['node'];
-  $profile = isset($form_state['sba_quicksign']['profile']) ? $form_state['sba_quicksign']['profile'] : FALSE;
-  if ($profile) {
-    _sba_quicksign_build_submission($form, $form_state, $node, $profile);
+function sba_quicksign_values_tree_build($profile, $src, &$tree, $parent) {
+
+  foreach ($src as $cid => $component) {
+    if ($component['pid']) {
+      $parent_key = $src[$component['pid']]['form_key'];
+      if (!isset($tree[$parent_key])) {
+        $tree[$parent_key] = array();
+      }
+      $tree[$parent_key][$component['form_key']] = isset($profile[$component['form_key']]) ? $profile[$component['form_key']] : NULL;
+    }
+    else {
+      $tree[$component['form_key']] = isset($profile[$component['form_key']]) ? $profile[$component['form_key']] : NULL;
+    }
   }
+  return $tree;
 }
 
 
@@ -158,7 +217,6 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
   // Modify the options on a specific instance of this node type.
   $node = isset($form['#node']) ? $form['#node'] : FALSE;
   if (isset($node->type) && sba_quicksign_is_quicksign_type($node->type)) {
-    // TODO: refactor this out.
     $node->quicksign_enabled = sba_quicksign_is_enabled($node);
     $settings = isset($node->nid) ? sba_quicksign_settings($node->nid) : array();
     $form['sba_quicksign'] = array(
@@ -199,32 +257,6 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
     );
     // No validation or submit handlers, we'll handle this during
     // hook_node_insert() and hook_node_update().
-  }
-}
-
-/**
- * Implements hook_form_alter().
- */
-function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
-  if (strpos($form_id, 'webform_client') !== FALSE && arg(2) != 'submission' && arg(4) != 'edit') {
-    // Quicksign content type.
-    if (isset($form['#node']) && sba_quicksign_is_quicksign_type($form['#node']->type)) {
-      $node = $form['#node'];
-      // Quicksign enabled.
-      if (sba_quicksign_is_enabled($node)) {
-        // Check for errors in quicksign form submission
-        // If present attempt to set Webform fields with
-        // profile values from prior submission.
-        $profile = !empty($_SESSION['sba_quicksign']['profile']) ? $_SESSION['sba_quicksign']['profile'] : FALSE;
-        if ($profile) {
-          sba_quicksign_form_defaults($form, $node, $profile);
-          if(count($_SESSION['sba_quicksign']['profile']) > 1 ) {
-            $form['#after_build'][] = 'sba_quicksign_after_build';
-          }
-          unset($_SESSION['sba_quicksign']);
-        }
-      }
-    }
   }
 }
 
@@ -302,20 +334,6 @@ function sba_quicksign_node_delete($node) {
     sba_quicksign_delete($node->nid);
   }
 }
-
-
-/**
- * Implements hook_node_view().
- */
-function sba_quicksign_node_view($node, $view_mode, $langcode) {
-  if (sba_quicksign_is_quicksign_type($node->type)) {
-    if (sba_quicksign_is_enabled($node)) {
-      $node->content['sba_quicksign'] = drupal_get_form('sba_quicksign_form');
-      $node->content['sba_quicksign']['#weight'] = 1000;
-    }
-  }
-}
-
 
 /**
  * Save quick sign settings per-node.
@@ -415,94 +433,6 @@ function sba_quicksign_get_required_fields($node) {
 }
 
 /**
- * @param $form
- * @param $original_form_state
- * @param $node
- * @param $submission
- */
-function _sba_quicksign_build_submission($form, &$original_form_state, $node, $submission) {
-  $submit_text = $node->content['webform']['#form']['actions']['submit']['#value']; // sketchy.
-  $form_id = 'webform_client_form_' . $node->nid;
-  $form_state['webform_completed'] = 1;
-  $form_state['values'] = array(
-    'submit' => $submit_text,
-    'op' => $submit_text,
-    'details' => array(
-      'nid' => $node->nid,
-      'sid' => '',
-      'uid' => 0,
-      'page_num' => 1,
-      'page_count' => 1,
-      'finished' => 0,
-    ),
-    'values' => array(),
-  );
-  $form_state['clicked_button']['#parents'] = NULL;
-  $tree = array();
-  $form_state['values']['submitted'] = sba_quicksign_submission_tree_build($submission, $node->webform['components'], $tree, 0);
-  $webform_submission = array(
-    'nid' => $node->nid,
-    'uid' => 0,
-    'submitted' => time(),
-    'remote_addr' => ip_address(),
-    'data' => array(),
-  );
-  foreach ($node->webform['components'] as $cid => $component) {
-    if ($component['type'] != 'fieldset') {
-      $fields[] = $component['form_key'];
-      if (isset($submission[$component['form_key']]) && !is_array($submission[$component['form_key']])) {
-        $webform_submission['data'][$cid]['value'][] = $submission[$component['form_key']];
-      }
-      elseif (isset($submission[$component['form_key']])) {
-        $webform_submission['data'][$cid]['value'] = $submission[$component['form_key']];
-      }
-      else {
-        // Backfill with null data to match what Webform does.
-        $webform_submission['data'][$cid]['value'][] = '';
-      }
-    }
-  }
-  drupal_form_submit($form_id, $form_state, $node, $webform_submission);
-  unset($_SESSION['sba_quicksign']);
-  // Pass through webform's version of $form_state['redirect']
-  // This ensures form submission redirects correctly even though we
-  // are processing a different form.
-  $original_form_state['redirect'] = $form_state['redirect'];
-}
-
-/**
- * Build the webform submission tree.
- *
- * @param $submission
- *   Associative array of webform component form keys and their values.
- * @param $src
- *   Webform components organized by component id.
- * @param $tree
- *   Output storage.
- * @param $parent
- *   Parent component (if any).
- *
- * @return mixed
- *   Returns the submitted values in a tree structure that Webform can parse.
- */
-function sba_quicksign_submission_tree_build($submission, $src, &$tree, $parent) {
-
-  foreach ($src as $cid => $component) {
-    if ($component['pid']) {
-      $parent_key = $src[$component['pid']]['form_key'];
-      if (!isset($tree[$parent_key])) {
-        $tree[$parent_key] = array();
-      }
-      $tree[$parent_key][$component['form_key']] = isset($submission[$component['form_key']]) ? $submission[$component['form_key']] : NULL;
-    }
-    else {
-      $tree[$component['form_key']] = isset($submission[$component['form_key']]) ? $submission[$component['form_key']] : NULL;
-    }
-  }
-  return $tree;
-}
-
-/**
  * Implements hook_webform_submission_insert().
  */
 function sba_quicksign_webform_submission_insert($node, $submission) {
@@ -527,7 +457,7 @@ function sba_quicksign_webform_submission_insert($node, $submission) {
  *   $type
  */
 function sba_quicksign_is_quicksign_type($type) {
-  $types = array('springboard_petition');
+  $types = array('springboard_petition', 'sba_social_action', 'sba_message_action');
   $quicksign = FALSE;
   if (in_array($type, $types)) {
     $quicksign = TRUE;

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -13,27 +13,31 @@ function sba_quicksign_views_api() {
  * Implements hook_form_alter().
  */
 function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
-  if (strpos($form_id, 'webform_client') !== FALSE && arg(2) != 'submission' && arg(4) != 'edit') {
-    // Quicksign content type.
-    if (isset($form['#node']) && sba_quicksign_is_quicksign_type($form['#node']->type)) {
-      $node = $form['#node'];
-      // Quicksign enabled.
-      if (sba_quicksign_is_enabled($node)) {
-        // Check for errors in quicksign form submission
-        // If present attempt to set Webform fields with
-        // profile values from prior submission.
-        $profile = !empty($_SESSION['sba_quicksign']['profile']) ? $_SESSION['sba_quicksign']['profile'] : FALSE;
-        if ($profile) {
-          sba_quicksign_form_defaults($form, $node, $profile);
-          if(count($_SESSION['sba_quicksign']['profile']) > 1 ) {
-            $form['#after_build'][] = 'sba_quicksign_after_build';
+  global $user;
+  if (empty($user->uid)) {
+    if (strpos($form_id, 'webform_client') !== FALSE && arg(2) != 'submission' && arg(4) != 'edit') {
+      // Quicksign content type.
+      if (isset($form['#node']) && sba_quicksign_is_quicksign_type($form['#node']->type)) {
+        $node = $form['#node'];
+        // Quicksign enabled.
+        if (sba_quicksign_is_enabled($node)) {
+          // Check for errors in quicksign form submission
+          // If present attempt to set Webform fields with
+          // profile values from prior submission.
+          $profile = !empty($_SESSION['sba_quicksign']['profile']) ? $_SESSION['sba_quicksign']['profile'] : FALSE;
+          if ($profile) {
+            sba_quicksign_form_defaults($form, $form_state, $node, $profile);
+            if (count($_SESSION['sba_quicksign']['profile']) > 1) {
+              $form['#after_build'][] = 'sba_quicksign_after_build';
+            }
+            unset($_SESSION['sba_quicksign']);
           }
-          unset($_SESSION['sba_quicksign']);
+          else {
+            $form['quicksign'] = sba_quicksign_form();
+            $form['quicksign']['#weight'] = 1001;
+            array_unshift($form['#validate'], 'sba_quicksign_form_validate');
+          }
         }
-
-        $form['quicksign'] = sba_quicksign_form();
-        $form['quicksign']['#weight'] = 1001;
-        array_unshift($form['#validate'], 'sba_quicksign_form_validate');
       }
     }
   }
@@ -145,12 +149,7 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
 
   if ($missing_fields) {
     $_SESSION['sba_quicksign']['profile'] = $profile;
-    if ($node->type == 'sba_message_action') {
-      drupal_set_message(t("Unfortunately, we don't have enough information to submit your message. Please complete the additional forms below. Next time you will be able to sign using just your email address."));
-    }
-    else {
-      drupal_set_message(t("Unfortunately, we don't have enough information to submit your petition. Please complete the additional forms below. Next time you will be able to sign using just your email address."));
-    }
+    drupal_set_message(t("Unfortunately, we don't have enough information. Please complete the additional forms below. Next time you will be able to sign using just your email address."));
     drupal_redirect_form($form_state);
   }
 
@@ -275,7 +274,7 @@ function sba_quicksign_after_build($form, $form_state) {
  * @param array|bool $user_data
  *   User profile data to use during substitution.
  */
-function sba_quicksign_form_defaults(&$form, $node, $user_data) {
+function sba_quicksign_form_defaults(&$form, &$form_state, $node, $user_data) {
   $components = $node->webform['components'];
   $component_hierarchy = __webform_user_parse_components($node->nid, $components);
   $map = webform_user_user_map($node->nid);

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -53,7 +53,7 @@ function sba_quicksign_views_api() {
 /**
  * Implements hook_form_alter().
  */
-function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
+function sba_quicksign_form_alter(&$form, &$form_state, $form_id) {
   global $user;
   if (strpos($form_id, 'webform_client') !== FALSE && arg(2) != 'submission' && arg(4) != 'edit') {
     if (isset($form['#node']) && sba_quicksign_is_quicksign_type($form['#node']->type)) {
@@ -200,7 +200,7 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
       $_SESSION['sba_quicksign']['profile']['mail'] = $mail;
       $_SESSION['quicksign_show'] = FALSE;
       drupal_set_message(t("We're sorry, we did not find an account with the email address !mail. Please fill out the full form.", array('!mail' => $mail)));
-      drupal_redirect_form($form_state);
+      //drupal_redirect_form($form_state);
     }
 
     // Compile list of webform required fields.
@@ -248,16 +248,18 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
 
       drupal_set_message(t("Unfortunately, we don't have enough information. Please complete the form below."));
       $_SESSION['quicksign_show'] = FALSE;
-      drupal_redirect_form($form_state);
+      //drupal_redirect_form($form_state);
     }
 
-    $_SESSION['quicksign_show'] = TRUE;
+    if ($account && (!$missing_fields && !$missing_non_profile_fields)) {
+      $_SESSION['quicksign_show'] = TRUE;
 
-    // If everything has gone smoothly to this point package up the
-    // loaded profile and pass it off for use during the submit callback.
-    $form_state['node'] = $node;
-    $_SESSION['sba_quicksign'] = TRUE;
-    _sba_quicksign_build_values($form, $form_state, $node, $profile);
+      // If everything has gone smoothly to this point package up the
+      // loaded profile and pass it off for use during the submit callback.
+      $form_state['node'] = $node;
+      $_SESSION['sba_quicksign'] = TRUE;
+      _sba_quicksign_build_values($form, $form_state, $node, $profile);
+    }
   }
 }
 

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -63,6 +63,7 @@ function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
           $components = $node->webform['components'];
           $component_hierarchy = __webform_user_parse_components($node->nid, $components);
           $profile = !empty($_SESSION['sba_quicksign']['profile']) ? $_SESSION['sba_quicksign']['profile'] : FALSE;
+          $form['#submit'][] = 'sba_quicksign_form_submit';
 
           if ($profile) {
             $form['#after_build'][] = 'sba_quicksign_after_build';
@@ -321,6 +322,9 @@ function sba_quicksign_values_tree_build($profile, $src, &$tree, $parent) {
   return $tree;
 }
 
+function sba_quicksign_form_submit($for, $form_state) {
+  $_SESSION['quicksign_show'] = TRUE;
+}
 
 /**
  * Implements hook_form_BASE_FORM_ID_alter().

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -627,7 +627,7 @@ function sba_quicksign_element_process_text_format($element) {
     $parents = array_flip($element['#array_parents']);
     if (isset($parents['sba_quicksign'])) {
       $prefix = isset($element['format']['#prefix']) ? $element['format']['#prefix'] : '';
-      $element['format']['#prefix'] = '<div class="quicksign-description">' . $element['#description'] . '</div>' . $prefix;
+      $element['format']['#prefix'] = '<div class="node-form-quicksign-description">' . $element['#description'] . '</div>' . $prefix;
       unset($element['#description']);
       $element['format']['#collapsible'] = TRUE;
       $element['format']['#collapsed'] = TRUE;

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -623,13 +623,16 @@ function sba_quicksign_element_info_alter(&$type) {
  * @return mixed
  */
 function sba_quicksign_element_process_text_format($element) {
-  if (in_array('quicksign_description', $element['#parents'])) {
-    $prefix = isset($element['format']['#prefix']) ? $element['format']['#prefix'] : '';
-    $element['format']['#prefix'] = $element['#description'] . $prefix;
-    unset($element['#description']);
-    $element['format']['#collapsible'] = TRUE;
-    $element['format']['#collapsed'] = TRUE;
-    $element['format']['#title'] = t('Text format');
+  if (isset($element['#array_parents'])) {
+    $parents = array_flip($element['#array_parents']);
+    if (isset($parents['sba_quicksign'])) {
+      $prefix = isset($element['format']['#prefix']) ? $element['format']['#prefix'] : '';
+      $element['format']['#prefix'] = $element['#description'] . $prefix;
+      unset($element['#description']);
+      $element['format']['#collapsible'] = TRUE;
+      $element['format']['#collapsed'] = TRUE;
+      $element['format']['#title'] = t('Text format');
+    }
   }
   return $element;
 }

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -60,10 +60,8 @@ function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
       $node = $form['#node'];
       if (empty($user->uid) || user_access('create ' . $node->type . ' content')) {
         if (sba_quicksign_is_enabled($node)) {
-
           $components = $node->webform['components'];
           $component_hierarchy = __webform_user_parse_components($node->nid, $components);
-
           $profile = !empty($_SESSION['sba_quicksign']['profile']) ? $_SESSION['sba_quicksign']['profile'] : FALSE;
 
           if ($profile) {
@@ -86,7 +84,7 @@ function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
             unset($_SESSION['sba_quicksign']);
           }
           else {
-            if (!isset($_SESSION['quicksign_show']) || $_SESSION['quicksign_show'] == TRUE) {
+            if (!isset($_SESSION['quicksign_show']) || $_SESSION['quicksign_show'] == TRUE || $_SESSION['quicksign_show'] == FALSE) {
               $quicksign_field = &_webform_user_find_field($form, $component_hierarchy['sba_quicksign']);
               $quicksign_field['children'] = sba_quicksign_form();
               $quicksign_field['children']['#weight'] = 1001;
@@ -98,7 +96,12 @@ function sba_quicksign_form_alter(&$form, $form_state, $form_id) {
       }
       else {
         // Don't display the quicksign form to logged in users.
-        $form['submitted']['sba_quicksign']['#access'] = FALSE;
+        if (sba_quicksign_is_enabled($node)) {
+          $components = $node->webform['components'];
+          $component_hierarchy = __webform_user_parse_components($node->nid, $components);
+          $quicksign_field = &_webform_user_find_field($form, $component_hierarchy['sba_quicksign']);
+          $quicksign_field['#access'] = FALSE;
+        }
       }
     }
   }
@@ -157,15 +160,18 @@ function sba_quicksign_form() {
  * @param $form_state
  */
 function sba_quicksign_form_validate(&$form, &$form_state) {
-
-  $parents = array_flip($form_state['clicked_button']['#parents']);
+  $parents = array_flip($form_state['triggering_element']['#parents']);
   if (isset($parents['sba_quicksign'])) {
     $_SESSION['quicksign_show'] = TRUE;
     // Make webform believe that we clicked the webform submit button.
     $form_state['values']['op'] = $form['actions']['submit']['#value'];
-
+    $node = node_load($form_state['values']['details']['nid']);
+    $components = $node->webform['components'];
+    $component_hierarchy = __webform_user_parse_components($node->nid, $components);
     // Validate mail field.
-    $mail = isset($form_state['values']['submitted']['sba_quicksign']['children']['qsign']['quicksign_mail']) ? $form_state['values']['submitted']['sba_quicksign']['children']['qsign']  ['quicksign_mail'] : FALSE;
+    $qsign_value = _sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy['sba_quicksign']);
+
+    $mail = isset($qsign_value['children']['qsign']['quicksign_mail']) ? $qsign_value['children']['qsign']['quicksign_mail'] : FALSE;
     if (!$mail) {
       return;
     }
@@ -177,15 +183,14 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
     else {
       $_SESSION['sba_quicksign']['quickmail'] = $mail;
     }
-
-    $node = node_load($form_state['values']['details']['nid']);
+    ;
     // Load user profile from email.
     $account = user_load_by_mail($mail);
     // No profile available.
     if (!$account) {
       $_SESSION['sba_quicksign']['profile']['mail'] = $mail;
       $_SESSION['quicksign_show'] = FALSE;
-      drupal_set_message(t("We're sorry, we did not find an account with the email address !mail. Please fill out the full form. Next time you will be able to submit using just your email address.", array('!mail' => $mail)));
+      drupal_set_message(t("We're sorry, we did not find an account with the email address !mail. Please fill out the full form.", array('!mail' => $mail)));
       drupal_redirect_form($form_state);
     }
 
@@ -195,23 +200,20 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
     $map = webform_user_user_map($node->nid);
     $required_non_profile_fields = array_diff($required_fields, $map);
     $missing_non_profile_fields = FALSE;
+
     foreach ($required_non_profile_fields as $form_key) {
-      if (empty($form_state['values']['submitted'][$form_key])) {
+     $field =  _sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy[$form_key]);
+      if (empty($field)) {
         $missing_non_profile_fields = TRUE;
       }
     }
 
     $missing_fields = FALSE;
     $profile = array();
-    $count_profile_required = 0;
     foreach ($map as $webform_field => $profile_field) {
-
-      if (in_array($webform_field, $required_fields)) {
-        $count_profile_required++;
-      }
-
-      if (!empty($form_state['values']['submitted'][$profile_field])) {
-        $profile[$webform_field] = $form_state['values']['submitted'][$profile_field];
+      $field_value = _sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy[$webform_field]);
+      if (!empty($field_value)) {
+        $profile[$webform_field] = $field_value;
       }
       else {
         if ($webform_field != 'mail') {
@@ -251,7 +253,7 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
   else {
     // Quicksign button was not clicked.
     unset($_SESSION['sba_quicksign']);
-    unset($form_state['values']['submitted']['sba_quicksign']);
+    unset($qsign_value);
   }
 }
 
@@ -269,8 +271,20 @@ function _sba_quicksign_build_values(&$form, &$form_state, $node, $profile) {
   }
   unset($_SESSION['sba_quicksign']);
   unset($_SESSION['quicksign_show']);
-
 }
+
+function _sba_quicksign_find_field_form_state($form_state_values, $path) {
+  foreach (array_keys($path) as $v) {
+    if (is_array($path[$v]) && count($path[$v])) {
+      // Recurse if there are more keys.
+      return _sba_quicksign_find_field_form_state($form_state_values[$v], $path[$v]);
+    }
+    else {
+      return $form_state_values[$v];
+    }
+  }
+}
+
 
 /**
  * Build the webform submission tree.

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -350,6 +350,12 @@ function sba_quicksign_node_delete($node) {
   }
 }
 
+function sba_quicksign_webform_component_delete($component) {
+  if ($component['form_key'] == 'sba_quicksign') {
+    sba_quicksign_delete($component['nid']);
+  }
+}
+
 /**
  * Save quick sign settings per-node.
  *


### PR DESCRIPTION
This refactors the quicksign form as a webform component, rather than a separate form.

The same behavior as the original module is expected - except in the case of a quicksign failure: the partial profile information, if it exists, is not populated into the webform, to protect user privacy.