### PR TITLE
Adding salesforce integration support for social actions

### DIFF
--- a/salesforce/salesforce_social_action/salesforce_social_action.info
+++ b/salesforce/salesforce_social_action/salesforce_social_action.info
@@ -1,0 +1,11 @@
+name = Salesforce Social Action
+description = Salesforce integration support for advocacy social actions.
+package = Salesforce
+core = 7.x
+version = 7.x-4.x-dev
+
+dependencies[] = libraries
+dependencies[] = salesforce
+dependencies[] = salesforce_soap
+dependencies[] = salesforce_sync
+dependencies[] = sba_social_action

--- a/salesforce/salesforce_social_action/salesforce_social_action.install
+++ b/salesforce/salesforce_social_action/salesforce_social_action.install
@@ -9,9 +9,9 @@
  * Implements hook_install().
  */
 function salesforce_social_action_install() {
-  // Install the message action fieldmap.
-  $message_action_mapping = entity_import('salesforce_mapping', salesforce_social_action_message_action_fieldmap());
-  entity_save('salesforce_mapping', $message_action_mapping);
+  // Install the social action fieldmap.
+  $social_action_mapping = entity_import('salesforce_mapping', salesforce_social_action_fieldmap());
+  entity_save('salesforce_mapping', $social_action_mapping);
 
   // Install the message action default fieldmap.
   salesforce_social_action_create_actions_taken_fieldmap();
@@ -107,7 +107,7 @@ function salesforce_social_action_create_actions_taken_fieldmap() {
 /**
  * Creates a default fieldmap for message action nodes.
  */
-function salesforce_social_action_message_action_fieldmap() {
+function salesforce_social_action_fieldmap() {
   module_load_include('inc', 'salesforce_genmap', 'includes/salesforce_genmap.map');
   $sfapi = salesforce_get_api();
   $object_type = '';
@@ -533,51 +533,4 @@ function salesforce_social_action_field_is_mapped($mapping, $field) {
  */
 function salesforce_social_action_mapped_twitter_fields() {
   return json_decode('{"field_mappings":[{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_screen_name"},"salesforce_field":{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter Screen Name","length":255,"name":"Twitter_Screen_Name__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"},{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_id_str"},"salesforce_field":{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter ID","length":255,"name":"Twitter_ID__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"},{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_status_count"},"salesforce_field":{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":"0","defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter Status Count","length":0,"name":"Twitter_Status_Count__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":18,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:double","sortable":true,"type":"double","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"},{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_following_count"},"salesforce_field":{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":"0","defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter Following Count","length":0,"name":"Twitter_Following_Count__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":18,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:double","sortable":true,"type":"double","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"},{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_followers_count"},"salesforce_field":{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":"0","defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter Followers Count","length":0,"name":"Twitter_Followers_Count__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":18,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:double","sortable":true,"type":"double","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"},{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_created_at"},"salesforce_field":{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter Account Create Date","length":0,"name":"Twitter_Account_Create_Date__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:date","sortable":true,"type":"date","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"}]}', TRUE);
-}
-
-/**
- * Revert manual changes that were required to work around a fieldmap bug in 4.7.
- * Changes the value of the module field from sba_message_action to salesforce_message_action.
- *
- * See https://www.assembla.com/spaces/springboard/tickets/455#/activity/ticket:
- * for more detail.
- */
-function salesforce_social_action_update_7001() {
-  db_update('salesforce_genmap_map')
-    ->fields(array(
-      'module' => 'salesforce_message_action',
-    ))
-    ->condition('module', 'sba_message_action')
-    ->execute();
-}
-
-/**
- * Maps 2 new message action fields introduced in 4.8.
- */
-function salesforce_social_action_update_7002() {
-  $result = db_query('SELECT mid, field_map FROM {salesforce_genmap_map} WHERE module = :module', array(':module' => 'salesforce_message_action'));
-
-  foreach ($result as $record) {
-    $map_need_updating = FALSE;
-    $map = unserialize($record->field_map);
-    if (!array_key_exists('sba_deliverable_count', $map['webform_map'])) {
-      $map['webform_map']['sba_deliverable_count'] = 'Generated_Message_Count__c';
-      $map_need_updating = TRUE;
-    }
-
-    if (!array_key_exists('sba_user_edit_flag', $map['webform_map'])) {
-      $map['webform_map']['sba_user_edit_flag'] = 'Message_Edited__c';
-      $map_need_updating = TRUE;
-    }
-
-    // Only perform the update if the fields weren't already mapped manually.
-    if ($map_need_updating) {
-      db_update('salesforce_genmap_map')
-        ->fields(array(
-          'field_map' => serialize($map),
-        ))
-        ->condition('mid', $record->mid)
-        ->execute();
-    }
-  }
 }

--- a/salesforce/salesforce_social_action/salesforce_social_action.install
+++ b/salesforce/salesforce_social_action/salesforce_social_action.install
@@ -1,0 +1,583 @@
+<?php
+
+/**
+ * @file
+ * Install and update routines for Salesforce social action module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function salesforce_social_action_install() {
+  // Install the message action fieldmap.
+  $message_action_mapping = entity_import('salesforce_mapping', salesforce_social_action_message_action_fieldmap());
+  entity_save('salesforce_mapping', $message_action_mapping);
+
+  // Install the message action default fieldmap.
+  salesforce_social_action_create_actions_taken_fieldmap();
+
+  salesforce_social_action_update_user_profile_map();
+}
+
+/**
+ * Adds new field mappings for the twitter fields to the user -> contact fieldmap.
+ */
+function salesforce_social_action_update_user_profile_map() {
+  $user_map = salesforce_mapping_load('user_to_contact');
+  $twitter_fields = salesforce_social_action_mapped_twitter_fields();
+
+  // Add the new field mappings to the existing map.
+  foreach ($twitter_fields['field_mappings'] as $field) {
+    if (!salesforce_social_action_field_is_mapped($user_map->field_mappings, $field['drupal_field']['fieldmap_value'])) {
+      $user_map->field_mappings[] = $field;
+    }
+  }
+
+  // Resave the map with the new fields.
+  $user_map->save();
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function salesforce_social_action_uninstall() {
+
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'salesforce_genmap_map');
+  $query->propertyCondition('module', 'salesforce_social_action');
+  $query->propertyCondition('nid', -30); // This should use the constant, but it doesn't work.
+  $result = $query->execute();
+  if (!empty($result)) {
+    $mids = array_keys($result['salesforce_genmap_map']);
+    entity_delete('salesforce_genmap_map', $mids[0]);
+  }
+
+  $result = salesforce_mapping_load_multiple(array('drupal_bundle' => 'sba_social_action'));
+  $mapping = array_shift($result);
+  entity_delete('salesforce_mapping', $mapping->salesforce_mapping_id);
+}
+
+/**
+ * Creates a default fieldmap for message action form submissions.
+ */
+function salesforce_social_action_create_actions_taken_fieldmap() {
+  $map = array();
+  $map = entity_create('salesforce_genmap_map', $map);
+  $map->nid = salesforce_social_action_DEFAULT_MAP_ID;
+  $map->map_handler = 'webform';
+  $map->salesforce_object_type = 'sb_Actions_Taken__c';
+  $object_type = '';
+  module_load_include('inc', 'salesforce_genmap', 'includes/salesforce_genmap.map');
+  $map->salesforce_record_type = $object_type;
+  $map->field_map = array(
+    'webform_map' => array(
+      'ms' => 'Market_Source__c',
+      'cid' => 'Campaign__c',
+      'referrer' => 'Referrer__c',
+      'initial_referrer' => 'Initial_Referrer__c',
+      'search_engine' => 'Search_Engine__c',
+      'search_string' => 'Search_String__c',
+      'user_agent' => 'User_Agent__c',
+      'sba_deliverable_count' => 'Generated_Message_Count__c',
+      'device_type' => 'Device_Type__c',
+      'device_name' => 'Device_Name__c',
+      'device_os' => 'Device_OS__c',
+      'device_browser' => 'Device_Browser__c',
+    ),
+    'salesforce_node_map' => array(
+      'title' => 'Name',
+      'action' => 'Action__c',
+      'action_type' => 'Action_Type__c',
+    ),
+    'salesforce_submission_map' => array(
+      'sid' => 'Submission_ID__c',
+      'date' => 'Date_of_Action__c',
+    ),
+  );
+  $map->sync_options = array(
+    'insert' => 'insert',
+    'update' => 'update',
+    'delete' => 'delete',
+  );
+  $map->status = 1;
+  $map->module = 'salesforce_social_action';
+  salesforce_genmap_save_map($map, 'webform');
+}
+
+/**
+ * Creates a default fieldmap for message action nodes.
+ */
+function salesforce_social_action_message_action_fieldmap() {
+  module_load_include('inc', 'salesforce_genmap', 'includes/salesforce_genmap.map');
+  $sfapi = salesforce_get_api();
+  $object_type = '';
+  if ($sfapi->isAuthorized()) {
+    $sf_records = _sfw_salesforce_record_type_list($sfapi, 'sb_action__c');
+    $sf_records = array_flip($sf_records);
+    if (array_key_exists('Social Action', $sf_records)) {
+      $object_type = $sf_records['Social Action'];
+    }
+  }
+
+  return '{
+    "type" : "salesforce_mapping",
+    "name" : "social_action",
+    "label" : "Social Action",
+    "sync_triggers" : "3",
+    "salesforce_object_type" : "sb_action__c",
+    "salesforce_record_type" : "' . $object_type . '",
+    "drupal_entity_type" : "node",
+    "drupal_bundle" : "sba_social_action",
+    "field_mappings" : [
+      {
+        "drupal_field" : { "fieldmap_type" : "property", "fieldmap_value" : "nid" },
+        "salesforce_field" : {
+          "autoNumber" : false,
+          "byteLength" : 0,
+          "calculated" : false,
+          "calculatedFormula" : null,
+          "cascadeDelete" : false,
+          "caseSensitive" : false,
+          "controllerName" : null,
+          "createable" : true,
+          "custom" : true,
+          "defaultValue" : null,
+          "defaultValueFormula" : null,
+          "defaultedOnCreate" : false,
+          "dependentPicklist" : false,
+          "deprecatedAndHidden" : false,
+          "digits" : 0,
+          "displayLocationInDecimal" : false,
+          "externalId" : true,
+          "filterable" : true,
+          "groupable" : false,
+          "htmlFormatted" : false,
+          "idLookup" : true,
+          "inlineHelpText" : "ID of the action in Springboard",
+          "label" : "Springboard ID",
+          "length" : 0,
+          "name" : "Springboard_ID__c",
+          "nameField" : false,
+          "namePointing" : false,
+          "nillable" : true,
+          "permissionable" : true,
+          "picklistValues" : [],
+          "precision" : 18,
+          "referenceTo" : [],
+          "relationshipName" : null,
+          "relationshipOrder" : null,
+          "restrictedDelete" : false,
+          "restrictedPicklist" : false,
+          "scale" : 0,
+          "soapType" : "xsd:double",
+          "sortable" : true,
+          "type" : "double",
+          "unique" : false,
+          "updateable" : true,
+          "writeRequiresMasterRead" : false
+        },
+        "key" : true,
+        "direction" : "drupal_sf",
+        "drupal_sf" : "always",
+        "sf_drupal" : "never"
+      },
+      {
+        "drupal_field" : { "fieldmap_type" : "property", "fieldmap_value" : "title" },
+        "salesforce_field" : {
+          "autoNumber" : false,
+          "byteLength" : 240,
+          "calculated" : false,
+          "calculatedFormula" : null,
+          "cascadeDelete" : false,
+          "caseSensitive" : false,
+          "controllerName" : null,
+          "createable" : true,
+          "custom" : false,
+          "defaultValue" : null,
+          "defaultValueFormula" : null,
+          "defaultedOnCreate" : true,
+          "dependentPicklist" : false,
+          "deprecatedAndHidden" : false,
+          "digits" : 0,
+          "displayLocationInDecimal" : false,
+          "externalId" : false,
+          "filterable" : true,
+          "groupable" : true,
+          "htmlFormatted" : false,
+          "idLookup" : true,
+          "inlineHelpText" : null,
+          "label" : "Action Name",
+          "length" : 80,
+          "name" : "Name",
+          "nameField" : true,
+          "namePointing" : false,
+          "nillable" : true,
+          "permissionable" : false,
+          "picklistValues" : [],
+          "precision" : 0,
+          "referenceTo" : [],
+          "relationshipName" : null,
+          "relationshipOrder" : null,
+          "restrictedDelete" : false,
+          "restrictedPicklist" : false,
+          "scale" : 0,
+          "soapType" : "xsd:string",
+          "sortable" : true,
+          "type" : "string",
+          "unique" : false,
+          "updateable" : true,
+          "writeRequiresMasterRead" : false
+        },
+        "key" : false,
+        "direction" : "drupal_sf",
+        "drupal_sf" : "always",
+        "sf_drupal" : "never"
+      },
+      {
+        "drupal_field" : { "fieldmap_type" : "property", "fieldmap_value" : "url" },
+        "salesforce_field" : {
+          "autoNumber" : false,
+          "byteLength" : 765,
+          "calculated" : false,
+          "calculatedFormula" : null,
+          "cascadeDelete" : false,
+          "caseSensitive" : false,
+          "controllerName" : null,
+          "createable" : true,
+          "custom" : true,
+          "defaultValue" : null,
+          "defaultValueFormula" : null,
+          "defaultedOnCreate" : false,
+          "dependentPicklist" : false,
+          "deprecatedAndHidden" : false,
+          "digits" : 0,
+          "displayLocationInDecimal" : false,
+          "externalId" : false,
+          "filterable" : true,
+          "groupable" : true,
+          "htmlFormatted" : false,
+          "idLookup" : false,
+          "inlineHelpText" : "Public URL of the action.",
+          "label" : "Public URL",
+          "length" : 255,
+          "name" : "Public_URL__c",
+          "nameField" : false,
+          "namePointing" : false,
+          "nillable" : true,
+          "permissionable" : true,
+          "picklistValues" : [],
+          "precision" : 0,
+          "referenceTo" : [],
+          "relationshipName" : null,
+          "relationshipOrder" : null,
+          "restrictedDelete" : false,
+          "restrictedPicklist" : false,
+          "scale" : 0,
+          "soapType" : "xsd:string",
+          "sortable" : true,
+          "type" : "url",
+          "unique" : false,
+          "updateable" : true,
+          "writeRequiresMasterRead" : false
+        },
+        "key" : false,
+        "direction" : "drupal_sf",
+        "drupal_sf" : "always",
+        "sf_drupal" : "never"
+      },
+      {
+        "drupal_field" : { "fieldmap_type" : "property", "fieldmap_value" : "edit_url" },
+        "salesforce_field" : {
+          "autoNumber" : false,
+          "byteLength" : 765,
+          "calculated" : false,
+          "calculatedFormula" : null,
+          "cascadeDelete" : false,
+          "caseSensitive" : false,
+          "controllerName" : null,
+          "createable" : true,
+          "custom" : true,
+          "defaultValue" : null,
+          "defaultValueFormula" : null,
+          "defaultedOnCreate" : false,
+          "dependentPicklist" : false,
+          "deprecatedAndHidden" : false,
+          "digits" : 0,
+          "displayLocationInDecimal" : false,
+          "externalId" : false,
+          "filterable" : true,
+          "groupable" : true,
+          "htmlFormatted" : false,
+          "idLookup" : false,
+          "inlineHelpText" : "Link to edit this action in Springboard.",
+          "label" : "Edit URL",
+          "length" : 255,
+          "name" : "Edit_URL__c",
+          "nameField" : false,
+          "namePointing" : false,
+          "nillable" : true,
+          "permissionable" : true,
+          "picklistValues" : [],
+          "precision" : 0,
+          "referenceTo" : [],
+          "relationshipName" : null,
+          "relationshipOrder" : null,
+          "restrictedDelete" : false,
+          "restrictedPicklist" : false,
+          "scale" : 0,
+          "soapType" : "xsd:string",
+          "sortable" : true,
+          "type" : "url",
+          "unique" : false,
+          "updateable" : true,
+          "writeRequiresMasterRead" : false
+        },
+        "key" : false,
+        "direction" : "drupal_sf",
+        "drupal_sf" : "always",
+        "sf_drupal" : "never"
+      },
+      {
+        "drupal_field" : { "fieldmap_type" : "property", "fieldmap_value" : "created" },
+        "salesforce_field" : {
+          "autoNumber" : false,
+          "byteLength" : 0,
+          "calculated" : false,
+          "calculatedFormula" : null,
+          "cascadeDelete" : false,
+          "caseSensitive" : false,
+          "controllerName" : null,
+          "createable" : true,
+          "custom" : true,
+          "defaultValue" : null,
+          "defaultValueFormula" : null,
+          "defaultedOnCreate" : false,
+          "dependentPicklist" : false,
+          "deprecatedAndHidden" : false,
+          "digits" : 0,
+          "displayLocationInDecimal" : false,
+          "externalId" : false,
+          "filterable" : true,
+          "groupable" : true,
+          "htmlFormatted" : false,
+          "idLookup" : false,
+          "inlineHelpText" : "Create date of the action",
+          "label" : "Date Created",
+          "length" : 0,
+          "name" : "Date_Created__c",
+          "nameField" : false,
+          "namePointing" : false,
+          "nillable" : true,
+          "permissionable" : true,
+          "picklistValues" : [],
+          "precision" : 0,
+          "referenceTo" : [],
+          "relationshipName" : null,
+          "relationshipOrder" : null,
+          "restrictedDelete" : false,
+          "restrictedPicklist" : false,
+          "scale" : 0,
+          "soapType" : "xsd:date",
+          "sortable" : true,
+          "type" : "date",
+          "unique" : false,
+          "updateable" : true,
+          "writeRequiresMasterRead" : false
+        },
+        "key" : false,
+        "direction" : "drupal_sf",
+        "drupal_sf" : "always",
+        "sf_drupal" : "never"
+      },
+      {
+        "drupal_field" : { "fieldmap_type" : "property", "fieldmap_value" : "body:value" },
+        "salesforce_field" : {
+          "autoNumber" : false,
+          "byteLength" : 30000,
+          "calculated" : false,
+          "calculatedFormula" : null,
+          "cascadeDelete" : false,
+          "caseSensitive" : false,
+          "controllerName" : null,
+          "createable" : true,
+          "custom" : true,
+          "defaultValue" : null,
+          "defaultValueFormula" : null,
+          "defaultedOnCreate" : false,
+          "dependentPicklist" : false,
+          "deprecatedAndHidden" : false,
+          "digits" : 0,
+          "displayLocationInDecimal" : false,
+          "externalId" : false,
+          "filterable" : false,
+          "groupable" : false,
+          "htmlFormatted" : false,
+          "idLookup" : false,
+          "inlineHelpText" : "This is the body or long description of the action.",
+          "label" : "Body",
+          "length" : 10000,
+          "name" : "Body__c",
+          "nameField" : false,
+          "namePointing" : false,
+          "nillable" : true,
+          "permissionable" : true,
+          "picklistValues" : [],
+          "precision" : 0,
+          "referenceTo" : [],
+          "relationshipName" : null,
+          "relationshipOrder" : null,
+          "restrictedDelete" : false,
+          "restrictedPicklist" : false,
+          "scale" : 0,
+          "soapType" : "xsd:string",
+          "sortable" : false,
+          "type" : "textarea",
+          "unique" : false,
+          "updateable" : true,
+          "writeRequiresMasterRead" : false
+        },
+        "key" : false,
+        "direction" : "drupal_sf",
+        "drupal_sf" : "always",
+        "sf_drupal" : "never"
+      },
+      {
+        "drupal_field" : {
+          "fieldmap_type" : "property",
+          "fieldmap_value" : "field_webform_user_internal_name"
+        },
+        "salesforce_field" : {
+          "autoNumber" : false,
+          "byteLength" : 765,
+          "calculated" : false,
+          "calculatedFormula" : null,
+          "cascadeDelete" : false,
+          "caseSensitive" : false,
+          "controllerName" : null,
+          "createable" : true,
+          "custom" : true,
+          "defaultValue" : null,
+          "defaultValueFormula" : null,
+          "defaultedOnCreate" : false,
+          "dependentPicklist" : false,
+          "deprecatedAndHidden" : false,
+          "digits" : 0,
+          "displayLocationInDecimal" : false,
+          "externalId" : false,
+          "filterable" : true,
+          "groupable" : true,
+          "htmlFormatted" : false,
+          "idLookup" : false,
+          "inlineHelpText" : "Internal organizational name for this action, if there is one.",
+          "label" : "Internal Name",
+          "length" : 255,
+          "name" : "Internal_Name__c",
+          "nameField" : false,
+          "namePointing" : false,
+          "nillable" : true,
+          "permissionable" : true,
+          "picklistValues" : [],
+          "precision" : 0,
+          "referenceTo" : [],
+          "relationshipName" : null,
+          "relationshipOrder" : null,
+          "restrictedDelete" : false,
+          "restrictedPicklist" : false,
+          "scale" : 0,
+          "soapType" : "xsd:string",
+          "sortable" : true,
+          "type" : "string",
+          "unique" : false,
+          "updateable" : true,
+          "writeRequiresMasterRead" : false
+        },
+        "key" : false,
+        "direction" : "drupal_sf",
+        "drupal_sf" : "always",
+        "sf_drupal" : "never"
+      }
+    ],
+    "push_async" : "0",
+    "push_batch" : "0",
+    "created" : "1430506377",
+    "updated" : "1430507210",
+    "weight" : "0",
+    "locked" : "0",
+    "rdf_mapping" : []
+  }';
+}
+
+/**
+ * Checks to see if a particular field has already been mapped.
+ *
+ * @param $mapping
+ *   The field mappings array to check.
+ * @param $field
+ *   The name of drupal field.
+ *
+ * @return TRUE if the field is aleady mapped.
+ */
+function salesforce_social_action_field_is_mapped($mapping, $field) {
+  foreach ($mapping as $mapped_field) {
+    if ($mapped_field['drupal_field']['fieldmap_value'] == $field) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+ * Maps twitter profile fields created by the sba_social_message module to the contact object
+ * in Salesforce.
+ */
+function salesforce_social_action_mapped_twitter_fields() {
+  return json_decode('{"field_mappings":[{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_screen_name"},"salesforce_field":{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter Screen Name","length":255,"name":"Twitter_Screen_Name__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"},{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_id_str"},"salesforce_field":{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter ID","length":255,"name":"Twitter_ID__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"},{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_status_count"},"salesforce_field":{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":"0","defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter Status Count","length":0,"name":"Twitter_Status_Count__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":18,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:double","sortable":true,"type":"double","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"},{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_following_count"},"salesforce_field":{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":"0","defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter Following Count","length":0,"name":"Twitter_Following_Count__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":18,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:double","sortable":true,"type":"double","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"},{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_followers_count"},"salesforce_field":{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":"0","defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter Followers Count","length":0,"name":"Twitter_Followers_Count__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":18,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:double","sortable":true,"type":"double","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"},{"drupal_field":{"fieldmap_type":"property","fieldmap_value":"sbp_twitter_created_at"},"salesforce_field":{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Twitter Account Create Date","length":0,"name":"Twitter_Account_Create_Date__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:date","sortable":true,"type":"date","unique":false,"updateable":true,"writeRequiresMasterRead":false},"key":false,"direction":"drupal_sf","drupal_sf":"always","sf_drupal":"never"}]}', TRUE);
+}
+
+/**
+ * Revert manual changes that were required to work around a fieldmap bug in 4.7.
+ * Changes the value of the module field from sba_message_action to salesforce_message_action.
+ *
+ * See https://www.assembla.com/spaces/springboard/tickets/455#/activity/ticket:
+ * for more detail.
+ */
+function salesforce_social_action_update_7001() {
+  db_update('salesforce_genmap_map')
+    ->fields(array(
+      'module' => 'salesforce_message_action',
+    ))
+    ->condition('module', 'sba_message_action')
+    ->execute();
+}
+
+/**
+ * Maps 2 new message action fields introduced in 4.8.
+ */
+function salesforce_social_action_update_7002() {
+  $result = db_query('SELECT mid, field_map FROM {salesforce_genmap_map} WHERE module = :module', array(':module' => 'salesforce_message_action'));
+
+  foreach ($result as $record) {
+    $map_need_updating = FALSE;
+    $map = unserialize($record->field_map);
+    if (!array_key_exists('sba_deliverable_count', $map['webform_map'])) {
+      $map['webform_map']['sba_deliverable_count'] = 'Generated_Message_Count__c';
+      $map_need_updating = TRUE;
+    }
+
+    if (!array_key_exists('sba_user_edit_flag', $map['webform_map'])) {
+      $map['webform_map']['sba_user_edit_flag'] = 'Message_Edited__c';
+      $map_need_updating = TRUE;
+    }
+
+    // Only perform the update if the fields weren't already mapped manually.
+    if ($map_need_updating) {
+      db_update('salesforce_genmap_map')
+        ->fields(array(
+          'field_map' => serialize($map),
+        ))
+        ->condition('mid', $record->mid)
+        ->execute();
+    }
+  }
+}

--- a/salesforce/salesforce_social_action/salesforce_social_action.module
+++ b/salesforce/salesforce_social_action/salesforce_social_action.module
@@ -35,7 +35,7 @@ function salesforce_social_action_salesforce_genmap_map_fields_alter(&$fields, $
 function salesforce_social_action_node_insert($node) {
   // If node is a message action type.
   if ($node->type == 'sba_social_action') {
-    // And if we have a default map. Salesforce message action default is -20.
+    // And if we have a default map. Salesforce social action default is -30.
     // Only copy the map for fresh inserts. Webform user will handle clones.
     $nid = salesforce_social_action_DEFAULT_MAP_ID;
     if (empty($node->clone_from_original_nid)) {

--- a/salesforce/salesforce_social_action/salesforce_social_action.module
+++ b/salesforce/salesforce_social_action/salesforce_social_action.module
@@ -1,0 +1,69 @@
+<?php
+
+define('salesforce_social_action_DEFAULT_MAP_ID', -30);
+
+/**
+ * @file
+ * Provides advocacy integration support for Salesforce.
+ */
+
+/**
+ * Implements hook_salesforce_genmap_map_field_info_alter().
+ */
+function salesforce_social_action_salesforce_genmap_map_field_info_alter(&$fields, $node, $module) {
+  if ($module == 'webform' && $node->type == 'sba_social_action') {
+    $fields['salesforce_node_map']['#fields']['action'] = 'Action';
+    $fields['salesforce_node_map']['#fields']['action_type'] = 'Action Type';
+  }
+}
+
+/**
+ * Implements hook_salesforce_genmap_map_fields_alter().
+ */
+function salesforce_social_action_salesforce_genmap_map_fields_alter(&$fields, $context) {
+  if ($context['module'] == 'webform' && $context['map']->module == 'salesforce_social_action') {
+    $fields[$context['map']->field_map['salesforce_node_map']['action']] = sprintf('[sb_action__c:sba_social_action:%d]', $context['node']->nid);
+    $fields[$context['map']->field_map['salesforce_node_map']['action_type']] = 'Social Action';
+  }
+}
+
+/**
+ * Implements hook_node_insert().
+ *
+ * Insert a copy of the default map when a message_action node is created.
+ */
+function salesforce_social_action_node_insert($node) {
+  // If node is a message action type.
+  if ($node->type == 'sba_social_action') {
+    // And if we have a default map. Salesforce message action default is -20.
+    // Only copy the map for fresh inserts. Webform user will handle clones.
+    $nid = salesforce_social_action_DEFAULT_MAP_ID;
+    if (empty($node->clone_from_original_nid)) {
+      $map = salesforce_genmap_load_map($nid, 'webform');
+      if (!empty($map)) {
+        // Copy the map to the node.
+        unset($map->mid);
+        $map->nid = $node->nid;
+        salesforce_genmap_save_map($map, 'webform');
+      }
+    }
+    // Set the relationship from the submission to the contact.
+    $webform_user_reference_fields = variable_get('webform_user_reference_fields', array());
+    $webform_user_reference_fields[$node->nid] = 'Contact__c';
+    variable_set('webform_user_reference_fields', $webform_user_reference_fields);
+  }
+}
+/**
+ * Implements hook_node_delete().
+ *
+ * Delete a fieldmap when a message action node is deelted.
+ */
+function salesforce_social_action_node_delete($node) {
+  // If node is a message action type.
+  if ($node->type == 'sba_social_action') {
+    salesforce_genmap_delete_map($node->nid, 'webform');
+    $webform_user_reference_fields = variable_get('webform_user_reference_fields', array());
+    unset($webform_user_reference_fields[$node->nid]);
+    variable_set('webform_user_reference_fields', $webform_user_reference_fields);
+  }
+}


### PR DESCRIPTION
The install file does the following:
* Creates an entity fieldmap for the sba_social_action node type that maps to the action object
* Creates a default fieldmap for sba_social_action submissons that maps to the actions taken object
* Maps the new twitter profile fields added in the social advocacy module to the contact object