### PR TITLE
Updates Springboard Tag config link

### DIFF
--- a/springboard_tag/springboard_tag.info
+++ b/springboard_tag/springboard_tag.info
@@ -3,7 +3,7 @@ description = Embeds third-party javascript snippets
 package = Jackson River Springboard - extras
 core = 7.x
 version = 7.x-4.x
-configure = admin/config/services/springboard-tags
+configure = admin/springboard/springboard-tags
 
 dependencies[] = ctools
 dependencies[] = fundraiser


### PR DESCRIPTION
Fixes the configure link for Springboard Tags at /admin/modules