### PR TITLE
QA fixes to recent donors list

### DIFF
--- a/fundraiser/modules/fundraiser_recent_donors/css/fundraiser_recent_donors.css
+++ b/fundraiser/modules/fundraiser_recent_donors/css/fundraiser_recent_donors.css
@@ -1,0 +1,19 @@
+/**
+ *  Adjust styles so the current currency suffix or prefix is positioned currectly
+ *  around the "Only show donations greater than" text field.
+ */
+.vertical-tabs-pane fieldset#edit-recent-donors-list span.recent-donors-currency-symbol-before,
+.vertical-tabs-pane fieldset#edit-recent-donors-list span.recent-donors-currency-symbol-after {
+  font-size: 16px;
+  position: relative;
+  bottom: 4px;
+}
+.vertical-tabs-pane fieldset#edit-recent-donors-list span.recent-donors-currency-symbol-before {
+  margin-right: 5px;
+}
+.vertical-tabs-pane fieldset#edit-recent-donors-list span.recent-donors-currency-symbol-after {
+  margin-left: 5px;
+}
+.vertical-tabs-pane fieldset#edit-recent-donors-list #edit-show-recent-donation-greater-than {
+  width: 20%;
+}

--- a/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
+++ b/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
@@ -280,6 +280,50 @@ function fundraiser_recent_donors_views_query_alter(&$view, &$query) {
   $query->add_where(1, 'field_data_commerce_order_total.commerce_order_total_amount', $minimum_value, '>');
 }
 
+/**
+ * Implements hook_views_post_execute().
+ *
+ * Replace the raw, currency-agnostic value initial displayed
+ * with currency-formatted output.  This is because an adjusted
+ * total with any particularlly refunded amount subtracted is
+ * a derived value.
+ */
+function fundraiser_recent_donors_views_post_execute(&$view) {
+  if ($view->name != 'recent_opt_in_donations' || !isset($view->args[0])) {
+    return;
+  }
+  foreach ($view->result as $key => $result) {
+    // Is this a partially refunded order; if so, alter the output to display the correct amount:
+    if ($view->result[$key]->_field_data['commerce_order_fundraiser_donor_opt_in_order_id']['entity']
+      ->status == 'partially_refunded') {
+      $pre_refund_amount = $view->result[$key]->field_commerce_order_total[0]['raw']['amount'];
+      $currency_code = $view->result[$key]->field_commerce_order_total[0]['raw']['currency_code'];
+
+      // Fetch the balance returned to the user so it can be subtracted from the original total:
+      $order_id = $view->result[$key]->commerce_order_fundraiser_donor_opt_in_order_id;
+      $order = commerce_order_load($order_id);
+      $balance = commerce_payment_order_balance($order);
+      $post_refund_balance = $pre_refund_amount - $balance['amount'];
+
+      // If this row's amount is less than or equal to the refund amount then remove this row from output:
+      $min_amount = _fundraiser_recent_donors_get_min_opt_in_donation_amount($view->args[0]);
+      $min_amount = commerce_currency_decimal_to_amount($min_amount, $currency_code, TRUE);
+      if ($post_refund_balance <= $min_amount) {
+        unset($view->result[$key]);
+        continue;
+      }
+
+      // Format the new output:
+      $partial_refund_markup = commerce_currency_format(
+        $post_refund_balance,
+        $view->result[$key]->field_commerce_order_total[0]['raw']['currency_code']
+      );
+      $view->result[$key]->field_commerce_order_total[0]['rendered']['#markup'] = $partial_refund_markup;
+    }
+  }
+  //dpm($view);
+}
+
 
 // Helper functions:
 

--- a/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
+++ b/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
@@ -313,50 +313,6 @@ function fundraiser_recent_donors_views_query_alter(&$view, &$query) {
   $query->add_where(1, 'field_data_commerce_order_total.commerce_order_total_amount', $minimum_value, '>');
 }
 
-/**
- * Implements hook_views_post_execute().
- *
- * Alter the value displayed for partially refunded donations as the
- * updated value is derived by subtracting the balance from the order total.
- *
- * Also exclude any rows whose partially refunded values are below the minimum
- * opt-in donation amount as defined within this donation's node.
- */
-function fundraiser_recent_donors_views_post_execute(&$view) {
-  if ($view->name != 'recent_opt_in_donations' || !isset($view->args[0])) {
-    return;
-  }
-  foreach ($view->result as $key => $result) {
-    // Is this a partially refunded order; if so, alter the output to display the correct amount:
-    if ($view->result[$key]->_field_data['commerce_order_fundraiser_donor_opt_in_order_id']['entity']
-      ->status == 'partially_refunded') {
-      $pre_refund_amount = $view->result[$key]->field_commerce_order_total[0]['raw']['amount'];
-      $currency_code = $view->result[$key]->field_commerce_order_total[0]['raw']['currency_code'];
-
-      // Fetch the balance returned to the user so it can be subtracted from the original total:
-      $order_id = $view->result[$key]->commerce_order_fundraiser_donor_opt_in_order_id;
-      $order = commerce_order_load($order_id);
-      $balance = commerce_payment_order_balance($order);
-      $post_refund_balance = $pre_refund_amount - $balance['amount'];
-
-      // If this row's amount is less than or equal to the refund amount then remove this row from output:
-      $min_amount = _fundraiser_recent_donors_get_min_opt_in_donation_amount($view->args[0]);
-      $min_amount = commerce_currency_decimal_to_amount($min_amount, $currency_code, TRUE);
-      if ($post_refund_balance <= $min_amount) {
-        unset($view->result[$key]);
-        continue;
-      }
-
-      // Format the new output:
-      $partial_refund_markup = commerce_currency_format(
-        $post_refund_balance,
-        $view->result[$key]->field_commerce_order_total[0]['raw']['currency_code']
-      );
-      $view->result[$key]->field_commerce_order_total[0]['rendered']['#markup'] = $partial_refund_markup;
-    }
-  }
-}
-
 
 // Helper functions:
 

--- a/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
+++ b/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
@@ -103,6 +103,11 @@ function fundraiser_recent_donors_form_alter(&$form, &$form_state, $form_id) {
       '#weight' => 99999,
     );
   }
+
+  // Handle the "Pre-popualte the node form fields" method for cloning a node:
+  if ($arg2 == 'clone') {
+    _fundraiser_recent_donors_clone_opt_in_data_on_clone_form_submit($form, $form['#node']->nid);
+  }
 }
 
 /**
@@ -337,14 +342,76 @@ function fundraiser_recent_donors_views_post_execute(&$view) {
       $view->result[$key]->field_commerce_order_total[0]['rendered']['#markup'] = $partial_refund_markup;
     }
   }
-  //dpm($view);
+}
+
+
+// Node clone support:
+
+/**
+ * Implements hook_clone_node_alter() from Node clone module.
+ *
+ * From: http://drupal.org/node/1256478
+ * 
+ * When the cloning method is "save-edit", this copies node-specific, opt-in settings.
+ *
+ * Those settings are:
+ * 1. Is opt-in enabled for this node
+ * 2. What is the opt-in minimum value for a donation to be displayed.
+ */
+function fundraiser_recent_donors_clone_node_alter(&$node, $context) {
+  drupal_set_message('<pre>' . print_r($node, 1) . '</pre>');
+  drupal_set_message('<pre>' . print_r($context, 1) . '</pre>');
+  if ($context['method'] == 'save-edit') {
+
+    // Get the ID of the next node to be created:
+    $new_nid = db_query("SELECT LAST_INSERT_ID() FROM {node}")->fetchAssoc();
+    drupal_set_message('nid: "' . print_r($new_nid, 1) . '"');
+    
+    //_fundraiser_reent_donors_clone_node_optin_data($context['original_node']->nid, $new_nid);
+  }
+}
+
+/**
+ * Copies opt-in data when a node is being cloned using the "Pre-populate the node form fields" method.
+ */
+function _fundraiser_recent_donors_clone_opt_in_data_on_clone_form_submit(&$form, $original_nid) {
+  dpm($form);
 }
 
 
 // Helper functions:
 
 /**
- * Helper function to check whether a given form has recent donation opt-in enabled:
+ * Duplicates the node-specific, opt-in settings for a given node.
+ * This is used during node cloning.
+ *
+ * @param $original_nid
+ *   The node ID of the original donation form.
+ * @param $new_nid
+ *   The node ID of the newly cloned donation form.
+ */
+function _fundraiser_reent_donors_clone_node_optin_data($original_nid, $new_nid) {
+  // Fetch the original node's opt-in data:
+  $opt_in_query = db_query("SELECT min_donation_amount, visibility " .
+    "FROM {fundraiser_donation_opt_in_block} " .
+    "WHERE nid = :nid",
+    array(':nid' => $original_nid));
+  foreach ($opt_in_query as $data) {
+    dpm($data);
+    // Duplicate the original node's opt-in data for the newly cloned node:
+    db_query("INSERT INTO {fundraiser_donation_opt_in_block} " .
+      "(nid, min_donation_amount, visibility) VALUES (:nid, :min_donation_amount, :visibility)",
+      array(
+        ':nid' => $new_nid,
+        ':min_donation_amount' => $data->min_donation_amount,
+        ':visibility' => $data->visibility,
+      ));
+    break; // There shouldn't be more than one record per node, but just in case.
+  }
+}
+
+/**
+ * Checks whether a given form has recent donation opt-in enabled:
  *
  * @param $nid
  *   Node ID of the donation form in question.
@@ -359,7 +426,7 @@ function _fundraiser_recent_donors_opt_in_enabled($nid) {
 }
 
 /**
- * Helper function to return the minimum opt-in donation amount for results to be displayed
+ * Returns the minimum opt-in donation amount for results to be displayed
  * in the associated view.
  *
  * @param $nid
@@ -376,7 +443,7 @@ function _fundraiser_recent_donors_get_min_opt_in_donation_amount($nid) {
 }
 
 /**
- * Helper function to display the rendered HTML of the recent op-in donations block.
+ * Displays the rendered HTML of the recent op-in donations block.
  */
 function _fundraiser_recent_donors_render_donation_block() {
   // Display nothing if the opt-in feature is not enabled for the current node:
@@ -392,7 +459,7 @@ function _fundraiser_recent_donors_render_donation_block() {
 }
 
 /**
- * Helper function to insert the opt-in checkbox onto the donation webform if it
+ * Inserts the opt-in checkbox onto the donation webform if it
  * does not already exist:
  *
  * @params $node

--- a/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
+++ b/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
@@ -453,7 +453,6 @@ function _fundraiser_recent_donors_add_opt_in_webform_component($node) {
 
   // Do nothing if the opt-in checkbox's form_key already exists on the form:
   $highest_component_weight = 0;
-  dpm($node->webform['components']);
   foreach ($node->webform['components'] as $component) {
     // Find the Payment Information pid if it exists so the opt-in checkbox can be placed within it:
     if ($component['form_key'] == 'payment_method' && !empty($component['pid'])) {

--- a/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
+++ b/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
@@ -283,10 +283,11 @@ function fundraiser_recent_donors_views_query_alter(&$view, &$query) {
 /**
  * Implements hook_views_post_execute().
  *
- * Replace the raw, currency-agnostic value initial displayed
- * with currency-formatted output.  This is because an adjusted
- * total with any particularlly refunded amount subtracted is
- * a derived value.
+ * Alter the value displayed for partially refunded donations as the
+ * updated value is derived by subtracting the balance from the order total.
+ *
+ * Also exclude any rows whose partially refunded values are below the minimum
+ * opt-in donation amount as defined within this donation's node.
  */
 function fundraiser_recent_donors_views_post_execute(&$view) {
   if ($view->name != 'recent_opt_in_donations' || !isset($view->args[0])) {
@@ -403,7 +404,7 @@ function _fundraiser_recent_donors_add_opt_in_webform_component($node) {
     'nid' => $node->nid,
     'pid' => 0,
     'form_key' => FUNDRAISER_RECENT_DONORS_OPT_IN_FORM_KEY,
-    'name' => t('Opt in '),
+    'name' => t('Opt in') . ' ',
     'type' => 'select',
     'extra' => array(
       'items' => FUNDRAISER_RECENT_DONORS_OPT_IN_FORM_KEY . '|' .

--- a/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
+++ b/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
@@ -78,7 +78,8 @@ function fundraiser_recent_donors_form_alter(&$form, &$form_state, $form_id) {
     if ($currency['symbol_placement'] == 'before') { 
       $currency_symbol = '<span class="recent-donors-currency-symbol-before">' . $currency['symbol'] . '</span>';
       $form['springboard_display']['recent_donors_list']['show_recent_donation_greater_than']['#prefix'] = $currency_symbol;
-    } else {
+    }
+    else {
       $currency_symbol = '<span class="recent-donors-currency-symbol-after">' . $currency['symbol'] . '</span>';
       $form['springboard_display']['recent_donors_list']['show_recent_donation_greater_than']['#suffix'] = $currency_symbol;
     }
@@ -102,11 +103,6 @@ function fundraiser_recent_donors_form_alter(&$form, &$form_state, $form_id) {
       '#description' => _fundraiser_recent_donors_render_donation_block(),
       '#weight' => 99999,
     );
-  }
-
-  // Handle the "Pre-popualte the node form fields" method for cloning a node:
-  if ($arg2 == 'clone') {
-    _fundraiser_recent_donors_clone_opt_in_data_on_clone_form_submit($form, $form['#node']->nid);
   }
 }
 
@@ -191,10 +187,27 @@ function _fundraiser_recent_donors_node_edit_submit($form, &$form_state) {
 
 /**
  * Implements hook_node_insert().
+
+ * 1. Add the opt-in checkbox if opt-in is enabled for this node.
+ * 
+ * 2. When a donation form node is cloned by the node_clone module, also copy its opt-in settings.
+ *
+ * Those settings are:
+ * - Is opt-in enabled for this node
+ * - What is the opt-in minimum value for a donation to be displayed.
  */
 function fundraiser_recent_donors_node_insert($node) {
-  // Add the opt-in checkbox if opt-in is enabled for this node:
+  if (!fundraiser_is_donation_type($node->type)) {
+    return;
+  }
+
+  // Add the opt-in checkbox if needed:
   _fundraiser_recent_donors_add_opt_in_webform_component($node);
+
+  // Duplicate opt-in data if this node is being created via the node_clone module:
+  if (isset($node->clone_from_original_nid)) {
+    _fundraiser_recent_donors_clone_node_optin_data($node->clone_from_original_nid, $node->nid);
+  }
 }
 
 /**
@@ -345,40 +358,6 @@ function fundraiser_recent_donors_views_post_execute(&$view) {
 }
 
 
-// Node clone support:
-
-/**
- * Implements hook_clone_node_alter() from Node clone module.
- *
- * From: http://drupal.org/node/1256478
- * 
- * When the cloning method is "save-edit", this copies node-specific, opt-in settings.
- *
- * Those settings are:
- * 1. Is opt-in enabled for this node
- * 2. What is the opt-in minimum value for a donation to be displayed.
- */
-function fundraiser_recent_donors_clone_node_alter(&$node, $context) {
-  drupal_set_message('<pre>' . print_r($node, 1) . '</pre>');
-  drupal_set_message('<pre>' . print_r($context, 1) . '</pre>');
-  if ($context['method'] == 'save-edit') {
-
-    // Get the ID of the next node to be created:
-    $new_nid = db_query("SELECT LAST_INSERT_ID() FROM {node}")->fetchAssoc();
-    drupal_set_message('nid: "' . print_r($new_nid, 1) . '"');
-    
-    //_fundraiser_reent_donors_clone_node_optin_data($context['original_node']->nid, $new_nid);
-  }
-}
-
-/**
- * Copies opt-in data when a node is being cloned using the "Pre-populate the node form fields" method.
- */
-function _fundraiser_recent_donors_clone_opt_in_data_on_clone_form_submit(&$form, $original_nid) {
-  dpm($form);
-}
-
-
 // Helper functions:
 
 /**
@@ -390,14 +369,13 @@ function _fundraiser_recent_donors_clone_opt_in_data_on_clone_form_submit(&$form
  * @param $new_nid
  *   The node ID of the newly cloned donation form.
  */
-function _fundraiser_reent_donors_clone_node_optin_data($original_nid, $new_nid) {
+function _fundraiser_recent_donors_clone_node_optin_data($original_nid, $new_nid) {
   // Fetch the original node's opt-in data:
   $opt_in_query = db_query("SELECT min_donation_amount, visibility " .
     "FROM {fundraiser_donation_opt_in_block} " .
     "WHERE nid = :nid",
     array(':nid' => $original_nid));
   foreach ($opt_in_query as $data) {
-    dpm($data);
     // Duplicate the original node's opt-in data for the newly cloned node:
     db_query("INSERT INTO {fundraiser_donation_opt_in_block} " .
       "(nid, min_donation_amount, visibility) VALUES (:nid, :min_donation_amount, :visibility)",

--- a/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
+++ b/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
@@ -54,6 +54,8 @@ function fundraiser_recent_donors_form_alter(&$form, &$form_state, $form_id) {
     if (isset($form['#node']->nid)) {
       $show_greater_than = _fundraiser_recent_donors_get_min_opt_in_donation_amount($form['#node']->nid);
     }
+
+    // The currency for the "Only show donations greater than" is whatever the node's default currency setting is:
     $form['springboard_display']['recent_donors_list']['show_recent_donation_greater_than'] = array(
       '#type' => 'textfield',
       '#title' => t('Only show donations greater than'),
@@ -67,7 +69,20 @@ function fundraiser_recent_donors_form_alter(&$form, &$form_state, $form_id) {
           ':input[name="allow_recent_donations_opt_in"]' => array('checked' => TRUE),
         ),
       ),
-    ); 
+    );
+
+    // Adjust this field's HTML so prefic/suffix symbols are inline; add the symbols:
+    $form['#attached']['js'][] =  drupal_get_path('module', 'fundraiser_recent_donors') . '/js/fundraiser_recent_donors.js';
+    $form['#attached']['css'][] =  drupal_get_path('module', 'fundraiser_recent_donors') . '/css/fundraiser_recent_donors.css';
+    $currency = fundraiser_get_currency_from_node($form['#node']);
+    if ($currency['symbol_placement'] == 'before') { 
+      $currency_symbol = '<span class="recent-donors-currency-symbol-before">' . $currency['symbol'] . '</span>';
+      $form['springboard_display']['recent_donors_list']['show_recent_donation_greater_than']['#prefix'] = $currency_symbol;
+    } else {
+      $currency_symbol = '<span class="recent-donors-currency-symbol-after">' . $currency['symbol'] . '</span>';
+      $form['springboard_display']['recent_donors_list']['show_recent_donation_greater_than']['#suffix'] = $currency_symbol;
+    }
+ 
     $form['#validate'][] = '_fundraiser_recent_donors_node_edit_validate';
     $form['#submit'][] = '_fundraiser_recent_donors_node_edit_submit';
     return;

--- a/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
+++ b/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
@@ -110,27 +110,34 @@ function fundraiser_recent_donors_form_alter(&$form, &$form_state, $form_id) {
  * Form submission for the donation form's op-in checkbox:
  */
 function _fundraiser_recent_donors_donation_form_submit($form, &$form_state) {
-  $form_key = FUNDRAISER_RECENT_DONORS_OPT_IN_FORM_KEY;
-  if (isset($form['#node']->nid) &&
-    isset($form_state['input']['submitted'][$form_key][$form_key])) {
-    // Get the donation ID:
-    $did_query = db_query("SELECT did FROM {fundraiser_donation} WHERE sid = :sid AND nid = :nid",
+  if (!isset($form['#node']->nid) || !isset($form_state['input']['submitted'])) {
+    return;
+  }
+
+  // Determine if the donor checked the opt-in box by flattening the webform component values to account
+  // for placement in or outside of fieldset:
+  $flattened_values = _fundraiser_webform_submission_flatten($form['#node']->nid, $form_state['input']['submitted']);
+  if (!isset($flattened_values[FUNDRAISER_RECENT_DONORS_OPT_IN_FORM_KEY])) { 
+    return;
+  }
+
+  // Get the donation ID:
+  $did_query = db_query("SELECT did FROM {fundraiser_donation} WHERE sid = :sid AND nid = :nid",
+    array(
+      ':sid' => $form_state['values']['details']['sid'],
+      ':nid' => $form_state['values']['details']['nid'],
+    )
+  );
+  foreach ($did_query as $did_data) {
+    db_query("INSERT INTO {fundraiser_donor_opt_in} VALUES (:sid, :nid, :did, :created)",
       array(
         ':sid' => $form_state['values']['details']['sid'],
         ':nid' => $form_state['values']['details']['nid'],
+        ':did' => $did_data->did,
+        ':created' => time(),
       )
     );
-    foreach ($did_query as $did_data) {
-      db_query("INSERT INTO {fundraiser_donor_opt_in} VALUES (:sid, :nid, :did, :created)",
-        array(
-          ':sid' => $form_state['values']['details']['sid'],
-          ':nid' => $form_state['values']['details']['nid'],
-          ':did' => $did_data->did,
-          ':created' => time(),
-        )
-      );
-      return;
-    }
+    return;
   }
 }
 

--- a/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
+++ b/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
@@ -438,7 +438,9 @@ function _fundraiser_recent_donors_render_donation_block() {
 
 /**
  * Inserts the opt-in checkbox onto the donation webform if it
- * does not already exist:
+ * does not already exist.  It will be placed at the bottom of the
+ * Payment Information fieldset if available; otherwise, it will be placed
+ * after the final webform component.
  *
  * @params $node
  *   The node object for the webform on which the opt-in checkbox will be added.
@@ -450,19 +452,25 @@ function _fundraiser_recent_donors_add_opt_in_webform_component($node) {
   }
 
   // Do nothing if the opt-in checkbox's form_key already exists on the form:
-  $max_weight = 0;
+  $highest_component_weight = 0;
+  dpm($node->webform['components']);
   foreach ($node->webform['components'] as $component) {
-    if ($component['weight'] > $max_weight) {
-      $max_weight = $component['weight'];
+    // Find the Payment Information pid if it exists so the opt-in checkbox can be placed within it:
+    if ($component['form_key'] == 'payment_method' && !empty($component['pid'])) {
+      $target_fieldset_parent_id = $component['pid'];
+    }
+    // Ensure this component sits below any others by find the highest component
+    if ($component['weight'] > $highest_component_weight) {
+      $highest_component_weight = $component['weight'];
     }
     if ($component['form_key'] == FUNDRAISER_RECENT_DONORS_OPT_IN_FORM_KEY) {
       return;
     }
   }
-
+  
   $component = array(
     'nid' => $node->nid,
-    'pid' => 0,
+    'pid' => $target_fieldset_parent_id,
     'form_key' => FUNDRAISER_RECENT_DONORS_OPT_IN_FORM_KEY,
     'name' => t('Opt in') . ' ',
     'type' => 'select',
@@ -472,7 +480,7 @@ function _fundraiser_recent_donors_add_opt_in_webform_component($node) {
       'multiple' => 1,
       'title_display' => 'none',
     ),
-    'weight' => 9999,
+    'weight' => $highest_component_weight + 1, 
   ); 
   webform_component_insert($component);
 }

--- a/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
+++ b/fundraiser/modules/fundraiser_recent_donors/fundraiser_recent_donors.module
@@ -142,7 +142,7 @@ function _fundraiser_recent_donors_node_edit_validate($form, &$form_state) {
     $min_amount = $form_state['values']['show_recent_donation_greater_than'];
     if (!is_numeric($min_amount) || $min_amount < 0) {
       form_set_error('show_recent_donation_greater_than',
-        t('Please enter a number greater than 0 within the "Only show donations greater than" field.'));
+        t('Please enter a valid number in the "Only show donations greater than" field.'));
     }
   }
 }

--- a/fundraiser/modules/fundraiser_recent_donors/includes/fundraiser_recent_donors.views_default.inc
+++ b/fundraiser/modules/fundraiser_recent_donors/includes/fundraiser_recent_donors.views_default.inc
@@ -90,6 +90,15 @@ function fundraiser_recent_donors_views_default_views() {
   $handler->display->display_options['arguments']['nid']['summary']['number_of_records'] = '0';
   $handler->display->display_options['arguments']['nid']['summary']['format'] = 'default_summary';
   $handler->display->display_options['arguments']['nid']['summary_options']['items_per_page'] = '25';
+  /* Filter criterion: Commerce Order: Order status */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'commerce_order';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['relationship'] = 'did';
+  $handler->display->display_options['filters']['status']['value'] = array(
+    'payment_received' => 'payment_received',
+    'partially_refunded' => 'partially_refunded',
+  );
 
   /* Display: Block */
   $handler = $view->new_display('block', 'Block', 'block');

--- a/fundraiser/modules/fundraiser_recent_donors/includes/fundraiser_recent_donors.views_default.inc
+++ b/fundraiser/modules/fundraiser_recent_donors/includes/fundraiser_recent_donors.views_default.inc
@@ -97,7 +97,6 @@ function fundraiser_recent_donors_views_default_views() {
   $handler->display->display_options['filters']['status']['relationship'] = 'did';
   $handler->display->display_options['filters']['status']['value'] = array(
     'payment_received' => 'payment_received',
-    'partially_refunded' => 'partially_refunded',
   );
 
   /* Display: Block */

--- a/fundraiser/modules/fundraiser_recent_donors/js/fundraiser_recent_donors.js
+++ b/fundraiser/modules/fundraiser_recent_donors/js/fundraiser_recent_donors.js
@@ -1,9 +1,15 @@
 /**
- * Position currency suffix/prefix inline with the "Only show donations greater than" field.
+ * @file
+ * js for Fundraiser Recent Donors
  */
+
 Drupal.behaviors.fundraiserRecentDonorsBehavior = {
   attach: function(context) { (function($) {
+    // Position the opt-in checkbox near the submit button:
+
+    // Position currency suffix/prefix inline with the "Only show donations greater than" field:
     $('.form-item-show-recent-donation-greater-than input#edit-show-recent-donation-greater-than').after($('span.recent-donors-currency-symbol-after'));
     $('.form-item-show-recent-donation-greater-than input#edit-show-recent-donation-greater-than').before($('span.recent-donors-currency-symbol-before'));
   })(jQuery); }
 }
+

--- a/fundraiser/modules/fundraiser_recent_donors/js/fundraiser_recent_donors.js
+++ b/fundraiser/modules/fundraiser_recent_donors/js/fundraiser_recent_donors.js
@@ -1,0 +1,9 @@
+/**
+ * Position currency suffix/prefix inline with the "Only show donations greater than" field.
+ */
+Drupal.behaviors.fundraiserRecentDonorsBehavior = {
+  attach: function(context) { (function($) {
+    $('.form-item-show-recent-donation-greater-than input#edit-show-recent-donation-greater-than').after($('span.recent-donors-currency-symbol-after'));
+    $('.form-item-show-recent-donation-greater-than input#edit-show-recent-donation-greater-than').before($('span.recent-donors-currency-symbol-before'));
+  })(jQuery); }
+}


### PR DESCRIPTION
* 800 - Updated min-donation amount field validation error message for clarity
* 801 - refunded donation should not be included in the list
* 801 - partially-refunded donation amount should be reflected in recent donors block
* 801 - Update min opt-in display amount filtering to respect the partial refund amount 
* 802 - Recent donors opt-in placement (changed to bottom of payment info)
* 804 - Prefix/suffix min-donation amount with donation node’s current currency
* 807 - On donation form node clone, also duplicate opt-in settings