### PR TITLE
tweak preview page access hooks

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/sba_message_action.module
+++ b/springboard_advocacy/modules/sba_message_action/sba_message_action.module
@@ -145,7 +145,7 @@ function sba_message_action_queues_access($nid) {
 function sba_message_action_preview_access($nid) {
   $node = node_load($nid);
   if (isset($node->type) &&  $node->type == 'sba_message_action') {
-    $session_nid = isset($_SESSION['action_sid']['nid']) ? $_SESSION['action_sid']['nid'] : 0;
+    $session_nid = isset($_SESSION['action_sid']['nid']) ? $_SESSION['action_sid']['nid'] : FALSE;
     if (($session_nid && $session_nid != $nid)) {
       return FALSE;
     }

--- a/springboard_advocacy/modules/sba_message_action/sba_message_action.module
+++ b/springboard_advocacy/modules/sba_message_action/sba_message_action.module
@@ -144,16 +144,14 @@ function sba_message_action_queues_access($nid) {
  */
 function sba_message_action_preview_access($nid) {
   $node = node_load($nid);
+  $access = FALSE;
   if (isset($node->type) &&  $node->type == 'sba_message_action') {
     $session_nid = isset($_SESSION['action_sid']['nid']) ? $_SESSION['action_sid']['nid'] : FALSE;
-    if (($session_nid && $session_nid != $nid)) {
-      return FALSE;
-    }
-    if (!$session_nid) {
-      return FALSE;
+    if ($session_nid && $session_nid == $nid) {
+      $access = TRUE;
     }
   }
-  return TRUE;
+  return $access;
 }
 
 /**

--- a/springboard_advocacy/modules/sba_social_action/sba_social_action.module
+++ b/springboard_advocacy/modules/sba_social_action/sba_social_action.module
@@ -82,16 +82,14 @@ function sba_social_action_menu() {
  */
 function sba_social_action_preview_access($nid) {
   $node = node_load($nid);
+  $access = FALSE;
   if (isset($node->type) &&  $node->type == 'sba_social_action') {
     $session_nid = isset($_SESSION['social_action_sid']['nid']) ? $_SESSION['social_action_sid']['nid'] : FALSE;
-    if ($session_nid && $session_nid != $nid) {
-      return FALSE;
-    }
-    if (!$session_nid) {
-      return FALSE;
+    if ($session_nid && $session_nid == $nid) {
+      $access = TRUE;
     }
   }
-  return TRUE;
+  return $access;
 }
 
 /**


### PR DESCRIPTION
The previous version sometimes allowed substitution of random nids in the url to produce a page with a php notice rather than access denied.