### PR TITLE
update the action flow field widget weight on node edit forms

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/sba_message_action.install
+++ b/springboard_advocacy/modules/sba_message_action/sba_message_action.install
@@ -603,3 +603,14 @@ function sba_message_action_update_7029() {
     field_update_instance($field);
   }
 }
+
+/**
+ * Update action_flow field widget weight.
+ */
+function sba_message_action_update_7030() {
+  $field = field_info_instance('node', 'field_sba_action_flow', 'sba_message_action');
+  if ($field) {
+    $field['widget']['weight'] = 4;
+    field_update_instance($field);
+  }
+}


### PR DESCRIPTION
Update the field_sba_action_flow widget weight on sites already implementing message actions so that it is in the correct top position within the multiflow fieldset on node add/edit pages.