### PR TITLE
stop quicksign from nulling values of non-profile components

### DIFF
--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -256,8 +256,10 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
 function _sba_quicksign_build_values(&$form, &$form_state, $node, $profile) {
   $quick_values = sba_quicksign_values_tree_build($profile, $node->webform['components'], $tree, 0);
   foreach ($quick_values as $key => $value) {
-    form_set_value($form['submitted'][$key],  $value, $form_state);
-    $form_state['complete form']['submitted'][$key]['#value'] = $value;
+    if (isset($value) || $key == 'sba_quicksign') {
+      form_set_value($form['submitted'][$key], $value, $form_state);
+      $form_state['complete form']['submitted'][$key]['#value'] = $value;
+    }
   }
 }
 
@@ -292,16 +294,15 @@ function _sba_quicksign_find_field_form_state($form_state_values, $path) {
 function sba_quicksign_values_tree_build($profile, $src, &$tree, $parent) {
 
   foreach ($src as $cid => $component) {
-    $value = isset($component['value']) ? $component['value'] : NULL;
     if ($component['pid']) {
       $parent_key = $src[$component['pid']]['form_key'];
       if (!isset($tree[$parent_key])) {
         $tree[$parent_key] = array();
       }
-      $tree[$parent_key][$component['form_key']] = isset($profile[$component['form_key']]) ? $profile[$component['form_key']] : $value;
+      $tree[$parent_key][$component['form_key']] = isset($profile[$component['form_key']]) ? $profile[$component['form_key']] : NULL;
     }
     else {
-      $tree[$component['form_key']] = isset($profile[$component['form_key']]) ? $profile[$component['form_key']] : $value;
+      $tree[$component['form_key']] = isset($profile[$component['form_key']]) ? $profile[$component['form_key']] : NULL;
     }
   }
   return $tree;

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -292,15 +292,16 @@ function _sba_quicksign_find_field_form_state($form_state_values, $path) {
 function sba_quicksign_values_tree_build($profile, $src, &$tree, $parent) {
 
   foreach ($src as $cid => $component) {
+    $value = isset($component['value']) ? $component['value'] : NULL;
     if ($component['pid']) {
       $parent_key = $src[$component['pid']]['form_key'];
       if (!isset($tree[$parent_key])) {
         $tree[$parent_key] = array();
       }
-      $tree[$parent_key][$component['form_key']] = isset($profile[$component['form_key']]) ? $profile[$component['form_key']] : NULL;
+      $tree[$parent_key][$component['form_key']] = isset($profile[$component['form_key']]) ? $profile[$component['form_key']] : $value;
     }
     else {
-      $tree[$component['form_key']] = isset($profile[$component['form_key']]) ? $profile[$component['form_key']] : NULL;
+      $tree[$component['form_key']] = isset($profile[$component['form_key']]) ? $profile[$component['form_key']] : $value;
     }
   }
   return $tree;


### PR DESCRIPTION
Quicksign was setting the default value of non-webform-user components to NULL instead of the default