### PR TITLE
use empty not isset in quicksign_node_insert

### DIFF
--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -358,7 +358,7 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
  * Implements hook_node_insert().
  */
 function sba_quicksign_node_insert($node) {
-  if (sba_quicksign_is_quicksign_type($node->type) && isset($node->quicksign_enabled)) {
+  if (sba_quicksign_is_quicksign_type($node->type) && !empty($node->quicksign_enabled)) {
     sba_quicksign_save($node);
     sba_quicksign_insert_components($node, 'insert');
   }


### PR DESCRIPTION
The quicksign component was being added (but not activated or visible) by default to every new quicksign-eligible node, even if quicksign was disabled for that node.