### PR TITLE
Added check for empty user agent before populating device info fields.

### DIFF
--- a/market_source/market_source.module
+++ b/market_source/market_source.module
@@ -363,28 +363,31 @@ function market_source_webform_after_build($form, &$form_state) {
   // Populate device info fields.
   if (libraries_load('mobiledetect')) {
     $mobile_detect = new Market_Source_Mobile_Detect();
-    $device_properties = $mobile_detect->getDeviceProperties();
 
-    if (!$mobile_detect->isMobile()) {
-      if (libraries_load('phpuseragent')) {
-        $ua_parse = parse_user_agent($mobile_detect->getUserAgent());
+    if (!empty($mobile_detect->getUserAgent())) {
+      $device_properties = $mobile_detect->getDeviceProperties();
 
-        $device_properties['os'] = $ua_parse['platform'];
-        $device_properties['browser'] = $ua_parse['browser'] . ' ' . $ua_parse['version'];
+      if (!$mobile_detect->isMobile()) {
+        if (libraries_load('phpuseragent')) {
+          $ua_parse = parse_user_agent($mobile_detect->getUserAgent());
+
+          $device_properties['os'] = $ua_parse['platform'];
+          $device_properties['browser'] = $ua_parse['browser'] . ' ' . $ua_parse['version'];
+        }
       }
+
+      $device_type = &_market_source_form_find_element($form, 'device_type');
+      $device_type['#value'] = $device_properties['type'];
+
+      $device_name = &_market_source_form_find_element($form, 'device_name');
+      $device_name['#value'] = $device_properties['name'];
+
+      $device_os = &_market_source_form_find_element($form, 'device_os');
+      $device_os['#value'] = $device_properties['os'];
+
+      $device_browser = &_market_source_form_find_element($form, 'device_browser');
+      $device_browser['#value'] = $device_properties['browser'];
     }
-
-    $device_type = &_market_source_form_find_element($form, 'device_type');
-    $device_type['#value'] = $device_properties['type'];
-
-    $device_name = &_market_source_form_find_element($form, 'device_name');
-    $device_name['#value'] = $device_properties['name'];
-
-    $device_os = &_market_source_form_find_element($form, 'device_os');
-    $device_os['#value'] = $device_properties['os'];
-
-    $device_browser = &_market_source_form_find_element($form, 'device_browser');
-    $device_browser['#value'] = $device_properties['browser'];
   }
 
   // Mandatory return value for #after_build callbacks.


### PR DESCRIPTION
Using the MobileDetect to check for an empty user agent instead of something like empty($_SERVER['http_user_agent']) because MobileDetect checks for all possible locations of the user agent string.