### PR TITLE
Reset text search field

### DIFF
--- a/springboard_advocacy/modules/sba_message/js/sba_message.js
+++ b/springboard_advocacy/modules/sba_message/js/sba_message.js
@@ -1279,6 +1279,8 @@
             }
             if (this.type == 'text') {
                 $(this).val('');
+                $(this).prop('disabled', false);
+                $(this).removeClass('disabled');
             }
         });
         $('.views-targets-button-wrapper').fadeOut(333);


### PR DESCRIPTION
On the message admin page, if you choose a state and then a district from the select options, various fields become disabled. Clicking the reset link clears and undisables them. The text entry "first name or last name" field was not becoming re-enabled after reset.