### PR TITLE
7.x 4.x 840 quicksign keep visible

### DIFF
--- a/salesforce/salesforce_message_action/salesforce_message_action.install
+++ b/salesforce/salesforce_message_action/salesforce_message_action.install
@@ -64,6 +64,7 @@ function salesforce_message_action_create_actions_taken_fieldmap() {
       'device_name' => 'Device_Name__c',
       'device_os' => 'Device_OS__c',
       'device_browser' => 'Device_Browser__c',
+      'sba_quicksign_flag' =>'Quick_Sign__c',
     ),
     'salesforce_node_map' => array(
       'title' => 'Name',

--- a/salesforce/salesforce_petition/salesforce_petition.install
+++ b/salesforce/salesforce_petition/salesforce_petition.install
@@ -57,6 +57,7 @@ function salesforce_petition_create_petition_action_fieldmap() {
       'device_name' => 'Device_Name__c',
       'device_os' => 'Device_OS__c',
       'device_browser' => 'Device_Browser__c',
+      'sba_quicksign_flag' =>'Quick_Sign__c',
     ),
     'salesforce_node_map' => array(
       'title' => 'Name',

--- a/salesforce/salesforce_social_action/salesforce_social_action.install
+++ b/salesforce/salesforce_social_action/salesforce_social_action.install
@@ -83,6 +83,7 @@ function salesforce_social_action_create_actions_taken_fieldmap() {
       'device_name' => 'Device_Name__c',
       'device_os' => 'Device_OS__c',
       'device_browser' => 'Device_Browser__c',
+      'sba_quicksign_flag' =>'Quick_Sign__c',
     ),
     'salesforce_node_map' => array(
       'title' => 'Name',

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
@@ -331,7 +331,7 @@ function sba_message_action_message_form(&$form, $message, $action_type) {
  * @param $form
  * @param $form_state
  */
-function sba_message_action_form_validate($form, &$form_state) {
+function sba_message_action_form_validate(&$form, &$form_state) {
   $node = $form['#node'];
   $node_wrapper = entity_metadata_wrapper('node', $node);
   $multi_flow = $node_wrapper->field_sba_action_flow->value() == 'multi' ? TRUE : FALSE;
@@ -350,11 +350,13 @@ function sba_message_action_form_validate($form, &$form_state) {
     // Enforce mandatory editing.
     if ($body_edited == $body_default && isset($message['body_required']) && $message['body_required']['#value'] == 1) {
         form_set_error('body_editable', t('Please personalize your message before sending.'));
+        $form['sba_messages']['message'][$message_id]['edited_body']['#attributes']['class'][] =  'error';
     }
     elseif ($body_edited != $body_default) {
       $changed = TRUE;
     }
     if ($subject_edited == $subject_default && isset($message['subject_required']) && $message['subject_required']['#value'] == 1) {
+       $form['sba_messages']['message'][$message_id]['subject']['#attributes']['class'][] =  'error';
         form_set_error('subject', t('Please personalize the subject line before sending your message.'));
     }
     elseif (!isset($message['subject_show']) && $subject_edited != $subject_default) {
@@ -376,7 +378,9 @@ function sba_message_action_form_validate($form, &$form_state) {
     }
   }
   else {
-    form_set_error('', t('We could not verify your address. Please check that the street, city, state and zip code information is correct.'));
+    if (empty($form_state['storage']['quicksign_validated'])) {
+      form_set_error('', t('We could not verify your address. Please check that the street, city, state and zip code information is correct.'));
+    }
   }
 }
 

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -166,6 +166,9 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
   $component_hierarchy = webform_user_parse_components($node->nid, $components);
   $qsign_value = _sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy['sba_quicksign']);
   $quicksign_field = &_webform_user_find_field($form, $component_hierarchy['sba_quicksign']);
+  if (isset($component_hierarchy['sba_quicksign_flag'])) {
+    $quicksign_flag = &_webform_user_find_field($form, $component_hierarchy['sba_quicksign_flag']);
+  }
 
   if (!isset($parents['sba_quicksign'])) {
     // Quicksign button was not clicked.
@@ -262,6 +265,9 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
       $form_state['node'] = $node;
       $_SESSION['sba_quicksign'] = TRUE;
       _sba_quicksign_build_values($form, $form_state, $node, $profile);
+      if (!empty($quicksign_flag)) {
+        form_set_value($quicksign_flag, 1, $form_state);
+      }
     }
   }
 }
@@ -405,6 +411,17 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
   }
 }
 
+function sba_quicksign_node_load($nodes, $types) {
+  // If no quicksign nodes are loaded no need to continue.
+  if (!array_intersect(array('springboard_petition', 'sba_social_action', 'sba_message_action'), $types)) {
+    return;
+  }
+  foreach ($nodes as $nid => $node) {
+    if (sba_quicksign_is_quicksign_type($node->type)) {
+      $node->quicksign_enabled = sba_quicksign_is_enabled($node);
+    }
+  }
+}
 
 /**
  * Implements hook_node_insert().
@@ -412,7 +429,7 @@ function sba_quicksign_form_node_form_alter(&$form, &$form_state, $form_id) {
 function sba_quicksign_node_insert($node) {
   if (sba_quicksign_is_quicksign_type($node->type) && !empty($node->quicksign_enabled)) {
     sba_quicksign_save($node);
-    sba_quicksign_insert_components($node, 'insert');
+    sba_quicksign_insert_components($node, 'insert', FALSE, FALSE);
   }
 }
 
@@ -421,22 +438,27 @@ function sba_quicksign_node_insert($node) {
  */
 function sba_quicksign_node_update($node) {
   if (sba_quicksign_is_quicksign_type($node->type)) {
-    $has_component = FALSE;
-    $cid = NULL;
+    $has_form_component = FALSE;
+    $has_flag_component = FALSE;
+    $form_cid = NULL;
+    $flag_cid = NULL;
     foreach ($node->webform['components'] as $key => $component) {
       if ($component['form_key'] == 'sba_quicksign') {
-        $has_component = TRUE;
-        $cid = $key;
+        $has_form_component = TRUE;
+        $form_cid = $key;
+      }
+      if ($component['form_key'] == 'sba_quicksign_flag') {
+        $has_flag_component = TRUE;
+        $flag_cid = $key;
       }
     }
-
     if (isset($node->quicksign_enabled)) {
       sba_quicksign_save($node);
-      if (!empty($node->quicksign_enabled) && !$has_component) {
-        sba_quicksign_insert_components($node, 'update');
+      if (!empty($node->quicksign_enabled) && (!$has_form_component || !$has_flag_component)) {
+        sba_quicksign_insert_components($node, 'update', $has_form_component, $has_flag_component);
       }
-      if (empty($node->quicksign_enabled) && $has_component) {
-        sba_quicksign_delete_components($node, $cid);
+      if (empty($node->quicksign_enabled) && ($has_form_component || $has_flag_component)) {
+        sba_quicksign_delete_components($node, $form_cid, $flag_cid);
       }
     }
   }
@@ -595,26 +617,42 @@ function sba_quicksign_is_quicksign_type($type) {
  * @param $node
  * @param $op
  */
-function sba_quicksign_insert_components($node, $op) {
+function sba_quicksign_insert_components($node, $op, $has_form_component, $has_flag_component) {
   module_load_include('inc', 'webform', 'includes/webform.components');
+  $fields = array();
 
-  $fields[] = array(
-    'nid' => $node->nid,
-    'form_key' => 'sba_quicksign',
-    'pid' => 0,
-    'name' => 'Quicksign Form',
-    'type' => 'markup',
-    'weight' => -100,
-    'email' => 0,
-    'extra' => array(
-      'attributes' => array(),
-      'private' => FALSE,
-    ),
-  );
+  if (!$has_form_component) {
+    $fields[] = array(
+      'nid' => $node->nid,
+      'form_key' => 'sba_quicksign',
+      'pid' => 0,
+      'name' => 'Quicksign Form',
+      'type' => 'markup',
+      'weight' => -100,
+      'email' => 0,
+      'extra' => array(
+        'attributes' => array(),
+        'private' => FALSE,
+      ),
+    );
+  }
+
+  if (!$has_flag_component) {
+    $fields[] = array(
+      'nid' => $node->nid,
+      'form_key' => 'sba_quicksign_flag',
+      'pid' => 0,
+      'name' => t('Quicksign Flag'),
+      'type' => 'hidden',
+      'value' => 0,
+      'weight' => -100,
+      'email' => 1,
+    );
+  }
 
   $exclude = array();
   $exclude[] = 'sba_quicksign';
-
+  $exclude[] = 'sba_quicksign_flag';
   // Add the component to the Webform.
   foreach ($fields as $field) {
     // Don't insert fields if cloning.
@@ -636,8 +674,13 @@ function sba_quicksign_insert_components($node, $op) {
  * @param $node
  * @param $cid
  */
-function sba_quicksign_delete_components($node, $cid) {
-  webform_component_delete($node, $node->webform['components'][$cid]);
+function sba_quicksign_delete_components($node, $form_cid, $flag_cid) {
+  if ($form_cid) {
+    webform_component_delete($node, $node->webform['components'][$form_cid]);
+  }
+  if ($flag_cid) {
+    webform_component_delete($node, $node->webform['components'][$flag_cid]);
+  }
 }
 
 /**

--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -83,6 +83,11 @@ function sba_quicksign_form_alter(&$form, &$form_state, $form_id) {
   }
 }
 
+/**
+ * @param $form
+ * @param $form_state
+ * @return mixed
+ */
 function sba_quicksign_after_build($form, $form_state) {
   if (!empty($form_state['input'])) {
     $form['#attached']['js'][] = drupal_get_path('module', 'sba_quicksign') . '/js/sba_quicksign.js';
@@ -90,10 +95,13 @@ function sba_quicksign_after_build($form, $form_state) {
     $components = $form['#node']->webform['components'];
     $component_hierarchy = __webform_user_parse_components($form['#node']->nid, $components);
     $quicksign_field = &_webform_user_find_field($form, $component_hierarchy['sba_quicksign']);
-    $quicksign_field['#access'] = FALSE;
+    //$quicksign_field['#access'] = FALSE;
     if (isset($parents['sba_quicksign'])) {
       $email_field = &_webform_user_find_field($form, $component_hierarchy['mail']);
-      $email_field['#value'] = $quicksign_field['children']['qsign']['quicksign_mail']['#value'];
+      $email_value = $quicksign_field['children']['qsign']['quicksign_mail']['#value'];
+      if (valid_email_address($email_value)) {
+        $email_field['#value'] = $quicksign_field['children']['qsign']['quicksign_mail']['#value'];
+      }
     }
     else {
       if (isset($_SESSION['sba_quicksign'])) {
@@ -172,11 +180,15 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
     // Validate mail field.
     $mail = isset($qsign_value['children']['qsign']['quicksign_mail']) ? $qsign_value['children']['qsign']['quicksign_mail'] : FALSE;
     if (!$mail) {
+      form_set_error('quicksign_mail', t('The quicksign email address entered is not valid.'));
+      sba_quicksign_remove_required_attr($form, $form_state);
+      $form_state['storage']['quicksign_validated'] = TRUE;
       return;
     }
 
     if (!valid_email_address($mail)) {
-      form_set_error('quicksign_mail', t('The quicksign email address entered is not valid.'));
+      sba_quicksign_remove_required_attr($form, $form_state);
+      $form_state['storage']['quicksign_validated'] = TRUE;
       return;
     }
 
@@ -190,7 +202,6 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
     $required_non_profile_fields = array_diff($required_fields, $map);
     $missing_non_profile_fields = FALSE;
     $missing_message_fields = sba_quicksign_check_message_fields($form, $form_state);
-
     foreach ($required_non_profile_fields as $form_key) {
       $field = _sba_quicksign_find_field_form_state($form_state['values'], $component_hierarchy[$form_key]);
       if (empty($field)) {
@@ -212,7 +223,9 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
         }
         else {
           // Special handling for mail
-          $profile['mail'] = $mail;
+          if (valid_email_address($mail)) {
+            $profile['mail'] = $mail;
+          }
         }
 
         if (in_array($webform_field, $required_fields)) {
@@ -232,9 +245,15 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
       form_set_value($quicksign_field, '', $form_state);
     }
 
-    if ($account && ($missing_fields || $missing_non_profile_fields || $missing_message_fields)) {
+    if ($account && ($missing_fields || $missing_non_profile_fields)) {
       drupal_set_message(t("Unfortunately, we don't have enough information on file to submit this form. Please complete the form below."));
       form_set_value($quicksign_field, '', $form_state);
+    }
+
+    if ($account && (!$missing_fields && !$missing_non_profile_fields) && $missing_message_fields) {
+      form_set_value($quicksign_field, '', $form_state);
+      $form_state['storage']['quicksign_validated'] = TRUE;
+      sba_quicksign_remove_required_attr($form, $form_state);
     }
 
     if ($account && (!$missing_fields && !$missing_non_profile_fields && !$missing_message_fields)) {
@@ -248,6 +267,30 @@ function sba_quicksign_form_validate(&$form, &$form_state) {
 }
 
 /**
+ * Sets $element['#required'] to false on webform fields.
+ *
+ * The quicksign validate hook fires before all others.  If validation fails
+ * because the quicksign email is bad, or there are missing message action
+ * fields, or there are missing webform user profile values,
+ * set all webform fields to required = false, so that the user isn't deluged
+ * with irrelevant error messages from the other webform component
+ * validation hooks because all of the webform fields are empty.
+ *
+ * @param $form
+ * @param $form_state
+ */
+function sba_quicksign_remove_required_attr(&$form, &$form_state) {
+  foreach (element_children($form) as $child) {
+    if (isset($form[$child]['#webform_component'])) {
+      $form[$child]['#required'] = FALSE;
+    }
+    sba_quicksign_remove_required_attr($form[$child], $form_state);
+  }
+}
+
+/**
+ * Helps retrieve values from nested components.
+ *
  * @param $form
  * @param $original_form_state
  * @param $node
@@ -263,6 +306,13 @@ function _sba_quicksign_build_values(&$form, &$form_state, $node, $profile) {
   }
 }
 
+/**
+ * Helps retrieve values from nested components.
+ *
+ * @param $form_state_values
+ * @param $path
+ * @return mixed
+ */
 function _sba_quicksign_find_field_form_state($form_state_values, $path) {
   foreach (array_keys($path) as $v) {
     if (is_array($path[$v]) && count($path[$v])) {
@@ -645,6 +695,17 @@ function sba_quicksign_element_process_text_format($element) {
   return $element;
 }
 
+/**
+ * Checks for changed values on message action fields.
+ *
+ * Allows quicksign to check if there are message action message
+ * fields that will fail validation on single-step, single-message actions
+ * on which the body or subject field is required to be edited.
+ *
+ * @param $form
+ * @param $form_state
+ * @return bool
+ */
 function sba_quicksign_check_message_fields($form, $form_state) {
   $node = $form['#node'];
   $error = FALSE;


### PR DESCRIPTION
1. Make quicksign form stay visible, even after validation failure.
2. Adds a field to sync with salesforce quicksign flag.
3. Makes validation failure less messy:

On single-step, editing-required quick-signed message actions, if the user passes validation, but the required editing fields don't because they have not been changed, only the required editing fields will be made to error - no more long list of "x field is required" for the user fields, when the quicksign button is clicked. If the required-editing fields are changed by the user, and then quicksign is clicked again, the form will submit successfully.

Also, the message action required-editing fields will get outlined in red if they fail validation because the user did not change them. Previous there no indication in the UI, except for a DSM, of which fields failed.
