### PR TITLE
7.x 4.x 526 clone message entities

### DIFF
--- a/springboard_advocacy/modules/sba_message/sba_message.admin.inc
+++ b/springboard_advocacy/modules/sba_message/sba_message.admin.inc
@@ -322,14 +322,7 @@ function sba_message_edit_form_submit(&$form, &$form_state) {
     $sba_message->data['weight']  = $weight + 1;
     $sba_message->save();
 
-    $record = array(
-      'view_name' => 'sba_messages_node',
-      'view_display' => 'block_1',
-      'args' => $arg,
-      'entity_id' => $sba_message->sba_message_id,
-      'weight' => $weight + 1,
-    );
-    drupal_write_record('draggableviews_structure', $record);
+    sba_message_draggable_save($arg, $sba_message->sba_message_id, $sba_message->data['weight']);
   }
 
   form_load_include($form_state, 'inc', 'sba_message', 'sba_message.api_calls');

--- a/springboard_advocacy/modules/sba_message/sba_message.module
+++ b/springboard_advocacy/modules/sba_message/sba_message.module
@@ -207,6 +207,24 @@ function sba_message_drag_submit(&$form, &$form_state) {
 }
 
 /**
+ * Save a draggable views record.
+ *
+ * @param $arg
+ * @param $sba_message_id
+ * @param $weight
+ */
+function sba_message_draggable_save($arg, $sba_message_id, $weight) {
+  $record = array(
+    'view_name' => 'sba_messages_node',
+    'view_display' => 'block_1',
+    'args' => $arg,
+    'entity_id' => $sba_message_id,
+    'weight' => $weight,
+  );
+  drupal_write_record('draggableviews_structure', $record);
+}
+
+/**
  * Implements hook_node_delete().
  *
  * When an action node is deleted, delete its messages.
@@ -548,39 +566,6 @@ function sba_message_preprocess_views_exposed_form(&$vars, $hook) {
   if (isset($vars['theme_hook_suggestion']) &&  $vars['theme_hook_suggestion'] == 'views_exposed_form__targets__block_3') {
     unset($vars['form']['submit']['#printed']);
     $vars['target_button'] = drupal_render($vars['form']['submit']);
-  }
-}
-
-function sba_message_node_insert($node) {
-  $message_types = variable_get('sba_message_node_types', array());
-  if (isset($message_types[$node->type])) {
-    if (!empty($node->clone_from_original_nid)) {
-      foreach ($node->messages as $id => $message) {
-        $message->sba_message_id = NULL;
-        unset($message->data['group_id']);
-        $message->is_new = TRUE;
-        $message->data['message_id'] = str_replace(' ', '-', uniqid(substr(variable_get('site_name', ''), 0, 10) . '-' . substr($node->title, 0, 10) . '-'));
-        $message->field_sba_action_id[LANGUAGE_NONE][0]['target_id'] = $node->nid;
-        $message->save();
-
-        $arg = json_encode(array($node->nid));
-        $record = array(
-          'view_name' => 'sba_messages_node',
-          'view_display' => 'block_1',
-          'args' => $arg,
-          'entity_id' => $message->sba_message_id,
-          'weight' => $message->data['weight'],
-        );
-        drupal_write_record('draggableviews_structure', $record);
-
-        $send = array();
-        $send['values']['data']['recipients'] = $message->data['recipients'];
-        $send['values']['data']['message_id'] = $message->data['message_id'];
-        $send['values']['advocacy_id'] = $node->advocacy_id;
-        module_load_include('inc', 'sba_message', 'sba_message.api_calls');
-        _sba_message_api_save($message, TRUE, $send);
-      }
-    }
   }
 }
 

--- a/springboard_advocacy/modules/sba_message/sba_message.module
+++ b/springboard_advocacy/modules/sba_message/sba_message.module
@@ -551,6 +551,39 @@ function sba_message_preprocess_views_exposed_form(&$vars, $hook) {
   }
 }
 
+function sba_message_node_insert($node) {
+  $message_types = variable_get('sba_message_node_types', array());
+  if (isset($message_types[$node->type])) {
+    if (!empty($node->clone_from_original_nid)) {
+      foreach ($node->messages as $id => $message) {
+        $message->sba_message_id = NULL;
+        unset($message->data['group_id']);
+        $message->is_new = TRUE;
+        $message->data['message_id'] = str_replace(' ', '-', uniqid(substr(variable_get('site_name', ''), 0, 10) . '-' . substr($node->title, 0, 10) . '-'));
+        $message->field_sba_action_id[LANGUAGE_NONE][0]['target_id'] = $node->nid;
+        $message->save();
+
+        $arg = json_encode(array($node->nid));
+        $record = array(
+          'view_name' => 'sba_messages_node',
+          'view_display' => 'block_1',
+          'args' => $arg,
+          'entity_id' => $message->sba_message_id,
+          'weight' => $message->data['weight'],
+        );
+        drupal_write_record('draggableviews_structure', $record);
+
+        $send = array();
+        $send['values']['data']['recipients'] = $message->data['recipients'];
+        $send['values']['data']['message_id'] = $message->data['message_id'];
+        $send['values']['advocacy_id'] = $node->advocacy_id;
+        module_load_include('inc', 'sba_message', 'sba_message.api_calls');
+        _sba_message_api_save($message, TRUE, $send);
+      }
+    }
+  }
+}
+
 
 /**
  * The class used for sba_message entities.

--- a/springboard_advocacy/springboard_advocacy.module
+++ b/springboard_advocacy/springboard_advocacy.module
@@ -299,16 +299,52 @@ function springboard_advocacy_views_api() {
  *
  *   Saves a UUID for action nodes.
  */
-function springboard_advocacy_node_insert($node) {
-  $types = variable_get('sba_action_types', array());
-  if (in_array($node->type, $types)) {
-    $uuid = array(
-      'nid' => $node->nid,
-      'advocacy_id' => str_replace(' ', '-', uniqid(substr(variable_get('site_name', ''), 0, 10) . '-' . substr($node->title, 0, 10) . '-')),
-    );
-    drupal_write_record('sba_form_id', $uuid);
-  }
-}
+ function springboard_advocacy_node_insert($node) {
+
+   $types = variable_get('sba_action_types', array());
+   if (in_array($node->type, $types)) {
+     $uuid = array(
+       'nid' => $node->nid,
+       'advocacy_id' => str_replace(' ', '-', uniqid(substr(variable_get('site_name', ''), 0, 10) . '-' . substr($node->title, 0, 10) . '-')),
+     );
+     drupal_write_record('sba_form_id', $uuid);
+
+     // Clone messages if this is a clone.
+     if (!empty($node->clone_from_original_nid) && !empty($node->messages) && module_exists('sba_message')) {
+       foreach ($node->messages as $id => $message) {
+
+         // The node object still has the original node's message entities loaded
+         // but not saved. Recast them as new, unset some API values
+         // replace the entity reference ID with our new node ID
+         // and save them as new messages.
+         $message->sba_message_id = NULL;
+         if (isset($message->data['group_id'])) {
+           unset($message->data['group_id']);
+         }
+         $message->is_new = TRUE;
+         $message->data['message_id'] = str_replace(' ', '-', uniqid(substr(variable_get('site_name', ''), 0, 10) . '-' . substr($message->name, 0, 10) . '-'));
+         $message->field_sba_action_id[LANGUAGE_NONE][0]['target_id'] = $node->nid;
+         $created = time();
+         $message->created = $created;
+         $message->changed = $created;
+         $message->save();
+
+         // Save the draggable views record
+         $arg = json_encode(array($node->nid));
+         sba_message_draggable_save($arg, $message->sba_message_id, $message->data['weight']);
+
+         // Create a record on the API server
+         $pseudo_form_state = array();
+         $pseudo_form_state['values']['data']['recipients'] = $message->data['recipients'];
+         $pseudo_form_state['values']['data']['message_id'] = $message->data['message_id'];
+         $pseudo_form_state['values']['advocacy_id'] = $uuid['advocacy_id'];
+         module_load_include('inc', 'sba_message', 'sba_message.api_calls');
+         _sba_message_api_save($message, TRUE, $pseudo_form_state);
+       }
+     }
+   }
+
+ }
 
 
 


### PR DESCRIPTION
Clone message entities when cloning actions.

In hook_insert, the cloned node still has the original node's message entities loaded but not saved. Recast them as new, unset some API values, replace the entity reference ID with our new node ID, and save them as new messages.

Then create a new record in draggable views table with the original nodes weights.

Then save the target and message info to the API server.