### PR TITLE
7.x 4.x 889 advocacy success hook

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
@@ -128,7 +128,7 @@ function sba_message_action_additional_elements(&$form, &$form_state) {
   }
 
   $form['#validate'][] = 'sba_message_action_form_validate';
-  array_unshift($form['#submit'], 'sba_message_action_form_submit');
+  $form['#submit'][] = 'sba_message_action_form_submit';
 }
 
 /**

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
@@ -382,7 +382,7 @@ function sba_message_action_preview_form_submit($form, &$form_state) {
       return;
     }
   }
-
+  // Fire the success hook for multi-step actions.
   if (isset($response->data)) {
     springboard_advocacy_success($node, $form_state['values']['contact'], $response->data);
   }

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
@@ -383,6 +383,9 @@ function sba_message_action_preview_form_submit($form, &$form_state) {
     }
   }
 
+  if (isset($response->data)) {
+    springboard_advocacy_success($node, $form_state['values']['contact'], $response->data);
+  }
   // Add session flag to prevent resubmission of the form
   $_SESSION['action_sid']['completed'] = TRUE;
   unset($_SESSION['retries']);

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
@@ -382,10 +382,9 @@ function sba_message_action_preview_form_submit($form, &$form_state) {
       return;
     }
   }
-
   // Fire the success hook for multi-step actions.
   if (isset($response->data)) {
-    $sid = !empty($_SESSION['social_action_sid']['sid']) ? $_SESSION['social_action_sid']['sid'] : FALSE;
+    $sid = !empty($_SESSION['action_sid']['sid']) ? $_SESSION['action_sid']['sid'] : FALSE;
     springboard_advocacy_success($node, $form_state['values']['contact'], $response->data, $sid);
   }
   // Add session flag to prevent resubmission of the form

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
@@ -385,7 +385,7 @@ function sba_message_action_preview_form_submit($form, &$form_state) {
   // Fire the success hook for multi-step actions.
   if (isset($response->data)) {
     $sid = !empty($_SESSION['action_sid']['sid']) ? $_SESSION['action_sid']['sid'] : FALSE;
-    springboard_advocacy_success($node, $form_state['values']['contact'], $response->data, $sid);
+    springboard_advocacy_success($node, $form_state['values']['contact'], (array) $response->data->messages, $sid);
   }
   // Add session flag to prevent resubmission of the form
   $_SESSION['action_sid']['completed'] = TRUE;

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
@@ -382,9 +382,11 @@ function sba_message_action_preview_form_submit($form, &$form_state) {
       return;
     }
   }
+
   // Fire the success hook for multi-step actions.
   if (isset($response->data)) {
-    springboard_advocacy_success($node, $form_state['values']['contact'], $response->data);
+    $sid = !empty($_SESSION['social_action_sid']['sid']) ? $_SESSION['social_action_sid']['sid'] : FALSE;
+    springboard_advocacy_success($node, $form_state['values']['contact'], $response->data, $sid);
   }
   // Add session flag to prevent resubmission of the form
   $_SESSION['action_sid']['completed'] = TRUE;

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
@@ -64,6 +64,9 @@ function sba_message_action_send_message(array $user_message, array $form_state)
     if (isset($response->data)) {
       // We got a valid response, build the confirmation message array.
       sba_message_action_set_confirmation_session_vars($response->data, $contact);
+      if (!empty($multi_flow[0]['value']) && $multi_flow[0]['value'] != 'multi') {
+        springboard_advocacy_success($node, $contact, $response->data);
+      }
     }
   }
   return !empty($response->data) ? $response->data : NULL;

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
@@ -67,7 +67,8 @@ function sba_message_action_send_message(array $user_message, array $form_state)
 
       // Fire the success hook for one-step actions.
       if (!empty($multi_flow[0]['value']) && $multi_flow[0]['value'] != 'multi') {
-        springboard_advocacy_success($node, $contact, $response->data, $_SESSION['action_sid']['sid']);
+        $sid = !empty($values['details']['sid']) ? $values['details']['sid'] : FALSE;
+        springboard_advocacy_success($node, $contact, $response->data, $sid);
       }
     }
   }

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
@@ -64,6 +64,8 @@ function sba_message_action_send_message(array $user_message, array $form_state)
     if (isset($response->data)) {
       // We got a valid response, build the confirmation message array.
       sba_message_action_set_confirmation_session_vars($response->data, $contact);
+
+      // Fire the success hook for one-step actions.
       if (!empty($multi_flow[0]['value']) && $multi_flow[0]['value'] != 'multi') {
         springboard_advocacy_success($node, $contact, $response->data);
       }

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
@@ -68,7 +68,7 @@ function sba_message_action_send_message(array $user_message, array $form_state)
       // Fire the success hook for one-step actions.
       if (!empty($multi_flow[0]['value']) && $multi_flow[0]['value'] != 'multi') {
         $sid = !empty($values['details']['sid']) ? $values['details']['sid'] : FALSE;
-        springboard_advocacy_success($node, $contact, $response->data, $sid);
+        springboard_advocacy_success($node, $contact, (array) $response->data->messages, $sid);
       }
     }
   }

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
@@ -67,7 +67,7 @@ function sba_message_action_send_message(array $user_message, array $form_state)
 
       // Fire the success hook for one-step actions.
       if (!empty($multi_flow[0]['value']) && $multi_flow[0]['value'] != 'multi') {
-        springboard_advocacy_success($node, $contact, $response->data);
+        springboard_advocacy_success($node, $contact, $response->data, $_SESSION['action_sid']['sid']);
       }
     }
   }

--- a/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.preview.inc
+++ b/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.preview.inc
@@ -90,6 +90,10 @@ function sba_social_action_message_preview_page($nid) {
     'sba_social_action_preview_form' => drupal_get_form('sba_social_action_preview_form', $node, $messages, $random_array),
   );
 
+  if (!empty($_SESSION['social_contact'])) {
+    springboard_advocacy_success($node, $_SESSION['social_contact'], $messages);
+  }
+
   return $build;
 }
 

--- a/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.preview.inc
+++ b/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.preview.inc
@@ -90,7 +90,9 @@ function sba_social_action_message_preview_page($nid) {
     'sba_social_action_preview_form' => drupal_get_form('sba_social_action_preview_form', $node, $messages, $random_array),
   );
 
-  if (!empty($_SESSION['social_contact'])) {
+  // We can't really tell if the user takes action, so non-empty $messages
+  // is the closest we'll get.
+  if (!empty($_SESSION['social_contact']) && !empty($messages)) {
     springboard_advocacy_success($node, $_SESSION['social_contact'], $messages);
   }
 

--- a/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.preview.inc
+++ b/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.preview.inc
@@ -92,8 +92,9 @@ function sba_social_action_message_preview_page($nid) {
 
   // We can't really tell if the user takes action, so non-empty $messages
   // is the closest we'll get.
+  $sid = !empty($_SESSION['social_action_sid']['sid']) ? $_SESSION['social_action_sid']['sid'] : FALSE;
   if (!empty($_SESSION['social_contact']) && !empty($messages)) {
-    springboard_advocacy_success($node, $_SESSION['social_contact'], $messages);
+    springboard_advocacy_success($node, $_SESSION['social_contact'], $messages, $sid);
   }
 
   return $build;

--- a/springboard_advocacy/modules/springboard_petition/springboard_petition.module
+++ b/springboard_advocacy/modules/springboard_petition/springboard_petition.module
@@ -106,13 +106,15 @@ function springboard_petition_form_alter(&$form, $form_state, $form_id) {
  */
 function springboard_petition_petition_submit($form, $form_state) {
   $submission_fields = _springboard_advocacy_webform_submission_flatten($form['#node']->nid, $form_state['values']['submitted_tree']);
-  $account = user_load_by_mail($submission_fields['mail']);
-  $sid = !empty($_SESSION['social_action_sid']['sid']) ? $_SESSION['social_action_sid']['sid'] : FALSE;
-  $opt_in = count($submission_fields['sbp_rps_optin']) ? TRUE : FALSE;
-  if ($opt_in && !empty($account->uid)) {
-    springboard_petition_log_opt_in($form['#node']->nid, $account->uid, $opt_in, $sid);
+  if (!empty($submission_fields['mail'])) {
+    $account = user_load_by_mail($submission_fields['mail']);
+    $sid = !empty($form_state['values']['details']['sid']) ? $form_state['values']['details']['sid'] : FALSE;
+    $opt_in = count($submission_fields['sbp_rps_optin']) ? TRUE : FALSE;
+    if ($opt_in && !empty($account->uid)) {
+      springboard_petition_log_opt_in($form['#node']->nid, $account->uid, $opt_in, $sid);
+    }
+    springboard_advocacy_success($form['#node'], $account, $submission_fields, $sid);
   }
-  springboard_advocacy_success($form['#node'], $account, $submission_fields, $sid);
 }
 
 /**

--- a/springboard_advocacy/modules/springboard_petition/springboard_petition.module
+++ b/springboard_advocacy/modules/springboard_petition/springboard_petition.module
@@ -107,7 +107,7 @@ function springboard_petition_form_alter(&$form, $form_state, $form_id) {
 function springboard_petition_petition_submit($form, $form_state) {
   $submission_fields = _springboard_advocacy_webform_submission_flatten($form['#node']->nid, $form_state['values']['submitted_tree']);
   if (!empty($submission_fields['mail'])) {
-    $account = user_load_by_mail($submission_fields['mail']);
+    $account = (array) user_load_by_mail($submission_fields['mail']);
     $sid = !empty($form_state['values']['details']['sid']) ? $form_state['values']['details']['sid'] : FALSE;
     $opt_in = count($submission_fields['sbp_rps_optin']) ? TRUE : FALSE;
     if ($opt_in && !empty($account->uid)) {

--- a/springboard_advocacy/modules/springboard_petition/springboard_petition.module
+++ b/springboard_advocacy/modules/springboard_petition/springboard_petition.module
@@ -106,12 +106,13 @@ function springboard_petition_form_alter(&$form, $form_state, $form_id) {
  */
 function springboard_petition_petition_submit($form, $form_state) {
   $submission_fields = _springboard_advocacy_webform_submission_flatten($form['#node']->nid, $form_state['values']['submitted_tree']);
+  $account = user_load_by_mail($submission_fields['mail']);
+  $sid = !empty($_SESSION['social_action_sid']['sid']) ? $_SESSION['social_action_sid']['sid'] : FALSE;
   $opt_in = count($submission_fields['sbp_rps_optin']) ? TRUE : FALSE;
-  $uid = _springboard_petition_get_uid_from_sid($form_state['values']['details']['sid']);
-  if ($opt_in) {
-    $sid = $form_state['values']['details']['sid'];
-    springboard_petition_log_opt_in($form['#node']->nid, $uid, $opt_in, $sid);
+  if ($opt_in && !empty($account->uid)) {
+    springboard_petition_log_opt_in($form['#node']->nid, $account->uid, $opt_in, $sid);
   }
+  springboard_advocacy_success($form['#node'], $account, $submission_fields, $sid);
 }
 
 /**

--- a/springboard_advocacy/modules/springboard_petition/springboard_petition.module
+++ b/springboard_advocacy/modules/springboard_petition/springboard_petition.module
@@ -110,8 +110,8 @@ function springboard_petition_petition_submit($form, $form_state) {
     $account = (array) user_load_by_mail($submission_fields['mail']);
     $sid = !empty($form_state['values']['details']['sid']) ? $form_state['values']['details']['sid'] : FALSE;
     $opt_in = count($submission_fields['sbp_rps_optin']) ? TRUE : FALSE;
-    if ($opt_in && !empty($account->uid)) {
-      springboard_petition_log_opt_in($form['#node']->nid, $account->uid, $opt_in, $sid);
+    if ($opt_in && !empty($account['uid'])) {
+      springboard_petition_log_opt_in($form['#node']->nid, $account['uid'], $opt_in, $sid);
     }
     springboard_advocacy_success($form['#node'], $account, $submission_fields, $sid);
   }

--- a/springboard_advocacy/springboard_advocacy.module
+++ b/springboard_advocacy/springboard_advocacy.module
@@ -1,4 +1,4 @@
- <?php
+<?php
 /**
  * @file
  * Base Springboard advocacy functions.
@@ -56,18 +56,18 @@ function springboard_advocacy_menu() {
   );
 
   $items['admin/springboard/advocacy/actions'] = array(
-    'title' => 'Advocacy: Actions',
-    'page arguments' => array('actions'),
-    'access callback' => 'springboard_advocacy_user_can_create_advocacy_type',
-  ) + springboard_advocacy_menu_common(FALSE, TRUE);
+      'title' => 'Advocacy: Actions',
+      'page arguments' => array('actions'),
+      'access callback' => 'springboard_advocacy_user_can_create_advocacy_type',
+    ) + springboard_advocacy_menu_common(FALSE, TRUE);
 
   $items['admin/springboard/advocacy/message-actions/all'] = array(
-    'title' => 'Advocacy: All Message Actions',
-    'page arguments' => array('message-actions/all'),
-    'access arguments' => array(
-      'create sba_message_action content',
-    ),
-  ) + springboard_advocacy_menu_common(FALSE, TRUE);
+      'title' => 'Advocacy: All Message Actions',
+      'page arguments' => array('message-actions/all'),
+      'access arguments' => array(
+        'create sba_message_action content',
+      ),
+    ) + springboard_advocacy_menu_common(FALSE, TRUE);
 
   $items['admin/springboard/advocacy/social-actions/all'] = array(
       'title' => 'Advocacy: All Social Actions',
@@ -78,28 +78,28 @@ function springboard_advocacy_menu() {
     ) + springboard_advocacy_menu_common(FALSE, TRUE);
 
   $items['admin/springboard/advocacy/petitions/all'] = array(
-    'title' => 'Advocacy: All Petitions',
-    'page arguments' => array('petitions/all'),
-    'access arguments' => array(
-      'create springboard_petition content',
-    ),
-  ) + springboard_advocacy_menu_common(FALSE, TRUE);
+      'title' => 'Advocacy: All Petitions',
+      'page arguments' => array('petitions/all'),
+      'access arguments' => array(
+        'create springboard_petition content',
+      ),
+    ) + springboard_advocacy_menu_common(FALSE, TRUE);
 
   $items['admin/springboard/advocacy/reports'] = array(
-    'title' => 'Advocacy Reports',
-    'page arguments' => array('reports'),
-    'page callback' => 'springboard_advocacy_settings_page',
-  ) + springboard_advocacy_menu_common();
+      'title' => 'Advocacy Reports',
+      'page arguments' => array('reports'),
+      'page callback' => 'springboard_advocacy_settings_page',
+    ) + springboard_advocacy_menu_common();
 
   $items['advocacy/ajax/search'] = array(
-      'title' => 'Data',
-      'page callback' => 'springboard_advocacy_ajax_search',
-      'type' => MENU_CALLBACK,
-      'file' => 'springboard_advocacy.views.inc',
-      'file path' => drupal_get_path('module', 'springboard_advocacy') . '/includes/views',
-       'access callback' => 'user_access',
-       'access arguments' => array('create sba_social_action content')
-    );
+    'title' => 'Data',
+    'page callback' => 'springboard_advocacy_ajax_search',
+    'type' => MENU_CALLBACK,
+    'file' => 'springboard_advocacy.views.inc',
+    'file path' => drupal_get_path('module', 'springboard_advocacy') . '/includes/views',
+    'access callback' => 'user_access',
+    'access arguments' => array('create sba_social_action content')
+  );
 
   return $items;
 }
@@ -900,4 +900,18 @@ function springboard_advocacy_update_multistep_components($sid, $node, $changed)
   $submission = webform_get_submission($node->nid, $sid, TRUE);
   // Update to trigger salesforce resync.
   webform_submission_update($node, $submission);
+}
+
+/**
+ * Action success hook.
+ *
+ * The $data array will be structured differently depending on which module
+ * is calling springboard_advocacy_success().
+ *
+ * @param $node
+ * @param $contact
+ * @param $data
+ */
+function springboard_advocacy_success($node, $contact, $data) {
+  module_invoke_all('action_success', $node, $contact, $data);
 }

--- a/springboard_advocacy/springboard_advocacy.module
+++ b/springboard_advocacy/springboard_advocacy.module
@@ -908,6 +908,20 @@ function springboard_advocacy_update_multistep_components($sid, $node, $changed)
  * The $data and $contact arrays will be structured differently depending
  * on which module is calling springboard_advocacy_success().
  *
+ * With petitions, $contact is a user object cast as an array.
+ *
+ * With message and social actions, $contact is the contact array
+ * that is sent to the transaction server, with the profile values plus zip+4.
+ *
+ * With message actions, $data is the is API $response->data->message cast
+ * as an array. The structure is different for single-step and multi-step
+ * actions.
+ *
+ * With social actions, $data is parsed API $response->data->message,
+ * in a somewhat different arrangement than message actions.
+ *
+ * With petitions, $data is the webform field values in a flat array.
+ *
  * @param $node
  * @param $contact
  * @param $data

--- a/springboard_advocacy/springboard_advocacy.module
+++ b/springboard_advocacy/springboard_advocacy.module
@@ -911,7 +911,8 @@ function springboard_advocacy_update_multistep_components($sid, $node, $changed)
  * @param $node
  * @param $contact
  * @param $data
+ * @param $sid
  */
-function springboard_advocacy_success($node, $contact, $data) {
-  module_invoke_all('action_success', $node, $contact, $data);
+function springboard_advocacy_success($node, $contact, $data, $sid) {
+  module_invoke_all('action_success', $node, $contact, $data, $sid);
 }

--- a/springboard_advocacy/springboard_advocacy.module
+++ b/springboard_advocacy/springboard_advocacy.module
@@ -905,8 +905,8 @@ function springboard_advocacy_update_multistep_components($sid, $node, $changed)
 /**
  * Action success hook.
  *
- * The $data array will be structured differently depending on which module
- * is calling springboard_advocacy_success().
+ * The $data and $contact arrays will be structured differently depending
+ * on which module is calling springboard_advocacy_success().
  *
  * @param $node
  * @param $contact


### PR DESCRIPTION
Create a success hook for actions.

This required changing the order in which submit hooks are executed for message actions, from the message action hook firing first, to firing after webform and webform user, so that the user account info is available when single-step message actions are submitted.