### PR TITLE
make hidden fields editable on submission results for all form types

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/sba_message_action.module
+++ b/springboard_advocacy/modules/sba_message_action/sba_message_action.module
@@ -425,7 +425,7 @@ function sba_message_action_form_alter(&$form, &$form_state, $form_id) {
     // Yes it is the user-facing form. Add all our custom non-webform-component
     // form items which insert or display message-entity data in the
     // message-action webform.
-    if ($client_form !== FALSE) {
+    if ($client_form !== FALSE && arg(2) != 'submission') {
 
       if (empty($form['#node']->show_my_name)) {
         $form['submitted']['sbp_sba_action_optin']['#access'] = FALSE;

--- a/springboard_advocacy/modules/sba_social_action/sba_social_action.module
+++ b/springboard_advocacy/modules/sba_social_action/sba_social_action.module
@@ -372,8 +372,7 @@ function sba_social_action_form_alter(&$form, &$form_state, $form_id) {
     // Yes it is the user-facing form. Add all our custom non-webform-component
     // form items which insert or display message-entity data in the
     // message-action webform.
-    if ($client_form !== FALSE) {
-
+    if ($client_form !== FALSE && arg(2) != 'submission') {
       if (empty($form['#node']->show_my_name)) {
         $form['submitted']['sbp_sba_action_optin']['#access'] = FALSE;
       }

--- a/webform_ui/webform_ui.admin.inc
+++ b/webform_ui/webform_ui.admin.inc
@@ -80,6 +80,14 @@ function webform_ui_settings_form($form, &$form_state) {
     '#weight' => 8,
   );
 
+  $form['webform_ui_make_hidden_editable'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Make hidden fields editable on the submission result edit page.'),
+    '#default_value' => variable_get('webform_ui_make_hidden_editable', 'FALSE'),
+    '#description' => t("Make market source and other hidden fields editable in order to correct salesforce sync errors."),
+    '#weight' => 8,
+  );
+
   $form['#submit'][] = 'webform_ui_settings_form_submit';
   return system_settings_form($form);
 }

--- a/webform_ui/webform_ui.module
+++ b/webform_ui/webform_ui.module
@@ -150,7 +150,7 @@ function webform_ui_form_webform_configure_after_build($form, $form_state) {
 
 
 /**
- * Implements hook_formwebform_client_form_alter().
+ * Implements hook_form_webform_client_form_alter().
  *
  * Make hidden fields on results page editable so salesforce syncs can
  * be corrected.

--- a/webform_ui/webform_ui.module
+++ b/webform_ui/webform_ui.module
@@ -148,6 +148,25 @@ function webform_ui_form_webform_configure_after_build($form, $form_state) {
   return $form;
 }
 
+
+/**
+ * Implements hook_formwebform_client_form_alter().
+ *
+ * Make hidden fields on results page editable so salesforce syncs can
+ * be corrected.
+ */
+function webform_ui_form_webform_client_form_alter(&$form, &$form_state) {
+  if (arg(2) == 'submission' && variable_get('webform_ui_make_hidden_editable', FALSE) && user_access('edit all webform submissions')) {
+    foreach (element_children($form['submitted']) as $key) {
+      if ($form['submitted'][$key]['#type'] == 'hidden') {
+        $form['submitted'][$key]['#type'] = 'textfield';
+        // Prevent the core textfield formatter's default 128 limit.
+        $form['submitted'][$key]['#maxlength'] = NULL;
+      }
+    }
+  }
+}
+
 /**
  * Implements hook_menu_alter().
  *


### PR DESCRIPTION
This makes it possible to edit hidden fields on the results page of all webform types.

It also fixes a bug that resends actions to the transaction server if the submission is edited. 