### PR TITLE
restore the previous submit order on message actions, add new submit …

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
@@ -128,7 +128,9 @@ function sba_message_action_additional_elements(&$form, &$form_state) {
   }
 
   $form['#validate'][] = 'sba_message_action_form_validate';
-  $form['#submit'][] = 'sba_message_action_form_submit';
+  array_unshift($form['#submit'], 'sba_message_action_form_submit');
+  $form['#submit'][] = 'sba_message_action_after_webform_form_submit';
+
 }
 
 /**
@@ -394,6 +396,7 @@ function sba_message_action_form_validate(&$form, &$form_state) {
  * @param $form_state
  */
 function sba_message_action_form_submit($form, &$form_state) {
+
   $node = $form['#node'];
   $node_wrapper = entity_metadata_wrapper('node', $node);
   $multi_flow = $node_wrapper->field_sba_action_flow->value() == 'multi' ? TRUE : FALSE;
@@ -402,6 +405,7 @@ function sba_message_action_form_submit($form, &$form_state) {
   $_SESSION['undelivered_messages'] = array();
   $_SESSION['contact'] = array();
   $_SESSION['form_details'] = array();
+  $_SESSION['response_messages'] = array();
   $_SESSION['action_sid'] = FALSE;
   //$_SESSION['action_completed'] = FALSE;
   // Create array of messages to submit for target resolution.
@@ -430,6 +434,20 @@ function sba_message_action_form_submit($form, &$form_state) {
   }
 }
 
+
+/**
+ * Fire the success hook if the correct values are present.
+ *
+ * @param $form
+ * @param $form_state
+ */
+function sba_message_action_after_webform_form_submit($form, &$form_state) {
+  if (!empty( $_SESSION['response_messages'])) {
+    $node = $form['#node'];
+    $sid = !empty($form_state['values']['details']['sid']) ? $form_state['values']['details']['sid'] : FALSE;
+    springboard_advocacy_success($node, $_SESSION['contact'], $_SESSION['response_messages'], $sid);
+  }
+}
 
 /**
  * Helper function to build message bodies.

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.preview.inc
@@ -382,11 +382,7 @@ function sba_message_action_preview_form_submit($form, &$form_state) {
       return;
     }
   }
-  // Fire the success hook for multi-step actions.
-  if (isset($response->data)) {
-    $sid = !empty($_SESSION['action_sid']['sid']) ? $_SESSION['action_sid']['sid'] : FALSE;
-    springboard_advocacy_success($node, $form_state['values']['contact'], (array) $response->data->messages, $sid);
-  }
+
   // Add session flag to prevent resubmission of the form
   $_SESSION['action_sid']['completed'] = TRUE;
   unset($_SESSION['retries']);

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
@@ -210,7 +210,7 @@ function sba_message_action_build_contact(array $values, $zip, array $geo) {
  */
 function sba_message_action_set_confirmation_session_vars($response, $contact) {
   if (!empty($response->messages)) {
-
+    $_SESSION['response_messages'] = (array) $response->messages;
     $_SESSION['delivered_messages'] = array();
     $_SESSION['undelivered_messages'] = array();
     $_SESSION['contact'] = $contact;


### PR DESCRIPTION
The reordering of the submit hooks on message actions for the success hook patch broke the "messages generated" count.

This restores the previous order, and adds a new, post-webform submit hook to call the success function from. In order to do that a new session variable had to be created to store the raw API response->messages object.

I wonder if for message actions and social actions, if the $data array in both cases should be the deliverable and undeliverable session variables, instead of the two different things they are now.

If that was the case, we wouldn't need the new session variable to store the raw response in this patch.
