### PR TITLE
7.x-4.x #222 restrict pagewrappers theme css

### DIFF
--- a/page_wrappers/page_wrappers.module
+++ b/page_wrappers/page_wrappers.module
@@ -480,11 +480,10 @@ function page_wrappers_form_node_form_alter(&$form, $form_state, $form_id) {
   if ($form_id == 'page_wrapper_node_form') {
     $lang = $form['language']['#value'];
     // add some help the body (Template HTML) field
-    // TODO: fix language lookup.
-    $form['body']['und'][0]['#prefix'] = '<p class="wrapper-text">';
-    $form['body']['und'][0]['#prefix'] .= t('The template should only include the content of the HTML &lt;body&gt; tag. <strong>Do not</strong> include the &lt;html&gt;, &lt;head&gt, or &lt;body&gt  tags in the template.');
-    $form['body']['und'][0]['#prefix'] .= t('Use the placeholder <strong>[content]</strong> to denote where the body content should be output, and <strong>[title]</strong> where the page title should appear, and <strong>[messages]</strong> where the error messages should appear.');
-    $form['body']['und'][0]['#prefix'] .= '</p>';
+    $form['body'][$lang][0]['#prefix'] = '<p class="wrapper-text">';
+    $form['body'][$lang][0]['#prefix'] .= t('The template should only include the content of the HTML &lt;body&gt; tag. <strong>Do not</strong> include the &lt;html&gt;, &lt;head&gt, or &lt;body&gt  tags in the template.');
+    $form['body'][$lang][0]['#prefix'] .= t('Use the placeholder <strong>[content]</strong> to denote where the body content should be output, and <strong>[title]</strong> where the page title should appear, and <strong>[messages]</strong> where the error messages should appear.');
+    $form['body'][$lang][0]['#prefix'] .= '</p>';
 
     // Remove themes from the CSS list based on settings in springboard_admin
     if(module_exists('springboard_admin') && _springboard_admin_apply_treatment($GLOBALS['user'])) {

--- a/page_wrappers/page_wrappers.module
+++ b/page_wrappers/page_wrappers.module
@@ -478,12 +478,23 @@ function page_wrappers_form_node_form_alter(&$form, $form_state, $form_id) {
 
   // page_wrapper_node_form
   if ($form_id == 'page_wrapper_node_form') {
+    $lang = $form['language']['#value'];
     // add some help the body (Template HTML) field
     // TODO: fix language lookup.
     $form['body']['und'][0]['#prefix'] = '<p class="wrapper-text">';
     $form['body']['und'][0]['#prefix'] .= t('The template should only include the content of the HTML &lt;body&gt; tag. <strong>Do not</strong> include the &lt;html&gt;, &lt;head&gt, or &lt;body&gt  tags in the template.');
     $form['body']['und'][0]['#prefix'] .= t('Use the placeholder <strong>[content]</strong> to denote where the body content should be output, and <strong>[title]</strong> where the page title should appear, and <strong>[messages]</strong> where the error messages should appear.');
     $form['body']['und'][0]['#prefix'] .= '</p>';
+
+    // Remove themes from the CSS list based on settings in springboard_admin
+    if(module_exists('springboard_admin') && _springboard_admin_apply_treatment($GLOBALS['user'])) {
+      $listed_themes = variable_get('springboard_listed_themes', array('springboard_base', 'springboard_backend', 'springboard_frontend'));
+      foreach($form['page_wrappers_theme_css'][$lang]['#options'] as $key=>$theme) {
+        if(!in_array($key, $listed_themes)) {
+          unset($form['page_wrappers_theme_css'][$lang]['#options'][$key]);
+        }
+      }
+    }
   }
 }
 

--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -190,6 +190,19 @@ function springboard_admin_form_springboard_admin_settings_alter(&$form, &$form_
       '#description' => t('Force the use of the springboard_backend theme on all Springboard-related administrative pages. The administrative theme set at admin/appearence will still be used for other Drupal administrative pages.'),
       '#default_value' => variable_get('springboard_theme_enable', 1),
     );
+    $themes = list_themes();
+    $theme_options = array();
+    foreach($themes as $key=>$theme) {
+      $theme_options[$key] = $theme->name;
+    }
+    $form['admin']['springboard_listed_themes'] = array(
+      '#type' => 'select',
+      '#title' => t('Choose themes to disclose to Springboard Admin users.'),
+      '#description' => t('Allows administrators to control the list of themes available for use in page wrappers.'),
+      '#multiple' => TRUE,
+      '#options' => $theme_options,
+      '#default_value' => variable_get('springboard_listed_themes', array('springboard_base', 'springboard_frontend', 'springboard_backend')),
+    );
     $roles = user_roles(TRUE, 'access springboard dashboard');
     $form['admin']['springboard_user_experience'] = array(
       '#type' => 'checkboxes',


### PR DESCRIPTION
I've created a new configuration in the Springboard Admin module that allows an administrator to specify which themes are listed for users that get the Springboard Admin UX in a Page Wrapper node's "include theme CSS" option.

The new administrative option:
![screen shot 2016-03-07 at 3 54 47 pm](https://cloud.githubusercontent.com/assets/122144/13582975/1237de3e-e47d-11e5-87cc-fad219e05365.png)

And the changes as seen on a new Page Wrapper form:
![screen shot 2016-03-07 at 3 55 18 pm](https://cloud.githubusercontent.com/assets/122144/13582992/27f7ca90-e47d-11e5-93b8-e1dd3536bb87.png)
