### PR TITLE
Allow failsafe to operate on rules provided by modules other than com…

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -2584,44 +2584,41 @@ function fundraiser_commerce_form_rules_ui_edit_element_alter(&$form, &$form_sta
 function fundraiser_commerce_form_rules_ui_form_rules_config_confirm_op_alter(&$form, &$form_state) {
   // Seems like there should be a better way to find the rule id than arg()
   $rule = rules_config_load(arg(5));
-  // Take action only on rules provided by commerce_payment.
-  if ($rule->module == 'commerce_payment') {
-    // Select all records so we can search inside the serizalied gateways field.
-    $donation_forms = db_query("SELECT nid, gateways FROM {fundraiser}");
-    if ($donation_forms) {
-      // Compile list of forms to use when build user message.
-      $matching_donation_forms = array();
-      while ($donation_form = $donation_forms->fetchAssoc()) {
-        $gateways = unserialize($donation_form['gateways']);
-        foreach ($gateways as $gateway) {
-          if (!empty($gateway['id'])) {
-            if (strpos($gateway['id'], $rule->name) && $gateway['status'] == 1) {
-              $matching_donation_forms[] = $donation_form['nid'];
-            }
+  // Select all records so we can search inside the serizalied gateways field.
+  $donation_forms = db_query("SELECT nid, gateways FROM {fundraiser}");
+  if ($donation_forms) {
+    // Compile list of forms to use when building the message to the user.
+    $matching_donation_forms = array();
+    while ($donation_form = $donation_forms->fetchAssoc()) {
+      $gateways = unserialize($donation_form['gateways']);
+      foreach ($gateways as $gateway) {
+        if (!empty($gateway['id'])) {
+          if (strpos($gateway['id'], $rule->name) && $gateway['status'] == 1) {
+            $matching_donation_forms[] = $donation_form['nid'];
           }
         }
       }
-      if (!empty($matching_donation_forms)) {
-        // Disable submit button.
-        $form['actions']['submit']['#disabled'] = TRUE;
-        // Build user message with links to enabled donaiton forms.
-        $message = t('The payment gateway @rule_label cannot be disabled because it is currently in use on the following donation forms:',
-          array('@rule_label' => $rule->label));
-        $matching_nodes = db_select('node', 'n')
-          ->condition('nid', $matching_donation_forms, 'IN')
-          ->fields('n', array('nid', 'title'))
-          ->execute();
-        while ($matching_node = $matching_nodes->fetchAssoc()) {
-          $message .= t('<li><a href="@donation_form_url">@node_title</a></li>',
-            array(
-              '@donation_form_url' => url('node/' . $matching_node['nid']),
-              '@node_title' => $matching_node['title'],
-            )
-          );
-        }
-        $message .= '</ul>';
-        drupal_set_message($message, 'warning');
+    }
+    if (!empty($matching_donation_forms)) {
+      // Disable submit button.
+      $form['actions']['submit']['#disabled'] = TRUE;
+      // Build user message with links to enabled donation forms.
+      $message = t('The payment gateway @rule_label cannot be disabled because it is currently in use on the following donation forms:',
+        array('@rule_label' => $rule->label));
+      $matching_nodes = db_select('node', 'n')
+        ->condition('nid', $matching_donation_forms, 'IN')
+        ->fields('n', array('nid', 'title'))
+        ->execute();
+      while ($matching_node = $matching_nodes->fetchAssoc()) {
+        $message .= t('<li><a href="@donation_form_url">@node_title</a></li>',
+          array(
+            '@donation_form_url' => url('node/' . $matching_node['nid']),
+            '@node_title' => $matching_node['title'],
+          )
+        );
       }
+      $message .= '</ul>';
+      drupal_set_message($message, 'warning');
     }
   }
 }


### PR DESCRIPTION
…merce_payment.

This diff looks bigger than it is because of an indentation change. I just removed the following:

-  // Take action only on rules provided by commerce_payment.
-  if ($rule->module == 'commerce_payment') {

and

- }