### PR TITLE
re #739 - unset empty datetime values

### DIFF
--- a/salesforce/salesforce_sync/includes/salesforce_sync.sync.inc
+++ b/salesforce/salesforce_sync/includes/salesforce_sync.sync.inc
@@ -649,6 +649,10 @@ class SalesforceSync {
             elseif ($value != '') {
               $item->sobject->fields[$field_name] = date('c', strtotime($value));
             }
+            else {
+              unset($item->sobject->fields[$field_name]);
+              $item->sobject->fieldsToNull[] = $field_name;
+            }
             break;
 
           case 'date':


### PR DESCRIPTION
A new issue arose during the course of the pwmb work: when trying to sync an 'authorized' but not yet charged donation, the following soap error is thrown on the batch:

''' is not a valid value for the type xsd:dateTime'

Salesforce_sync.sync.inc unsets empty date fields but not datetime fields. This PR alters salesforce_sync.sync.inc to unset datetime fields in the same way as date fields.
