### PR TITLE
Batches only process one record at a time; use $chunk as an array

### DIFF
--- a/webform_user/includes/webform_user.drush.inc
+++ b/webform_user/includes/webform_user.drush.inc
@@ -91,7 +91,7 @@ function webform_user_create_missing_users_batch_process($chunk, $node_id, $oper
     WHERE `s`.`sid` IN (:submission_ids) ORDER BY `s`.`sid` ASC;';
 
   $result = db_query($query, array(
-    ':submission_ids' => implode(',', $chunk),
+    ':submission_ids' => $chunk,
   ));
 
   $submissions = array();


### PR DESCRIPTION
Batches would only process one record at a time because Drupal core would take the "71,1234,43" string as integer (71).

Use `$chunk` as array and let `db_query()` do the db placeholders.