### PR TITLE
re #739 - set closedate if it's blank for pending transactions

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -950,6 +950,10 @@ function fundraiser_commerce_fundraiser_donation_get_donation($donation) {
       $donation->close_date = date('Y-m-d H:i:s', $donation->last_changed);
       $donation->transaction_date = date('Y-m-d H:i:s', $donation->last_changed);
     }
+    elseif (!$donation->status_charged && !isset($donation->close_date)) {
+      // Re #739 - set close date to last changed for pwmb
+      $donation->close_date = date('Y-m-d', $donation->last_changed);
+    }
   }
   // This order data was stored during hook_fundraiser_donation_process(), and scrubbed by the gateway.
   if (!empty($order->data)) {


### PR DESCRIPTION
When a pending transaction tries to sync with a blank closedate, a "required field missing" error is thrown. This change sets the blank closedate to the last changed date, day granularity only.