### PR TITLE
7.x 4.x 881 add parse components logic to actions

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
@@ -333,6 +333,9 @@ function sba_message_action_message_form(&$form, $message, $action_type) {
  */
 function sba_message_action_form_validate(&$form, &$form_state) {
   $node = $form['#node'];
+  $components = $node->webform['components'];
+  $component_hierarchy = webform_user_parse_components($node->nid, $components);
+  $form['#hierarchy'] = $component_hierarchy;
   $node_wrapper = entity_metadata_wrapper('node', $node);
   $multi_flow = $node_wrapper->field_sba_action_flow->value() == 'multi' ? TRUE : FALSE;
   if (isset($form_state['values']['sba_messages'])) {
@@ -364,7 +367,8 @@ function sba_message_action_form_validate(&$form, &$form_state) {
     }
     // Set user_edited_flag
     if ($changed && isset($form['submitted']['sba_user_edit_flag'])) {
-      form_set_value($form['submitted']['sba_user_edit_flag'], 1, $form_state);
+      $sba_user_edit_flag = &_webform_user_find_field($form, $component_hierarchy['sba_user_edit_flag']);
+      form_set_value($sba_user_edit_flag, 1, $form_state);
     }
   }
   form_load_include($form_state, 'inc', 'springboard_advocacy', 'includes/springboard_advocacy.smarty_streets');
@@ -374,7 +378,8 @@ function sba_message_action_form_validate(&$form, &$form_state) {
   if (!empty($smarty_geo) && is_array($smarty_geo)) {
     form_set_value($form['smarty_geo'], $smarty_geo, $form_state);
     if (isset($smarty_geo['zip']) && isset($smarty_geo['plus4'])) {
-      form_set_value($form['submitted']['sbp_zip_plus_four'], $smarty_geo['zip'] . '-' . $smarty_geo['plus4'], $form_state);
+      $zip_plus_four = &_webform_user_find_field($form, $component_hierarchy['sbp_zip_plus_four']);
+      form_set_value($zip_plus_four, $smarty_geo['zip'] . '-' . $smarty_geo['plus4'], $form_state);
     }
   }
   else {
@@ -420,8 +425,10 @@ function sba_message_action_form_submit($form, &$form_state) {
       foreach ($data->messages as $key => $message) {
         $deliverable += count($message->deliverable);
       }
-      if (isset($form_state['values']['submitted']['sba_deliverable_count'])) {
-        $form_state['values']['submitted']['sba_deliverable_count'] = $deliverable;
+      $component_hierarchy = $form['#hierarchy'];
+      if (isset($component_hierarchy['sba_deliverable_count'])) {
+        $sba_deliverable_count = &_webform_user_find_field($form, $component_hierarchy['sba_deliverable_count']);
+        form_set_value($sba_deliverable_count, $deliverable, $form_state);
       }
     }
   }

--- a/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.form.inc
+++ b/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.form.inc
@@ -242,7 +242,8 @@ function sba_social_action_form_validate($form, &$form_state) {
       form_set_value($form['smarty_geo'], $smarty_geo, $form_state);
       if (isset($smarty_geo['zip']) && isset($smarty_geo['plus4'])) {
         $zip_plus_four = &_webform_user_find_field($form, $component_hierarchy['sbp_zip_plus_four']);
-        form_set_value($zip_plus_four, $smarty_geo['zip'] . '-' . $smarty_geo['plus4'], $form_state);      }
+        form_set_value($zip_plus_four, $smarty_geo['zip'] . '-' . $smarty_geo['plus4'], $form_state);
+      }
     }
     else {
       form_set_error('', t('We could not verify your address. Please check that the street, city, state and zip code information is correct.'));

--- a/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.form.inc
+++ b/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.form.inc
@@ -227,6 +227,9 @@ function sba_social_action_message_form(&$form, $message, $message_entity_type, 
  * @param $form_state
  */
 function sba_social_action_form_validate($form, &$form_state) {
+  $components = $form['#node']->webform['components'];
+  $component_hierarchy = webform_user_parse_components($form['#node']->nid, $components);
+  $form['#hierarchy'] = $component_hierarchy;
   form_load_include($form_state, 'inc', 'springboard_advocacy', 'includes/springboard_advocacy.smarty_streets');
   $webform_values_flat = _springboard_advocacy_webform_submission_flatten($form['#node']->nid, $form_state['values']['submitted']);
   form_set_value($form['webform_flat'], $webform_values_flat, $form_state);
@@ -238,8 +241,8 @@ function sba_social_action_form_validate($form, &$form_state) {
     if (!empty($smarty_geo) && is_array($smarty_geo)) {
       form_set_value($form['smarty_geo'], $smarty_geo, $form_state);
       if (isset($smarty_geo['zip']) && isset($smarty_geo['plus4'])) {
-        form_set_value($form['submitted']['sbp_zip_plus_four'], $smarty_geo['zip'] . '-' . $smarty_geo['plus4'], $form_state);
-      }
+        $zip_plus_four = &_webform_user_find_field($form, $component_hierarchy['sbp_zip_plus_four']);
+        form_set_value($zip_plus_four, $smarty_geo['zip'] . '-' . $smarty_geo['plus4'], $form_state);      }
     }
     else {
       form_set_error('', t('We could not verify your address. Please check that the street, city, state and zip code information is correct.'));
@@ -288,8 +291,10 @@ function sba_social_action_form_submit($form, &$form_state) {
       foreach ($data->messages as $key => $message) {
         $deliverable += count($message->deliverable);
       }
-      if (isset($form_state['values']['submitted']['sba_deliverable_count'])) {
-        $form_state['values']['submitted']['sba_deliverable_count'] = $deliverable;
+      $component_hierarchy = $form['#hierarchy'];
+      if (isset($component_hierarchy['sba_deliverable_count'])) {
+        $sba_deliverable_count = &_webform_user_find_field($form, $component_hierarchy['sba_deliverable_count']);
+        form_set_value($sba_deliverable_count, $deliverable, $form_state);
       }
     }
   }


### PR DESCRIPTION
A few webform fields in message and social actions were subject to breakage if moved into new fieldsets by a client. This prevents their values from being lost.