### PR TITLE
Add springboard_honeypot module to block IPs after N Honeypot rejections

### DIFF
--- a/springboard_honeypot/springboard_honeypot.admin.inc
+++ b/springboard_honeypot/springboard_honeypot.admin.inc
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Admin functions for springboard_honeypot module.
+ */
+
+/**
+ * Admin settings for springboard_honeypot.
+ */
+function springboard_honeypot_admin_form($form, &$form_state) {
+  $form['springboard_honeypot_count_threshold'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Honeypot blacklist count threshold'),
+    '#description' => t('Maximum number of Honeypot validation failures tolerated before adding IP to the system blacklist.'),
+    '#default_value' => variable_get('springboard_honeypot_count_threshold', 50),
+    '#required' => TRUE,
+    '#size' => 5,
+  );
+
+  return system_settings_form($form);
+}

--- a/springboard_honeypot/springboard_honeypot.info
+++ b/springboard_honeypot/springboard_honeypot.info
@@ -1,0 +1,5 @@
+name = Springboard Honeypot
+description = "Implement Honeypot hooks for Springboard."
+core = 7.x
+configure = admin/config/content/springboard-honeypot
+package = "Spam control"

--- a/springboard_honeypot/springboard_honeypot.install
+++ b/springboard_honeypot/springboard_honeypot.install
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for springboard_honeypot module.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function springboard_honeypot_schema() {
+  $schema['springboard_honeypot'] = array(
+    'description' => 'Table that stores failed attempts to submit a form.',
+    'fields' => array(
+      'uid' => array(
+        'description' => 'Foreign key to {users}.uid; uniquely identifies a Drupal user to whom this ACL data applies.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'ip' => array(
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'description' => 'Hostname of user that that triggered honeypot.',
+      ),
+      'timestamp' => array(
+        'description' => 'Date/time when the form submission failed, as Unix timestamp.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+    ),
+    'indexes' => array(
+      'uid' => array('uid'),
+      'ip' => array('ip'),
+      'timestamp' => array('timestamp'),
+    ),
+  );
+  return $schema;
+}

--- a/springboard_honeypot/springboard_honeypot.module
+++ b/springboard_honeypot/springboard_honeypot.module
@@ -62,4 +62,10 @@ function springboard_honeypot_add_to_blacklist($ip) {
     ->fields(array('ip' => $ip))
     ->execute();
   watchdog('springboard_honeypot', 'Banned IP address %ip', array('%ip' => $ip));
+
+  // Now that the IP has been added to the system blacklist, delete the IP from
+  // springboard_honeypot to keep it from growing too large.
+  db_delete('springboard_honeypot')
+    ->condition('ip', $ip)
+    ->execute();
 }

--- a/springboard_honeypot/springboard_honeypot.module
+++ b/springboard_honeypot/springboard_honeypot.module
@@ -32,7 +32,7 @@ function springboard_honeypot_honeypot_reject($form_id, $uid, $type) {
 }
 
 /**
- * Add an IP to the blacklist.
+ * Record the IP and uid of a Honeypot rejection.
  */
 function springboard_honeypot_add($uid, $ip) {
   db_insert('springboard_honeypot')

--- a/springboard_honeypot/springboard_honeypot.module
+++ b/springboard_honeypot/springboard_honeypot.module
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ * Springboard Honeypot module.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function springboard_honeypot_menu() {
+  $items['admin/config/content/springboard-honeypot'] = array(
+    'title' => 'Springboard Honeypot configuration',
+    'description' => 'Configure Springboard Honeypot.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('springboard_honeypot_admin_form'),
+    'access arguments' => array('administer honeypot'),
+    'file' => 'springboard_honeypot.admin.inc',
+  );
+  return $items;
+}
+
+/**
+ * Implements hook_honeypot_reject().
+ */
+function springboard_honeypot_honeypot_reject($form_id, $uid, $type) {
+  $ip = ip_address();
+  springboard_honeypot_add($uid, $ip);
+  if (springboard_honeypot_count($uid, $ip) >= variable_get('springboard_honeypot_count_threshold', 50)) {
+    springboard_honeypot_add_to_blacklist($ip);
+  }
+}
+
+/**
+ * Add an IP to the blacklist.
+ */
+function springboard_honeypot_add($uid, $ip) {
+  db_insert('springboard_honeypot')
+    ->fields(array(
+      'uid' => $uid,
+      'ip' => $ip,
+      'timestamp' => REQUEST_TIME,
+    ))
+    ->execute();
+}
+
+/**
+ * Count the number of Honeypot rejections for a given IP and uid.
+ */
+function springboard_honeypot_count($uid, $ip) {
+  $query = db_select('springboard_honeypot')
+    ->condition('uid', $uid)
+    ->condition('ip', $ip);
+  return $query->countQuery()->execute()->fetchField();
+}
+
+/**
+ * Immediately add the IP to the system blacklist.
+ */
+function springboard_honeypot_add_to_blacklist($ip) {
+  db_insert('blocked_ips')
+    ->fields(array('ip' => $ip))
+    ->execute();
+  watchdog('springboard_honeypot', 'Banned IP address %ip', array('%ip' => $ip));
+}


### PR DESCRIPTION
We don't want to use the built-in Honeypot trigger to immediately block all Honeypot rejections. However, we do want to block IPs that have multiple Honeypot rejections.

This module will block IPs after a configurable number of failures. The default is 50, which is high enough to target spammers using scripts/bots, but safe for other traffic.

Keeping the name of this module generic enough so we can expand on Honeypot integration down the road.