### PR TITLE
log smarty calls, and prevent smarty calls if form error is not empty

### DIFF
--- a/springboard_advocacy/includes/springboard_advocacy.admin.inc
+++ b/springboard_advocacy/includes/springboard_advocacy.admin.inc
@@ -115,6 +115,13 @@ function springboard_advocacy_settings_form() {
     '#required' => TRUE,
   );
 
+  $form['geo']['smarty']['springboard_advocacy_smarty_debug'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Log Smarty API calls to Watchdog'),
+    '#description' => t('Log smarty responses watchdog. Not recommended for production sites.'),
+    '#default_value' => variable_get('springboard_advocacy_smarty_debug', ''),
+  );
+
   if(module_exists('sba_social_action')) {
 
     // Twitter Oauth credentials. These are different than the credentials in the

--- a/springboard_advocacy/includes/springboard_advocacy.smarty_streets.inc
+++ b/springboard_advocacy/includes/springboard_advocacy.smarty_streets.inc
@@ -43,6 +43,11 @@ function springboard_advocacy_smarty_lookup(array $values) {
 
     $data = json_decode($response->data);
 
+    if (variable_get('springboard_advocacy_smarty_debug', 0)) {
+      $message = isset($data[0]->components) ? print_r($data[0]->components, TRUE) : '';
+      watchdog('advocacy', 'SmartyStreets API lookup: @message', array('@message' => $message), WATCHDOG_INFO);
+    }
+
     if (empty($data)) {
       if (user_access('administer springboard advocacy')) {
         drupal_set_message(t('A zip code + four could not be found for the address entered.'), 'error');

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
@@ -374,17 +374,20 @@ function sba_message_action_form_validate(&$form, &$form_state) {
   form_load_include($form_state, 'inc', 'springboard_advocacy', 'includes/springboard_advocacy.smarty_streets');
   $webform_values_flat = _springboard_advocacy_webform_submission_flatten($form['#node']->nid, $form_state['values']['submitted']);
   form_set_value($form['webform_flat'], $webform_values_flat, $form_state);
-  $smarty_geo = springboard_advocacy_smarty_lookup($webform_values_flat);
-  if (!empty($smarty_geo) && is_array($smarty_geo)) {
-    form_set_value($form['smarty_geo'], $smarty_geo, $form_state);
-    if (isset($smarty_geo['zip']) && isset($smarty_geo['plus4'])) {
-      $zip_plus_four = &_webform_user_find_field($form, $component_hierarchy['sbp_zip_plus_four']);
-      form_set_value($zip_plus_four, $smarty_geo['zip'] . '-' . $smarty_geo['plus4'], $form_state);
+  $form_error = &drupal_static('form_set_error');
+  if (empty($form_error)) {
+    $smarty_geo = springboard_advocacy_smarty_lookup($webform_values_flat);
+    if (!empty($smarty_geo) && is_array($smarty_geo)) {
+      form_set_value($form['smarty_geo'], $smarty_geo, $form_state);
+      if (isset($smarty_geo['zip']) && isset($smarty_geo['plus4'])) {
+        $zip_plus_four = &_webform_user_find_field($form, $component_hierarchy['sbp_zip_plus_four']);
+        form_set_value($zip_plus_four, $smarty_geo['zip'] . '-' . $smarty_geo['plus4'], $form_state);
+      }
     }
-  }
-  else {
-    if (empty($form_state['storage']['quicksign_validated'])) {
-      form_set_error('', t('We could not verify your address. Please check that the street, city, state and zip code information is correct.'));
+    else {
+      if (empty($form_state['storage']['quicksign_validated'])) {
+        form_set_error('', t('We could not verify your address. Please check that the street, city, state and zip code information is correct.'));
+      }
     }
   }
 }

--- a/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.form.inc
+++ b/springboard_advocacy/modules/sba_social_action/includes/sba_social_action.form.inc
@@ -234,19 +234,22 @@ function sba_social_action_form_validate($form, &$form_state) {
   $webform_values_flat = _springboard_advocacy_webform_submission_flatten($form['#node']->nid, $form_state['values']['submitted']);
   form_set_value($form['webform_flat'], $webform_values_flat, $form_state);
 
-  // If the message is not districted, we'll skip the smarty lookup and substitute bogus values
-  // in sba_social_action_build_contact().
+  // If the message is not districted, we'll skip the smarty lookup
+  // and substitute bogus values in sba_social_action_build_contact().
   if (!empty($form_state['values']['districted'])) {
-    $smarty_geo = springboard_advocacy_smarty_lookup($webform_values_flat);
-    if (!empty($smarty_geo) && is_array($smarty_geo)) {
-      form_set_value($form['smarty_geo'], $smarty_geo, $form_state);
-      if (isset($smarty_geo['zip']) && isset($smarty_geo['plus4'])) {
-        $zip_plus_four = &_webform_user_find_field($form, $component_hierarchy['sbp_zip_plus_four']);
-        form_set_value($zip_plus_four, $smarty_geo['zip'] . '-' . $smarty_geo['plus4'], $form_state);
+    $form_error = &drupal_static('form_set_error');
+    if (empty($form_error)) {
+      $smarty_geo = springboard_advocacy_smarty_lookup($webform_values_flat);
+      if (!empty($smarty_geo) && is_array($smarty_geo)) {
+        form_set_value($form['smarty_geo'], $smarty_geo, $form_state);
+        if (isset($smarty_geo['zip']) && isset($smarty_geo['plus4'])) {
+          $zip_plus_four = &_webform_user_find_field($form, $component_hierarchy['sbp_zip_plus_four']);
+          form_set_value($zip_plus_four, $smarty_geo['zip'] . '-' . $smarty_geo['plus4'], $form_state);
+        }
       }
-    }
-    else {
-      form_set_error('', t('We could not verify your address. Please check that the street, city, state and zip code information is correct.'));
+      else {
+        form_set_error('', t('We could not verify your address. Please check that the street, city, state and zip code information is correct.'));
+      }
     }
   }
 }


### PR DESCRIPTION
- Don't do a smarty API lookup if there is a form validation error.
- Optionally log smarty calls to watchdog.