### PR TITLE
move single step message action success hook into submit function

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
@@ -128,7 +128,8 @@ function sba_message_action_additional_elements(&$form, &$form_state) {
   }
 
   $form['#validate'][] = 'sba_message_action_form_validate';
-  $form['#submit'][] = 'sba_message_action_form_submit';
+  $form['#submit'][] = 'sba_message_action_form_submit_success';
+  array_unshift($form['#submit'], 'sba_message_action_form_submit');
 }
 
 /**
@@ -399,16 +400,14 @@ function sba_message_action_form_validate(&$form, &$form_state) {
  * @param $form_state
  */
 function sba_message_action_form_submit($form, &$form_state) {
-  $node = $form['#node'];
-  $node_wrapper = entity_metadata_wrapper('node', $node);
-  $multi_flow = $node_wrapper->field_sba_action_flow->value() == 'multi' ? TRUE : FALSE;
 
   $_SESSION['delivered_messages'] = array();
   $_SESSION['undelivered_messages'] = array();
   $_SESSION['contact'] = array();
   $_SESSION['form_details'] = array();
   $_SESSION['action_sid'] = FALSE;
-  //$_SESSION['action_completed'] = FALSE;
+  $_SESSION['success_messages'] = array();
+
   // Create array of messages to submit for target resolution.
   if (isset($form_state['values']['sba_messages'])) {
     $messages = array();
@@ -437,7 +436,27 @@ function sba_message_action_form_submit($form, &$form_state) {
   }
 }
 
-
+/**
+ * Second submit hook to fire after webform_client_submit().
+ *
+ * In order to get the submission ID we need a second submit hook which
+ * fires after webform has done its processing. The other submit hook has
+ * to fire before webform in order to make session values available for token
+ * replacement in confirmation messages when there is a reirect set in
+ * confirmation settings.
+ *
+ * @param array $form
+ *   The form array.
+ * @param array $form_state
+ *   The form_state array.
+ */
+function sba_message_action_form_submit_success($form, &$form_state) {
+  if (!empty($_SESSION['success_messages'])) {
+    $node = $form['#node'];
+    $sid = !empty($_SESSION['webform_confirmations_sid']) ? $_SESSION['webform_confirmations_sid'] : FALSE;
+    springboard_advocacy_success($node, $_SESSION['contact'], $_SESSION['success_messages'], $sid);
+  }
+}
 /**
  * Helper function to build message bodies.
  *

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.webform.inc
@@ -67,8 +67,7 @@ function sba_message_action_send_message(array $user_message, array $form_state)
 
       // Fire the success hook for one-step actions.
       if (!empty($multi_flow[0]['value']) && $multi_flow[0]['value'] != 'multi') {
-        $sid = !empty($values['details']['sid']) ? $values['details']['sid'] : FALSE;
-        springboard_advocacy_success($node, $contact, (array) $response->data->messages, $sid);
+        $_SESSION['success_messages'] =  (array) $response->data->messages;
       }
     }
   }


### PR DESCRIPTION
Changes implemeted for the message action success hook broke token replacement in single step message actions which have redirects set.

This patch restores the previous execution order the message action submit hook (prior to webform's submitters), creates a new submit which fires after webform has processed the form, and moves the single step success call from the message_action.webform.inc file into the new submit hook. Unfortunately, this means putting more response data into session.