### PR TITLE
Adding a honeypot timer blacklist setting.

### DIFF
--- a/springboard_honeypot/springboard_honeypot.admin.inc
+++ b/springboard_honeypot/springboard_honeypot.admin.inc
@@ -18,5 +18,12 @@ function springboard_honeypot_admin_form($form, &$form_state) {
     '#size' => 5,
   );
 
+  $form['springboard_honeypot_timer_blacklist'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Honeypot timer blacklist'),
+    '#description' => t('Forms that should not use Honeypot\'s timer validation. Use this setting to turn off the timer on specfic forms without turning it off globally. Enter one form id per line.'),
+    '#default_value' => variable_get('springboard_honeypot_timer_blacklist', ''),
+  );
+
   return system_settings_form($form);
 }

--- a/springboard_honeypot/springboard_honeypot.module
+++ b/springboard_honeypot/springboard_honeypot.module
@@ -32,6 +32,23 @@ function springboard_honeypot_honeypot_reject($form_id, $uid, $type) {
 }
 
 /**
+ * Implements hook_honeypot_form_protections_alter().
+ */
+function springboard_honeypot_honeypot_form_protections_alter(&$options, $form) {
+  // Get our timer blacklist.
+  $blacklist = variable_get('springboard_honeypot_timer_blacklist', '');
+  $blacklist = explode("\n", $blacklist);
+
+  // Remove the time restriction option from each blacklisted form.
+  foreach ($blacklist as $form_id) {
+    if ($form['form_id']['#value'] == $form_id && in_array('time_restriction', $options)) {
+      $key = array_search('time_restriction', $options);
+      unset($options[$key]);
+    }
+  }
+}
+
+/**
  * Add an IP to the blacklist.
  */
 function springboard_honeypot_add($uid, $ip) {


### PR DESCRIPTION
Create a setting that allows admins to exclude the honeypot timer from specific forms.