### PR TITLE
make sure payment method settings is an array

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -2859,7 +2859,7 @@ function fundraiser_commerce_form_alter(&$form, &$form_state, $form_id) {
       // Add standalone image if only one gateway is enabled.
       if ($enabled == 1) {
         foreach ($node->gateways as $gateway) {
-          if (!empty($gateway['status']) && $gateway['status'] == 1) {
+          if (!empty($gateway['status']) && $gateway['status'] == 1 && !empty($settings) && is_array($settings['payment_method'])) {
             $form['submitted']['payment_information']['payment_fields'][$gateway['method']]['#description'] = '<img src="' . $settings['payment_method']['settings']['standalone_image'] . '">';
           }
         }


### PR DESCRIPTION
If a payment method settings has never been re-saved, $settings['payment_method'] is a single-character string rather than an array, causing a php notice. It essentially means you have an active payment method which has not been configured, or perhaps not reconfigured after an update which has added more config options, as the dual ask amount seems to have introduced.