### PR TITLE
For each $blacklist element, also run `trim()` in case newlines are `\r\n` and not just `\n`

### DIFF
--- a/springboard_honeypot/springboard_honeypot.module
+++ b/springboard_honeypot/springboard_honeypot.module
@@ -37,14 +37,11 @@ function springboard_honeypot_honeypot_reject($form_id, $uid, $type) {
 function springboard_honeypot_honeypot_form_protections_alter(&$options, $form) {
   // Get our timer blacklist.
   $blacklist = variable_get('springboard_honeypot_timer_blacklist', '');
-  $blacklist = explode("\n", $blacklist);
+  $blacklist = array_map('trim', explode("\n", $blacklist));
 
   // Remove the time restriction option from each blacklisted form.
-  foreach ($blacklist as $form_id) {
-    if ($form['form_id']['#value'] == $form_id && in_array('time_restriction', $options)) {
-      $key = array_search('time_restriction', $options);
-      unset($options[$key]);
-    }
+  if (in_array($form['#form_id'], $blacklist) && $key = array_search('time_restriction', $options)) {
+    unset($options[$key]);
   }
 }
 


### PR DESCRIPTION
For each $blacklist element, also run `trim()` in case newlines are `\r\n` and not just `\n`.

Also, simplifying the unset logic.