### PR TITLE
tweak failure handling in hmac and sustainers upgrade

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/fundraiser_sustainers_upgrade.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/fundraiser_sustainers_upgrade.module
@@ -410,6 +410,8 @@ function fundraiser_sustainers_upgrade_stop_in_tracks() {
     'Non-numeric values in payload.',
     'Donation ID is not a master ID.',
     'No session values found.',
+    'No recurring donations remaining.',
+    'The upgrade amount is lower than or equal to the current donation.',
   );
   return $stop_in_tracks;
 }

--- a/springboard_hmac/springboard_hmac.module
+++ b/springboard_hmac/springboard_hmac.module
@@ -112,7 +112,7 @@ function springboard_hmac_verify($payload, $hmac) {
   // Check the payload for errors.
   $failure_reason = springboard_hmac_verify_payload($parsed_payload);
   if (!empty($failure_reason)) {
-    springboard_hmac_save($hmac);
+    //springboard_hmac_save($hmac);
     return springboard_hmac_failure($failure_reason, $parsed_payload);
   }
 
@@ -131,7 +131,7 @@ function springboard_hmac_verify($payload, $hmac) {
   // unaltered and we can continue.
   if ($hmac != $verification_hmac) {
     $reason = t('Authentication failed. Tokens do not match.');
-    springboard_hmac_save($hmac);
+    //springboard_hmac_save($hmac);
     return springboard_hmac_failure($reason, $parsed_payload);
   }
   else {


### PR DESCRIPTION
add two error statuses to stop in tracks criteria
don't save failed hmac validations to prevent spam flooding