### PR TITLE
use empty rather than isset in cardonfile check

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -2048,7 +2048,7 @@ function fundraiser_sustainers_edit_form($did) {
   $type = '';
 
   // Use next donation in case it has differnt info than the master donation.
-  if (isset($next_donation->data['cardonfile']) && module_exists('commerce_cardonfile')) {
+  if (!empty($next_donation->data['cardonfile']) && module_exists('commerce_cardonfile')) {
     $cardonfile = commerce_cardonfile_load($next_donation->data['cardonfile']);
     if (!empty($cardonfile)) {
       $number = '**** **** **** '  . $cardonfile->card_number;


### PR DESCRIPTION
The value of $next_donation->data['cardonfile']  can be "FALSE" when the example payment method is used, which causes an array_flip() error in entity_load().