### PR TITLE
Saving the sustainers_series object after donation amount is updated.

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -2353,6 +2353,11 @@ function _fundraiser_sustainers_donation_amount_form_update_donations($master_di
     }
   }
 
+  // Update the sustainer series object with the new amount.
+ $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $master_did);
+ $fundraiser_sustainers_series->amount = $amount;
+ $fundraiser_sustainers_series->save();
+ 
   drupal_set_message(t('The amount of all future donations has been updated to @amount.', array('@amount' => $formatted_amount)));
 }
 


### PR DESCRIPTION
This update re-saves the sustainers_series entity with the new donation amount. The save operation will cause the object to resync to Salesforce if the entity mapping module is enabled and configured to send updates.