### PR TITLE
Change sustainer upgrade default text and tokens.

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/fundraiser_sustainers_upgrade.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/fundraiser_sustainers_upgrade.module
@@ -868,7 +868,7 @@ function fundraiser_sustainers_upgrade_tokens($type, $tokens, $data = array(), $
             if (!empty($redirect[0]['value'])) {
               $query = $redirect[0]['value'];
             }
-            $replacements[$original] = "(I'm Not " . l($value, 'sustainers-upgrade/cancel', array('absolute' => TRUE, 'query' => array('su_redirect' => $query))) . ")";
+            $replacements[$original] = "(Not " . $value ."? " . l('Click here.', 'sustainers-upgrade/cancel', array('absolute' => TRUE, 'query' => array('su_redirect' => $query))) . ")";
           }
           break;
 
@@ -876,7 +876,7 @@ function fundraiser_sustainers_upgrade_tokens($type, $tokens, $data = array(), $
           if (!empty($payload['amount'])) {
             $status = fundraiser_sustainers_upgrade_check_donation_status($payload);
             $stop_in_tracks = fundraiser_sustainers_upgrade_stop_in_tracks();
-            if (!in_array($status['status'], $stop_in_tracks)) {
+            if (!in_array($status['status'], $stop_in_tracks) || arg(2) == 'done') {
               $order = commerce_order_load($status['donation']->did);
               $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
               $order_total = $order_wrapper->commerce_order_total->value();
@@ -888,7 +888,7 @@ function fundraiser_sustainers_upgrade_tokens($type, $tokens, $data = array(), $
         case 'next_charge_amount_formatted':
           $status = fundraiser_sustainers_upgrade_check_donation_status($payload);
           $stop_in_tracks = fundraiser_sustainers_upgrade_stop_in_tracks();
-          if (!in_array($status['status'], $stop_in_tracks)) {
+          if (!in_array($status['status'], $stop_in_tracks) || arg(2) == 'done') {
             $order = commerce_order_load($status['recurring'][0]->did);
             $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
             $order_total = $order_wrapper->commerce_order_total->value();
@@ -899,7 +899,7 @@ function fundraiser_sustainers_upgrade_tokens($type, $tokens, $data = array(), $
         case 'charges_remaining':
           $status = fundraiser_sustainers_upgrade_check_donation_status($payload);
           $stop_in_tracks = fundraiser_sustainers_upgrade_stop_in_tracks();
-          if (!in_array($status['status'], $stop_in_tracks)) {
+          if (!in_array($status['status'], $stop_in_tracks) || arg(2) == 'done') {
             $replacements[$original] = count($status['recurring']);
           }
           break;

--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/includes/install/fundraiser_sustainers_upgrade.install_example.inc
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/includes/install/fundraiser_sustainers_upgrade.install_example.inc
@@ -17,16 +17,14 @@ function _fundraiser_sustainers_upgrade_add_example() {
   $node->title = 'Default Sustainers Upgrade Form';
   $node->status = 1;
   $node->promote = 0;
-  $node->body[LANGUAGE_NONE][0]['value'] = 'Thank you [donation:first_name] [donation:last_name] [sustainer_upgrade:signout] for upgrading your monthly donation to [sustainer_upgrade:upgrade_amount_formatted].
+  $node->body[LANGUAGE_NONE][0]['value'] = 'Thank you [donation:first_name] [donation:last_name]. [sustainer_upgrade:signout] To upgrade your monthly donation to [sustainer_upgrade:upgrade_amount_formatted], click Confirm below.
 
-Your original donation for [donation:currency:code][donation:amount], was made on [donation:payment-transaction:created:short] with your card ending in [donation:card_number]. You have [sustainer_upgrade:charges_remaining] charges remaining in this series, which will be upgraded to [sustainer_upgrade:upgrade_amount_formatted].
-
-To upgrade your sustaining donation to [sustainer_upgrade:upgrade_amount_formatted], click Confirm below.';
+Your original donation for [donation:currency:symbol][donation:amount], was made on [donation:payment-transaction:created:short] with your card ending in [donation:card_number]. You have [sustainer_upgrade:charges_remaining] charges remaining in this series, which will be upgraded to [sustainer_upgrade:upgrade_amount_formatted].';
   $node->body[LANGUAGE_NONE][0]['format'] = 'filtered_html';
   $node->field_sustainers_upgrade_name[LANGUAGE_NONE][0]['value'] = "Default Sustainers Upgrade Form";
   $node->field_sustainers_upgrade_fail[LANGUAGE_NONE][0]['value'] = "Donation upgrade can not be completed.";
-  $node->field_sustainers_upgrade_roll[LANGUAGE_NONE][0]['value'] = "Your donation upgrade has been cancelled and rolled back to [sustainer_upgrade:upgrade_amount_formatted].";
-  $node->field_sustainers_upgrade_b_roll[LANGUAGE_NONE][0]['value'] = 'Hello [donation:first_name] [donation:last_name] [sustainer_upgrade:signout]. To rollback your sustaining donation to [sustainer_upgrade:upgrade_amount_formatted], click Confirm below';
+  $node->field_sustainers_upgrade_roll[LANGUAGE_NONE][0]['value'] = "Your donation upgrade has been canceled and rolled back to [sustainer_upgrade:upgrade_amount_formatted].";
+  $node->field_sustainers_upgrade_b_roll[LANGUAGE_NONE][0]['value'] = 'Hello [donation:first_name] [donation:last_name]. [sustainer_upgrade:signout] To rollback your sustaining donation to [sustainer_upgrade:upgrade_amount_formatted], click Confirm below.';
   $node->webform = array(
     'confirmation' => 'Thank you [donation:first_name] [donation:last_name] for upgrading your sustaining donation to [sustainer_upgrade:upgrade_amount_formatted].',
     'confirmation_format' => 'filtered_html',


### PR DESCRIPTION
This changes some default text and allows the upgrade tokens to be used on the confirmation page, after some changes from last week broke them there.