### PR TITLE
Adding new hook for sustainer order insertion.

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -2935,12 +2935,10 @@ function _fundraiser_sustainers_create_future_orders($donation, $month, $year, $
       // Update the recurring table.
       _fundraiser_sustainers_create_recurring($recurring_donation);
 
-      // Load the newly created individual donation into salesforce_donation.
-      if (module_exists('salesforce_genmap')) {
-        $sf_donation = fundraiser_donation_get_donation($new_donation->did, TRUE);
-        salesforce_genmap_send_object_to_queue('salesforce_donation', 'insert',
-          $sf_donation->node, $sf_donation->did, $sf_donation, 'donation');
-      }
+      // Load up the new donation so that all it's properties are set correctly.
+      $created_donation = fundraiser_donation_get_donation($new_donation->did, TRUE);
+      // Fire a hook to allow other modules to respond to the future order being created.
+      module_invoke_all('fundraiser_sustainers_future_order_insert', $created_donation);
 
       // Update the previous charge object.
       $previous_charge = $next;

--- a/salesforce/salesforce_donation/salesforce_donation.module
+++ b/salesforce/salesforce_donation/salesforce_donation.module
@@ -340,6 +340,15 @@ function salesforce_donation_fundraiser_donation_delete($donation) {
 }
 
 /**
+ * Implements hook_fundraiser_sustainers_future_order_insert().
+ *
+ * Queue up pending donations for export to Salesforce.
+ */
+function salesforce_donation_fundraiser_sustainers_future_order_insert($donation) {
+  salesforce_genmap_send_object_to_queue('salesforce_donation', 'insert', $donation->node, $donation->did, $donation, 'donation');
+}
+
+/**
  * Implements hook_salesforce_genmap_map_item_alter().
  */
 function salesforce_donation_salesforce_genmap_map_item_alter(&$item, $donation) {


### PR DESCRIPTION
In addition to the new hook, the queueing of the future donations has been moved into the salesforce_donation module via implementation of the new hook.

I tested both real-time and delayed sustainer creation and orders are being queued as expected.