### PR TITLE
7.x 4.10 beta1 1017 paypal and authnet settings lost after save

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -2697,8 +2697,15 @@ function fundraiser_commerce_form_rules_ui_edit_element_alter(&$form, &$form_sta
       ? $form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value']
       : '';
     $method = commerce_payment_method_instance_load($method_id . '|commerce_payment_' . $method_id);
+    $path = drupal_get_path('module', 'fundraiser_commerce') . '/gateways/' . $method['module'] . '.inc';
+    if (file_exists($path)) {
+      form_load_include($form_state, 'inc', 'fundraiser_commerce', '/gateways/' . $method['module']);
+      $function = $method['module'] . '_form_rules_ui_edit_element_builder';
+      if (function_exists($function)) {
+        $function($form, $form_state, $method);
+      }
+    }
     $form_state['storage']['old_settings_assoc'] = isset($method['settings']) ? $method['settings'] : FALSE;
-
     $form['#submit'][] = 'fundraiser_commerce_gateway_log_gateway_settings_changes';
     $form['#attached']['js'][]= drupal_get_path('module', 'fundraiser_commerce') . '/js//gateway.js';
   }

--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -2697,16 +2697,27 @@ function fundraiser_commerce_form_rules_ui_edit_element_alter(&$form, &$form_sta
       ? $form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value']
       : '';
     $method = commerce_payment_method_instance_load($method_id . '|commerce_payment_' . $method_id);
+
+    // Load form builder functions from the gateway include files,
+    // if they exist, in order to add custom settings form elements. Needed
+    // because hook_form_rules_ui_edit_element_alter() has cache problems if
+    // implemented from an include file.
     if (!empty($method['module'])) {
       $path = drupal_get_path('module', 'fundraiser_commerce') . '/gateways/' . $method['module'] . '.inc';
+      // Is there a module_name.inc file in the gateways folder?
       if (file_exists($path)) {
+        // Load the inc file.
         form_load_include($form_state, 'inc', 'fundraiser_commerce', '/gateways/' . $method['module']);
+        // Check to see if the form builder function exists.
         $function = $method['module'] . '_form_rules_ui_edit_element_builder';
         if (function_exists($function)) {
+          // Invoke the function to add the new elements to the
+          // action settings form.
           $function($form, $form_state);
         }
       }
     }
+
     $form_state['storage']['old_settings_assoc'] = isset($method['settings']) ? $method['settings'] : FALSE;
     $form['#submit'][] = 'fundraiser_commerce_gateway_log_gateway_settings_changes';
     $form['#attached']['js'][]= drupal_get_path('module', 'fundraiser_commerce') . '/js//gateway.js';

--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -2697,12 +2697,14 @@ function fundraiser_commerce_form_rules_ui_edit_element_alter(&$form, &$form_sta
       ? $form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value']
       : '';
     $method = commerce_payment_method_instance_load($method_id . '|commerce_payment_' . $method_id);
-    $path = drupal_get_path('module', 'fundraiser_commerce') . '/gateways/' . $method['module'] . '.inc';
-    if (file_exists($path)) {
-      form_load_include($form_state, 'inc', 'fundraiser_commerce', '/gateways/' . $method['module']);
-      $function = $method['module'] . '_form_rules_ui_edit_element_builder';
-      if (function_exists($function)) {
-        $function($form, $form_state, $method);
+    if (!empty($method['module'])) {
+      $path = drupal_get_path('module', 'fundraiser_commerce') . '/gateways/' . $method['module'] . '.inc';
+      if (file_exists($path)) {
+        form_load_include($form_state, 'inc', 'fundraiser_commerce', '/gateways/' . $method['module']);
+        $function = $method['module'] . '_form_rules_ui_edit_element_builder';
+        if (function_exists($function)) {
+          $function($form, $form_state);
+        }
       }
     }
     $form_state['storage']['old_settings_assoc'] = isset($method['settings']) ? $method['settings'] : FALSE;

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet.inc
@@ -389,15 +389,38 @@ function commerce_authnet_fundraiser_commerce_refund($payment_method, $refund) {
   return $success;
 }
 
+/**
+ * Alter the action form settings field.
+ *
+ * Called from fundraiser_commerce_form_rules_ui_edit_element_alter().
+ *
+ * @param $form
+ * @param $form_state
+ */
 function commerce_authnet_form_rules_ui_edit_element_builder(&$form, &$form_state) {
 
-  $rule = rules_config_load(arg(5));
-  // @TODO: is there a better way to get the rule name?
+  if (arg(4) == 'reaction' && arg(5) == 'manage') {
+    // We're in the rules UI.
+    $rule = rules_config_load(arg(6));
+  }
+    elseif (arg(3) == 'payment-methods' && arg(4) == 'manage') {
+    // We're in the commerce payment method UI.
+    $rule = rules_config_load(arg(5));
+  }
+  // @TODO: is there a better way to get the rule?
   $actions = !empty($rule) ? $rule->actions() : FALSE;
   if (!empty($actions)) {
     // Find the settings for the Authorize.net gateway action.
     foreach ($actions as $action) {
-      if (isset($action->settings['payment_method']['method_id']) &&  $action->settings['payment_method']['method_id'] == 'authnet_aim' && $action->elementId() == arg(7)) {
+      if (arg(7) == 'edit') {
+        // We're in the rules UI.
+        $action_id = arg(8);
+      }
+      else {
+        // We're in the commerce payment method UI.
+        $action_id = arg(7);
+      }
+      if (isset($action->settings['payment_method']['method_id']) &&  $action->settings['payment_method']['method_id'] == 'authnet_aim' && $action->elementId() == $action_id) {
         // @TODO: is there a better way to get the action ID?
         $settings[] = $action->settings;
       }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet.inc
@@ -392,21 +392,27 @@ function commerce_authnet_fundraiser_commerce_refund($payment_method, $refund) {
 /**
  * Alter the action form settings field.
  *
- * Called from fundraiser_commerce_form_rules_ui_edit_element_alter().
+ * This function was formerly an implemention of
+ * hook_form_rules_ui_edit_element_alter() but behaved inconsistently here
+ * in the gateway.inc file. Now it is renamed and called dynamically from
+ * fundraiser_commerce_form_rules_ui_edit_element_alter() using
+ * form_load_include().
  *
  * @param $form
  * @param $form_state
  */
 function commerce_authnet_form_rules_ui_edit_element_builder(&$form, &$form_state) {
 
+  // Check if we're in the commerce_ui or rules UI admin pages.
   if (arg(4) == 'reaction' && arg(5) == 'manage') {
     // We're in the rules UI.
     $rule = rules_config_load(arg(6));
   }
-    elseif (arg(3) == 'payment-methods' && arg(4) == 'manage') {
+  elseif (arg(3) == 'payment-methods' && arg(4) == 'manage') {
     // We're in the commerce payment method UI.
     $rule = rules_config_load(arg(5));
   }
+
   // @TODO: is there a better way to get the rule?
   $actions = !empty($rule) ? $rule->actions() : FALSE;
   if (!empty($actions)) {

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet.inc
@@ -402,107 +402,113 @@ function commerce_authnet_fundraiser_commerce_refund($payment_method, $refund) {
  * @param $form_state
  */
 function commerce_authnet_form_rules_ui_edit_element_builder(&$form, &$form_state) {
-
-  // Check if we're in the commerce_ui or rules UI admin pages.
-  if (arg(4) == 'reaction' && arg(5) == 'manage') {
-    // We're in the rules UI.
-    $rule = rules_config_load(arg(6));
-  }
-  elseif (arg(3) == 'payment-methods' && arg(4) == 'manage') {
-    // We're in the commerce payment method UI.
-    $rule = rules_config_load(arg(5));
-  }
-
-  // @TODO: is there a better way to get the rule?
-  $actions = !empty($rule) ? $rule->actions() : FALSE;
-  if (!empty($actions)) {
-    // Find the settings for the Authorize.net gateway action.
-    foreach ($actions as $action) {
-      if (arg(7) == 'edit') {
+  // The following two "if" checks are probably not needed, but retained for
+  // readability purposes.
+  if (isset($form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value'])) {
+    $id = $form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value'];
+    $is_com = isset($form['parameter']['commerce_order']) ? 1 : 0;
+    if ($id == 'authnet_aim' && $is_com) {
+      // Check if we're in the commerce_ui or rules UI admin pages.
+      if (arg(4) == 'reaction' && arg(5) == 'manage') {
         // We're in the rules UI.
-        $action_id = arg(8);
+        $rule = rules_config_load(arg(6));
       }
-      else {
+      elseif (arg(3) == 'payment-methods' && arg(4) == 'manage') {
         // We're in the commerce payment method UI.
-        $action_id = arg(7);
+        $rule = rules_config_load(arg(5));
       }
-      if (isset($action->settings['payment_method']['method_id']) &&  $action->settings['payment_method']['method_id'] == 'authnet_aim' && $action->elementId() == $action_id) {
-        // @TODO: is there a better way to get the action ID?
-        $settings[] = $action->settings;
+
+      // @TODO: is there a better way to get the rule?
+      $actions = !empty($rule) ? $rule->actions() : FALSE;
+      if (!empty($actions)) {
+        // Find the settings for the Authorize.net gateway action.
+        foreach ($actions as $action) {
+          if (arg(7) == 'edit') {
+            // We're in the rules UI.
+            $action_id = arg(8);
+          }
+          else {
+            // We're in the commerce payment method UI.
+            $action_id = arg(7);
+          }
+          if (isset($action->settings['payment_method']['method_id']) && $action->settings['payment_method']['method_id'] == 'authnet_aim' && $action->elementId() == $action_id) {
+            // @TODO: is there a better way to get the action ID?
+            $settings[] = $action->settings;
+          }
+        }
+        $config = isset($settings[0]['payment_method']['settings']) ? $settings[0]['payment_method']['settings'] : '';
+
+        // Add a fieldset of Authorize.net request fields
+        // available to have Webform field data mapped to them.
+        $form['parameter']['payment_method']['settings']['payment_method']['settings']['value_map'] = array(
+          '#type' => 'fieldset',
+          '#title' => t('Submission mapping'),
+          '#description' => t('Enter the webform field keys to map to these authorize.net fields.'),
+          '#tree' => TRUE,
+        );
+        $available_fields = _commerce_authnet_extra_fields();
+        unset($available_fields[0]);
+        $i = 1;
+        foreach ($available_fields as $field) {
+          $form['parameter']['payment_method']['settings']['payment_method']['settings']['commerce_authnet_webform_field_' . $i] = array(
+            '#title' => t('Enter webform field #%i', array('%i' => $i)),
+            '#type' => 'textfield',
+            '#description' => t('Example: field_name'),
+            '#default_value' => !empty($config['commerce_authnet_webform_field_' . $i]) ? $config['commerce_authnet_webform_field_' . $i] : '',
+          );
+
+          $form['parameter']['payment_method']['settings']['payment_method']['settings']['commerce_authnet_authorize_field_' . $i] = array(
+            '#title' => t('Authorize field #%i', array('%i' => $i)),
+            '#type' => 'select',
+            '#options' => _commerce_authnet_extra_fields(),
+            '#default_value' => !empty($config['commerce_authnet_authorize_field_' . $i]) ? $config['commerce_authnet_authorize_field_' . $i] : '',
+          );
+          $i++;
+        }
+
+        // Add a fieldset of Authorize.net response
+        // fields available to be mapped to donation fields.
+        $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields'] = array(
+          '#type' => 'fieldset',
+          '#title' => t('Response Fields for Mapping'),
+          '#description' => t('The selected fields will be made available for mapping to exported donations.'),
+          '#collapsible' => TRUE,
+          '#collapsed' => FALSE,
+          '#element_validate' => array('fundraiser_commerce_response_fields_validate'),
+        );
+        $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['mappable'] = array(
+          '#type' => 'value',
+          '#value' => array(),
+        );
+        $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'] = array(
+          '#theme' => 'table',
+          '#header' => array(
+            'checkbox' => t('Available'),
+            'description' => t('Authorize.net gateway response field'),
+          ),
+          '#rows' => array(),
+        );
+        foreach (_commerce_authnet_response_fields() as $machine_name => $field) {
+          $id = 'mappable_fields-' . $machine_name;
+          $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'][$machine_name] = array(
+            '#id' => $id,
+            '#type' => 'checkbox',
+            '#default_value' => in_array($machine_name, !empty($config['response_fields']['mappable']) ? $config['response_fields']['mappable'] : array()),
+          );
+          $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all']['#rows'][$machine_name] = array(
+            'checkbox' => array(
+              // Tricky but it works: The table element's children
+              // (the checkboxes) will all have rendered as
+              // form components by the time the table theme function picks
+              // them up by reference here.
+              'data' => &$form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'][$machine_name],
+            ),
+            'description' => '<label for="' . $id . '">' . $field['name'] . '</label><span>' . t($field['description']) . '</span>',
+          );
+        }
       }
-    }
-    $config = isset($settings[0]['payment_method']['settings']) ? $settings[0]['payment_method']['settings'] : '';
-
-    // Add a fieldset of Authorize.net request fields
-    // available to have Webform field data mapped to them.
-    $form['parameter']['payment_method']['settings']['payment_method']['settings']['value_map'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('Submission mapping'),
-      '#description' => t('Enter the webform field keys to map to these authorize.net fields.'),
-      '#tree' => TRUE,
-    );
-    $available_fields = _commerce_authnet_extra_fields();
-    unset($available_fields[0]);
-    $i = 1;
-    foreach ($available_fields as $field) {
-      $form['parameter']['payment_method']['settings']['payment_method']['settings']['commerce_authnet_webform_field_' . $i] = array(
-        '#title' => t('Enter webform field #%i', array('%i' => $i)),
-        '#type' => 'textfield',
-        '#description' => t('Example: field_name'),
-        '#default_value' => !empty($config['commerce_authnet_webform_field_' . $i]) ? $config['commerce_authnet_webform_field_' . $i] : '',
-      );
-
-      $form['parameter']['payment_method']['settings']['payment_method']['settings']['commerce_authnet_authorize_field_' . $i] = array(
-        '#title' => t('Authorize field #%i', array('%i' => $i)),
-        '#type' => 'select',
-        '#options' => _commerce_authnet_extra_fields(),
-        '#default_value' => !empty($config['commerce_authnet_authorize_field_' . $i]) ? $config['commerce_authnet_authorize_field_' . $i] : '',
-      );
-      $i++;
-    }
-
-    // Add a fieldset of Authorize.net response
-    // fields available to be mapped to donation fields.
-    $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('Response Fields for Mapping'),
-      '#description' => t('The selected fields will be made available for mapping to exported donations.'),
-      '#collapsible' => TRUE,
-      '#collapsed' => FALSE,
-      '#element_validate' => array('fundraiser_commerce_response_fields_validate'),
-    );
-    $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['mappable'] = array(
-      '#type' => 'value',
-      '#value' => array(),
-    );
-    $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'] = array(
-      '#theme' => 'table',
-      '#header' => array(
-        'checkbox' => t('Available'),
-        'description' => t('Authorize.net gateway response field'),
-      ),
-      '#rows' => array(),
-    );
-    foreach (_commerce_authnet_response_fields() as $machine_name => $field) {
-      $id = 'mappable_fields-' . $machine_name;
-      $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'][$machine_name] = array(
-        '#id' => $id,
-        '#type' => 'checkbox',
-        '#default_value' => in_array($machine_name, !empty($config['response_fields']['mappable']) ? $config['response_fields']['mappable'] : array()),
-      );
-      $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all']['#rows'][$machine_name] = array(
-        'checkbox' => array(
-          // Tricky but it works: The table element's children
-          // (the checkboxes) will all have rendered as
-          // form components by the time the table theme function picks
-          // them up by reference here.
-          'data' => &$form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'][$machine_name],
-        ),
-        'description' => '<label for="' . $id . '">' . $field['name'] . '</label><span>' . t($field['description']) . '</span>',
-      );
     }
   }
-
 }
 
 function fundraiser_commerce_commerce_authnet_aim_request_alter(&$nvp) {

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet.inc
@@ -389,89 +389,91 @@ function commerce_authnet_fundraiser_commerce_refund($payment_method, $refund) {
   return $success;
 }
 
-function commerce_authnet_form_rules_ui_edit_element_alter(&$form, &$form_state) {
-  if (isset($form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value'])) {
-    $id = $form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value'];
-    $is_com = isset($form['parameter']['commerce_order']) ? 1 : 0;
-    if ($id == 'authnet_aim' && $is_com) {
-      $rule = rules_config_load(arg(5));  //@TODO: is there a better way to get the rule name?
-      $actions = $rule->actions();
-      if (!empty($actions)) {
-        // Find the settings for the Authorize.net gateway action.
-        foreach ($actions as $action) {
-          if($action->settings['payment_method']['method_id'] == 'authnet_aim' && $action->elementId() == arg(7)) {  //@TODO: is there a better way to get the action ID?
-           $settings[] = $action->settings;
-          }
-        }
-        $config = isset($settings[0]['payment_method']['settings']) ? $settings[0]['payment_method']['settings'] : '';
-        
-        // Add a fieldset of Authorize.net request fields available to have Webform field data mapped to them.
-        $form['parameter']['payment_method']['settings']['payment_method']['settings']['value_map'] = array(
-            '#type' => 'fieldset',
-            '#title' => t('Submission mapping'),
-            '#description' => t('Enter the webform field keys to map to these authorize.net fields.'),
-            '#tree' => TRUE,
-        );
-        $available_fields = _commerce_authnet_extra_fields();
-        unset($available_fields[0]);
-        $i = 1;
-        foreach ($available_fields as $field) {
-          $form['parameter']['payment_method']['settings']['payment_method']['settings']['commerce_authnet_webform_field_' . $i] = array(
-            '#title' => t('Enter webform field #%i', array('%i' => $i)),
-            '#type' => 'textfield',
-            '#description' => t('Example: field_name'),
-            '#default_value' => !empty($config['commerce_authnet_webform_field_' . $i]) ? $config['commerce_authnet_webform_field_' . $i] : '',
-          );
+function commerce_authnet_form_rules_ui_edit_element_builder(&$form, &$form_state) {
 
-          $form['parameter']['payment_method']['settings']['payment_method']['settings']['commerce_authnet_authorize_field_' . $i] = array(
-            '#title' => t('Authorize field #%i', array('%i' => $i)),
-            '#type' => 'select',
-            '#options' => _commerce_authnet_extra_fields(),
-            '#default_value' => !empty($config['commerce_authnet_authorize_field_' . $i]) ? $config['commerce_authnet_authorize_field_' . $i] : '',
-          );
-          $i++;
-        }
-        
-        // Add a fieldset of Authorize.net response fields available to be mapped to donation fields.
-        $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields'] = array(
-          '#type' => 'fieldset',
-          '#title' => t('Response Fields for Mapping'),
-          '#description' => t('The selected fields will be made available for mapping to exported donations.'),
-          '#collapsible' => TRUE,
-          '#collapsed' => FALSE,
-          '#element_validate' => array('fundraiser_commerce_response_fields_validate'),
-        );
-        $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['mappable'] = array(
-          '#type' => 'value',
-          '#value' => array(),
-        );
-        $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'] = array(
-          '#theme' => 'table',
-          '#header' => array(
-            'checkbox' => t('Available'),
-            'description' => t('Authorize.net gateway response field')
-          ),
-          '#rows' => array(),
-        );
-        foreach (_commerce_authnet_response_fields() as $machine_name => $field) {
-          $id = 'mappable_fields-' . $machine_name;
-          $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'][$machine_name] = array(
-            '#id' => $id,
-            '#type' => 'checkbox',
-            '#default_value' => in_array($machine_name, !empty($config['response_fields']['mappable']) ? $config['response_fields']['mappable'] : array()),
-          );
-          $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all']['#rows'][$machine_name] = array(
-            'checkbox' => array(
-              // Tricky but it works: The table element's children (the checkboxes) will all have rendered as 
-              // form components by the time the table theme function picks them up by reference here.
-              'data' => &$form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'][$machine_name],
-            ),
-            'description' => '<label for="' . $id . '">' . $field['name'] . '</label><span>' . t($field['description']) . '</span>',
-          );
-        }
+  $rule = rules_config_load(arg(5));
+  // @TODO: is there a better way to get the rule name?
+  $actions = !empty($rule) ? $rule->actions() : FALSE;
+  if (!empty($actions)) {
+    // Find the settings for the Authorize.net gateway action.
+    foreach ($actions as $action) {
+      if (isset($action->settings['payment_method']['method_id']) &&  $action->settings['payment_method']['method_id'] == 'authnet_aim' && $action->elementId() == arg(7)) {
+        // @TODO: is there a better way to get the action ID?
+        $settings[] = $action->settings;
       }
     }
+    $config = isset($settings[0]['payment_method']['settings']) ? $settings[0]['payment_method']['settings'] : '';
+
+    // Add a fieldset of Authorize.net request fields
+    // available to have Webform field data mapped to them.
+    $form['parameter']['payment_method']['settings']['payment_method']['settings']['value_map'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Submission mapping'),
+      '#description' => t('Enter the webform field keys to map to these authorize.net fields.'),
+      '#tree' => TRUE,
+    );
+    $available_fields = _commerce_authnet_extra_fields();
+    unset($available_fields[0]);
+    $i = 1;
+    foreach ($available_fields as $field) {
+      $form['parameter']['payment_method']['settings']['payment_method']['settings']['commerce_authnet_webform_field_' . $i] = array(
+        '#title' => t('Enter webform field #%i', array('%i' => $i)),
+        '#type' => 'textfield',
+        '#description' => t('Example: field_name'),
+        '#default_value' => !empty($config['commerce_authnet_webform_field_' . $i]) ? $config['commerce_authnet_webform_field_' . $i] : '',
+      );
+
+      $form['parameter']['payment_method']['settings']['payment_method']['settings']['commerce_authnet_authorize_field_' . $i] = array(
+        '#title' => t('Authorize field #%i', array('%i' => $i)),
+        '#type' => 'select',
+        '#options' => _commerce_authnet_extra_fields(),
+        '#default_value' => !empty($config['commerce_authnet_authorize_field_' . $i]) ? $config['commerce_authnet_authorize_field_' . $i] : '',
+      );
+      $i++;
+    }
+
+    // Add a fieldset of Authorize.net response
+    // fields available to be mapped to donation fields.
+    $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Response Fields for Mapping'),
+      '#description' => t('The selected fields will be made available for mapping to exported donations.'),
+      '#collapsible' => TRUE,
+      '#collapsed' => FALSE,
+      '#element_validate' => array('fundraiser_commerce_response_fields_validate'),
+    );
+    $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['mappable'] = array(
+      '#type' => 'value',
+      '#value' => array(),
+    );
+    $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'] = array(
+      '#theme' => 'table',
+      '#header' => array(
+        'checkbox' => t('Available'),
+        'description' => t('Authorize.net gateway response field'),
+      ),
+      '#rows' => array(),
+    );
+    foreach (_commerce_authnet_response_fields() as $machine_name => $field) {
+      $id = 'mappable_fields-' . $machine_name;
+      $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'][$machine_name] = array(
+        '#id' => $id,
+        '#type' => 'checkbox',
+        '#default_value' => in_array($machine_name, !empty($config['response_fields']['mappable']) ? $config['response_fields']['mappable'] : array()),
+      );
+      $form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all']['#rows'][$machine_name] = array(
+        'checkbox' => array(
+          // Tricky but it works: The table element's children
+          // (the checkboxes) will all have rendered as
+          // form components by the time the table theme function picks
+          // them up by reference here.
+          'data' => &$form['parameter']['payment_method']['settings']['payment_method']['settings']['response_fields']['all'][$machine_name],
+        ),
+        'description' => '<label for="' . $id . '">' . $field['name'] . '</label><span>' . t($field['description']) . '</span>',
+      );
+    }
   }
+
 }
 
 function fundraiser_commerce_commerce_authnet_aim_request_alter(&$nvp) {

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_paypal_wps.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_paypal_wps.inc
@@ -187,7 +187,7 @@ function commerce_paypal_wps_fundraiser_commerce_refund($payment_method, $refund
  *  Implements hook_form_alter().
  *
  */
-function commerce_paypal_wps_form_rules_ui_edit_element_builder(&$form, &$form_state, $method) {
+function commerce_paypal_wps_form_rules_ui_edit_element_builder(&$form, &$form_state) {
   // Adds needed refund field elements to PayPal settings form.
   $rule = rules_config_load(arg(5));
   // @ToDo: is there a better way to get the rule name?

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_paypal_wps.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_paypal_wps.inc
@@ -183,19 +183,39 @@ function commerce_paypal_wps_fundraiser_commerce_refund($payment_method, $refund
   }
 }
 
-/*
- *  Implements hook_form_alter().
+/**
+ * Alter the action form settings field.
  *
+ * Called from fundraiser_commerce_form_rules_ui_edit_element_alter().
+ *
+ * @param $form
+ * @param $form_state
  */
 function commerce_paypal_wps_form_rules_ui_edit_element_builder(&$form, &$form_state) {
   // Adds needed refund field elements to PayPal settings form.
-  $rule = rules_config_load(arg(5));
+  if (arg(4) == 'reaction' && arg(5) == 'manage') {
+    // We're in the rules UI.
+    $rule = rules_config_load(arg(6));
+  }
+  elseif (arg(3) == 'payment-methods' && arg(4) == 'manage') {
+    // We're in the commerce payment method UI.
+    $rule = rules_config_load(arg(5));
+  }
+
   // @ToDo: is there a better way to get the rule name?
   $actions = !empty($rule) ? $rule->actions() : FALSE;
   if (!empty($actions)) {
     // Find the settings for the Authorize.net gateway action.
     foreach ($actions as $action) {
-      if (isset($action->settings['payment_method']['method_id']) && $action->settings['payment_method']['method_id'] == 'paypal_wps' && $action->elementId() == arg(7)) {
+      if (arg(7) == 'edit') {
+        // We're in the rules UI.
+        $action_id = arg(8);
+      }
+      else {
+        // We're in the commerce payment method UI.
+        $action_id = arg(7);
+      }
+      if (isset($action->settings['payment_method']['method_id']) && $action->settings['payment_method']['method_id'] == 'paypal_wps' && $action->elementId() == $action_id) {
         // @TODO: is there a better way to get the action ID?
         $settings[] = $action->settings;
       }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_paypal_wps.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_paypal_wps.inc
@@ -196,67 +196,76 @@ function commerce_paypal_wps_fundraiser_commerce_refund($payment_method, $refund
  * @param $form_state
  */
 function commerce_paypal_wps_form_rules_ui_edit_element_builder(&$form, &$form_state) {
-
-  // Check if we're in the commerce_ui or rules UI admin pages.
-  if (arg(4) == 'reaction' && arg(5) == 'manage') {
-    // We're in the rules UI.
-    $rule = rules_config_load(arg(6));
-  }
-  elseif (arg(3) == 'payment-methods' && arg(4) == 'manage') {
-    // We're in the commerce payment method UI.
-    $rule = rules_config_load(arg(5));
-  }
-
-  // @ToDo: is there a better way to get the rule name?
-  $actions = !empty($rule) ? $rule->actions() : FALSE;
-  if (!empty($actions)) {
-    // Find the settings for the Authorize.net gateway action.
-    foreach ($actions as $action) {
-      if (arg(7) == 'edit') {
+  // Adds needed refund field elements to PayPal settings form.
+  // The following two "if" checks are probably not needed, but retained for
+  // readability purposes.
+  if (isset($form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value'])) {
+    $id = $form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value'];
+    $is_com = isset($form['parameter']['commerce_order']) ? 1 : 0;
+    if ($id == 'paypal_wps' && $is_com) {
+      // Check if we're in the commerce_ui or rules UI admin pages.
+      if (arg(4) == 'reaction' && arg(5) == 'manage') {
         // We're in the rules UI.
-        $action_id = arg(8);
+        $rule = rules_config_load(arg(6));
       }
-      else {
+      elseif (arg(3) == 'payment-methods' && arg(4) == 'manage') {
         // We're in the commerce payment method UI.
-        $action_id = arg(7);
+        $rule = rules_config_load(arg(5));
       }
-      if (isset($action->settings['payment_method']['method_id']) && $action->settings['payment_method']['method_id'] == 'paypal_wps' && $action->elementId() == $action_id) {
-        // @TODO: is there a better way to get the action ID?
-        $settings[] = $action->settings;
+
+      // @ToDo: is there a better way to get the rule name?
+      $actions = !empty($rule) ? $rule->actions() : FALSE;
+      if (!empty($actions)) {
+        // Find the settings for the Authorize.net gateway action.
+        foreach ($actions as $action) {
+          if (arg(7) == 'edit') {
+            // We're in the rules UI.
+            $action_id = arg(8);
+          }
+          else {
+            // We're in the commerce payment method UI.
+            $action_id = arg(7);
+          }
+          if (isset($action->settings['payment_method']['method_id']) && $action->settings['payment_method']['method_id'] == 'paypal_wps' && $action->elementId() == $action_id) {
+            // @TODO: is there a better way to get the action ID?
+            $settings[] = $action->settings;
+          }
+        }
+        $config = isset($settings[0]['payment_method']['settings']) ? $settings[0]['payment_method']['settings'] : '';
+
+        $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_username'] = array(
+          '#type' => 'textfield',
+          '#title' => t('API username'),
+          '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
+          '#default_value' => !empty($config['api_username']) ? $config['api_username'] : '',
+        );
+        $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_password'] = array(
+          '#type' => 'textfield',
+          '#title' => t('API password'),
+          '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
+          '#default_value' => !empty($config['api_password']) ? $config['api_password'] : '',
+        );
+        $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_signature'] = array(
+          '#type' => 'textfield',
+          '#title' => t('Signature'),
+          '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
+          '#default_value' => !empty($config['api_signature']) ? $config['api_signature'] : '',
+        );
+        $form['parameter']['payment_method']['settings']['payment_method']['settings']['log'] = array(
+          '#type' => 'checkboxes',
+          '#title' => t('Log the following messages for debugging'),
+          '#options' => array(
+            'request' => t('API request messages'),
+            'response' => t('API response messages'),
+          ),
+          '#default_value' => isset($config['log']) ? $config['log'] : array(
+            'request' => '0',
+            'response' => '0'
+          ),
+        );
       }
     }
-    $config = isset($settings[0]['payment_method']['settings']) ? $settings[0]['payment_method']['settings'] : '';
-
-    $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_username'] = array(
-      '#type' => 'textfield',
-      '#title' => t('API username'),
-      '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
-      '#default_value' => !empty($config['api_username']) ? $config['api_username'] : '',
-    );
-    $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_password'] = array(
-      '#type' => 'textfield',
-      '#title' => t('API password'),
-      '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
-      '#default_value' => !empty($config['api_password']) ? $config['api_password'] : '',
-    );
-    $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_signature'] = array(
-      '#type' => 'textfield',
-      '#title' => t('Signature'),
-      '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
-      '#default_value' => !empty($config['api_signature']) ? $config['api_signature'] : '',
-    );
-    $form['parameter']['payment_method']['settings']['payment_method']['settings']['log'] = array(
-      '#type' => 'checkboxes',
-      '#title' => t('Log the following messages for debugging'),
-      '#options' => array(
-        'request' => t('API request messages'),
-        'response' => t('API response messages'),
-      ),
-      '#default_value' => isset($config['log']) ? $config['log'] : array('request' => '0', 'response' => '0'),
-    );
   }
-
-  return $form;
 }
 
 /**
@@ -271,7 +280,7 @@ function commerce_paypal_wps_form_rules_ui_edit_element_builder(&$form, &$form_s
 function commerce_paypal_form__fundraiser_refund_form_alter(&$form, $form_state, $form_id) {
   $donation_id = arg(3);
   if (!is_numeric($donation_id)) {
-    return;  
+    return;
   }
   $donation = fundraiser_donation_get_donation($donation_id);
   if (!isset($donation->refunds) || empty($donation->refunds)) {
@@ -289,5 +298,5 @@ function commerce_paypal_form__fundraiser_refund_form_alter(&$form, $form_state,
       );
       break;
     }
-  } 
+  }
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_paypal_wps.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_paypal_wps.inc
@@ -187,53 +187,51 @@ function commerce_paypal_wps_fundraiser_commerce_refund($payment_method, $refund
  *  Implements hook_form_alter().
  *
  */
-function commerce_paypal_wps_form_rules_ui_edit_element_alter(&$form, &$form_state) {
+function commerce_paypal_wps_form_rules_ui_edit_element_builder(&$form, &$form_state, $method) {
   // Adds needed refund field elements to PayPal settings form.
-  if (isset($form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value'])) {
-    $id = $form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value'];
-    $is_com = isset($form['parameter']['commerce_order']) ? 1 : 0;
-    if ($id == 'paypal_wps' && $is_com) {
-      $rule = rules_config_load(arg(5));  //@TODO: is there a better way to get the rule name?
-      $actions = $rule->actions();
-      if (!empty($actions)) {
-        // Find the settings for the Authorize.net gateway action.
-        foreach ($actions as $action) {
-          if($action->settings['payment_method']['method_id'] == 'paypal_wps' && $action->elementId() == arg(7)) {  //@TODO: is there a better way to get the action ID?
-            $settings[] = $action->settings;
-          }
-        }
-        $config = isset($settings[0]['payment_method']['settings']) ? $settings[0]['payment_method']['settings'] : '';
-
-        $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_username'] = array(
-          '#type' => 'textfield',
-          '#title' => t('API username'),
-          '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
-          '#default_value' => !empty($config['api_username']) ? $config['api_username'] : '',
-        );
-        $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_password'] = array(
-          '#type' => 'textfield',
-          '#title' => t('API password'),
-          '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
-          '#default_value' => !empty($config['api_password']) ? $config['api_password'] : '',
-        );
-        $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_signature'] = array(
-          '#type' => 'textfield',
-          '#title' => t('Signature'),
-          '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
-          '#default_value' => !empty($config['api_signature']) ? $config['api_signature'] : '',
-        );
-        $form['parameter']['payment_method']['settings']['payment_method']['settings']['log'] = array(
-          '#type' => 'checkboxes',
-          '#title' => t('Log the following messages for debugging'),
-          '#options' => array(
-            'request' => t('API request messages'),
-            'response' => t('API response messages'),
-          ),
-          '#default_value' => isset($config['log']) ? $config['log'] : array('request' => '0', 'response' => '0'),
-        );
+  $rule = rules_config_load(arg(5));
+  // @ToDo: is there a better way to get the rule name?
+  $actions = !empty($rule) ? $rule->actions() : FALSE;
+  if (!empty($actions)) {
+    // Find the settings for the Authorize.net gateway action.
+    foreach ($actions as $action) {
+      if (isset($action->settings['payment_method']['method_id']) && $action->settings['payment_method']['method_id'] == 'paypal_wps' && $action->elementId() == arg(7)) {
+        // @TODO: is there a better way to get the action ID?
+        $settings[] = $action->settings;
       }
     }
+    $config = isset($settings[0]['payment_method']['settings']) ? $settings[0]['payment_method']['settings'] : '';
+
+    $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_username'] = array(
+      '#type' => 'textfield',
+      '#title' => t('API username'),
+      '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
+      '#default_value' => !empty($config['api_username']) ? $config['api_username'] : '',
+    );
+    $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_password'] = array(
+      '#type' => 'textfield',
+      '#title' => t('API password'),
+      '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
+      '#default_value' => !empty($config['api_password']) ? $config['api_password'] : '',
+    );
+    $form['parameter']['payment_method']['settings']['payment_method']['settings']['api_signature'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Signature'),
+      '#description' => t('These credentials are only needed for initiating PayPal WPS refunds through Springboard.'),
+      '#default_value' => !empty($config['api_signature']) ? $config['api_signature'] : '',
+    );
+    $form['parameter']['payment_method']['settings']['payment_method']['settings']['log'] = array(
+      '#type' => 'checkboxes',
+      '#title' => t('Log the following messages for debugging'),
+      '#options' => array(
+        'request' => t('API request messages'),
+        'response' => t('API response messages'),
+      ),
+      '#default_value' => isset($config['log']) ? $config['log'] : array('request' => '0', 'response' => '0'),
+    );
   }
+
+  return $form;
 }
 
 /**

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_paypal_wps.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_paypal_wps.inc
@@ -186,13 +186,18 @@ function commerce_paypal_wps_fundraiser_commerce_refund($payment_method, $refund
 /**
  * Alter the action form settings field.
  *
- * Called from fundraiser_commerce_form_rules_ui_edit_element_alter().
+ * This function was formerly an implemention of
+ * hook_form_rules_ui_edit_element_alter() but behaved inconsistently here
+ * in the gateway.inc file. Now it is renamed and called dynamically from
+ * fundraiser_commerce_form_rules_ui_edit_element_alter() using
+ * form_load_include().
  *
  * @param $form
  * @param $form_state
  */
 function commerce_paypal_wps_form_rules_ui_edit_element_builder(&$form, &$form_state) {
-  // Adds needed refund field elements to PayPal settings form.
+
+  // Check if we're in the commerce_ui or rules UI admin pages.
   if (arg(4) == 'reaction' && arg(5) == 'manage') {
     // We're in the rules UI.
     $rule = rules_config_load(arg(6));


### PR DESCRIPTION
hook_form_rules_ui_edit_element_alter() will not work consistently when implemented in the fundraiser gateway include files. This patch renames the implementations in authnet.inc and paypal_wps.inc and calls them dynamically from fundraiser_commerce_form_rules_ui_edit_element_alter() instead, which is properly situation in a .module file.

It also fixes a fatal error that occurs when trying to access the payment method rule reaction settings from Rules UI menu paths instead of commerce payments UI menu paths.

The diff looks larger than it really is because of line indentation changes from the removal of two unecessary control structures wrapping the rest of the code in the hooks.

The following control structures were removed from the top of the hook implementations:

// This test is duplicate of code in Fundraiser_commerce_form_rules_ui_edit_element_alter
if (isset($form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value'])) {
    $id = $form['parameter']['payment_method']['settings']['payment_method']['method_id']['#value'];

   // This test appears to be unecessary.
    $is_com = isset($form['parameter']['commerce_order']) ? 1 : 0;
    if ($id == 'authnet_aim' && $is_com)  {
