### PR TITLE
undo a regression in sustainer upgrade default text

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/fundraiser_sustainers_upgrade.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/fundraiser_sustainers_upgrade.module
@@ -1194,7 +1194,7 @@ function fundraiser_sustainers_upgrade_cancel_redirect() {
   $redirect_url = isset($_GET['su_redirect']) ? $_GET['su_redirect'] : '';
   $redirect_url = trim($redirect_url);
   $redirect_url = preg_replace('/^' . preg_quote($GLOBALS['base_url'], '/') . '\//', '', $redirect_url);
-  $redirect = array();
+  $redirect = NULL;
   $options = array();
   if (valid_url($redirect_url, TRUE)) {
     $redirect = $redirect_url;

--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/includes/install/fundraiser_sustainers_upgrade.install_example.inc
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/includes/install/fundraiser_sustainers_upgrade.install_example.inc
@@ -17,9 +17,9 @@ function _fundraiser_sustainers_upgrade_add_example() {
   $node->title = 'Default Sustainers Upgrade Form';
   $node->status = 1;
   $node->promote = 0;
-  $node->body[LANGUAGE_NONE][0]['value'] = 'Thank you [donation:first_name] [donation:last_name] [sustainer_upgrade:signout] for upgrading your monthly donation to [sustainer_upgrade:upgrade_amount_formatted].
+  $node->body[LANGUAGE_NONE][0]['value'] = 'Thank you [donation:first_name] [donation:last_name]. [sustainer_upgrade:signout] To upgrade your monthly donation to [sustainer_upgrade:upgrade_amount_formatted], click Confirm below.
 
-  Your original donation for [donation:currency:code][donation:amount], was made on [donation:order:created:] with your card ending in [donation:card_number]. You have [sustainer_upgrade:charges_remaining] charges remaining in this series, which will be upgraded to [sustainer_upgrade:upgrade_amount_formatted].';
+  Your original donation for [donation:currency:symbol][donation:amount], was made on [donation:order:created] with your card ending in [donation:card_number]. You have [sustainer_upgrade:charges_remaining] charges remaining in this series, which will be upgraded to [sustainer_upgrade:upgrade_amount_formatted].';
   $node->body[LANGUAGE_NONE][0]['format'] = 'filtered_html';
   $node->field_sustainers_upgrade_name[LANGUAGE_NONE][0]['value'] = "Default Sustainers Upgrade Form";
   $node->field_sustainers_upgrade_fail[LANGUAGE_NONE][0]['value'] = "Donation upgrade can not be completed.";

--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/includes/install/fundraiser_sustainers_upgrade.install_fields.inc
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/includes/install/fundraiser_sustainers_upgrade.install_fields.inc
@@ -582,7 +582,11 @@ function _fundraiser_sustainers_upgrade_cancel_field(&$fields) {
 
     '_instance' => array(
       'bundle' => 'sustainers_upgrade_form',
-      'default_value' => NULL,
+      'default_value' => array(
+        0 => array(
+          'value' => variable_get('site_frontpage', 'node'),
+        ),
+      ),
       'deleted' => '0',
       'description' => 'The page to redirect to if the user clicks the "I\'m not" link; e.g, node/4',
       'display' => array(


### PR DESCRIPTION
Merge conflict resolution accidentally regressed some default text.

Also, this fixes some php notices that were occurring during acceptance tests due to the redirect url having no default value.