### PR TITLE
994: Implementing GA tracking for PayPal transaction events.

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -2309,29 +2309,30 @@ function fundraiser_commerce_commerce_paypal_ipn_process($order, $payment_method
   if ($ipn['payment_status'] == 'Pending') {
     return;
   }
-  if ($ipn['payment_status'] == 'Completed') {
-    // Grab the donation object from the order.
-    $donation = fundraiser_donation_get_donation($order->order_id);
-    // Update the donation and order data and result values based on the success.
-    _fundraiser_commerce_update_donation_result_data($donation, TRUE);
-    // Finish up any last cleanup for this transaction.
-    fundraiser_commerce_fundraiser_donation_after_process($donation);
-    // Save the donation
-    fundraiser_donation_update($donation);
-    // Finish up the submission to kick off success / decline triggers.
-    _fundraiser_donation_submit_after_process($donation);
-  }
-  if ($ipn['payment_status'] == 'Refunded') {
-    // commerce_paypal_wps handles the Commerce refund transactions. This is here to record the fundrasier_refund item
-    // when the refund is initiated from the PayPal dashboard.
-    $donation = fundraiser_donation_get_donation($order->order_id);
-    _fundraiser_commerce_ipn_refund($donation, $payment_method, $ipn);
+  if (!empty($order) && !empty($payment_method) && !empty($ipn)) {
+    if ($ipn['payment_status'] == 'Completed' && !empty($order)) {
+      // Grab the donation object from the order.
+      $donation = fundraiser_donation_get_donation($order->order_id);
+      // Update the donation and order data and result values based on the success.
+      _fundraiser_commerce_update_donation_result_data($donation, TRUE);
+      // Finish up any last cleanup for this transaction.
+      fundraiser_commerce_fundraiser_donation_after_process($donation);
+      // Save the donation
+      fundraiser_donation_update($donation);
+      // Finish up the submission to kick off success / decline triggers.
+      _fundraiser_donation_submit_after_process($donation);
+    }
+    elseif ($ipn['payment_status'] == 'Refunded') {
+      // commerce_paypal_wps handles the Commerce refund transactions. This is here to record the fundrasier_refund item
+      // when the refund is initiated from the PayPal dashboard.
+      $donation = fundraiser_donation_get_donation($order->order_id);
+      _fundraiser_commerce_ipn_refund($donation, $payment_method, $ipn);
 
-  }
-  if ($ipn['payment_status'] == 'Reversed') {
-    $donation = fundraiser_donation_get_donation($order->order_id);
-    _fundraiser_commerce_ipn_reverse($donation, $ipn);
-
+    }
+    elseif ($ipn['payment_status'] == 'Reversed') {
+      $donation = fundraiser_donation_get_donation($order->order_id);
+      _fundraiser_commerce_ipn_reverse($donation, $ipn);
+    }
   }
 }
 

--- a/fundraiser/modules/fundraiser_tickets/components/tickets.inc
+++ b/fundraiser/modules/fundraiser_tickets/components/tickets.inc
@@ -157,23 +157,25 @@ function _fundraiser_tickets_validate_webform_field($element, &$form_state) {
     unset($ticket_values['fundraiser-tickets-extra-donation']);
   }
 
-  // Grab the selected values and verify we have at least one
-  $selected = array_filter($ticket_values);
-  if (empty($selected)) {
-    form_error($element, 'Please select at least one ticket type.');
-  }
+  if (!empty($ticket_values)) {
+    // Grab the selected values and verify we have at least one
+    $selected = array_filter($ticket_values);
+    if (empty($selected)) {
+      form_error($element, 'Please select at least one ticket type.');
+    }
 
-  // Verify we still have enough tickets to fulfill the order
-  foreach ($selected as $key => $quantity) {
-    $product_id = _fundraiser_tickets_get_product_id_from_form_element_name($key);
+    // Verify we still have enough tickets to fulfill the order
+    foreach ($selected as $key => $quantity) {
+      $product_id = _fundraiser_tickets_get_product_id_from_form_element_name($key);
 
-    if ($product_id && $quantity > 0) {
-      $product_wrapper = entity_metadata_wrapper('commerce_product', commerce_product_load($product_id));
+      if ($product_id && $quantity > 0) {
+        $product_wrapper = entity_metadata_wrapper('commerce_product', commerce_product_load($product_id));
 
-      // Compute the available tickets
-      $available_tickets = $product_wrapper->fr_tickets_quantity->value() - $product_wrapper->fr_tickets_quantity_sold->value();
-      if ($quantity > $available_tickets) {
-        form_error($element, t('Your order could not be completed because only @quantity @type tickets remain.', array('@quantity' => $available_tickets, '@type' => $product_wrapper->title->value())));
+        // Compute the available tickets
+        $available_tickets = $product_wrapper->fr_tickets_quantity->value() - $product_wrapper->fr_tickets_quantity_sold->value();
+        if ($quantity > $available_tickets) {
+          form_error($element, t('Your order could not be completed because only @quantity @type tickets remain.', array('@quantity' => $available_tickets, '@type' => $product_wrapper->title->value())));
+        }
       }
     }
   }
@@ -187,7 +189,7 @@ function _fundraiser_tickets_sanitize_webform_field($element, &$form_state) {
   $ticket_values = drupal_array_get_nested_value($form_state['values'], $element['#parents']);
   $extra_donation_key = 'fundraiser-tickets-extra-donation';
 
-  if (!array_key_exists($extra_donation_key, $ticket_values)) {
+  if (!empty($ticket_values) && !array_key_exists($extra_donation_key, $ticket_values)) {
     return;
   }
 

--- a/springboard_measurement_protocol/README.txt
+++ b/springboard_measurement_protocol/README.txt
@@ -1,0 +1,10 @@
+This module provides functionality for sending analytics to Google's Measurement
+Protocol service. Current events supported are:
+
+- PayPal transactions (payments):
+  Requires the googleanalytics and commerce_paypal modules.
+
+In future, this module would preferrably also act as a bridging module between
+your custom module and the Measurement Protocol service, by allowing you to
+construct a payload and handling the transmission of the payload to Measurement
+Protocol.

--- a/springboard_measurement_protocol/includes/springboard_measurement_protocol.admin.inc
+++ b/springboard_measurement_protocol/includes/springboard_measurement_protocol.admin.inc
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Admin file for the Springboard Measurement Protocol module.
+ */
+
+/**
+ * Page callback for admin settings.
+ */
+function springboard_measurement_protocol_admin() {
+  if (module_exists('googleanalytics')) {
+    $form['paypal_events'] = array(
+      '#type' => 'fieldset',
+      '#collapsible' => TRUE,
+      '#collapsed' => FALSE,
+      '#title' => t('PayPal Events'),
+    );
+    $form['paypal_events']['springboard_measurement_protocol_paypal_enable'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Send events for PayPal transactions'),
+      '#description' => t("Send analytics to Google's Measurement Protocol service when a PayPal transaction occurs."),
+      '#default_value' => variable_get('springboard_measurement_protocol_paypal_enable', FALSE),
+    );
+  }
+
+  return system_settings_form($form);
+}

--- a/springboard_measurement_protocol/includes/springboard_measurement_protocol.admin.inc
+++ b/springboard_measurement_protocol/includes/springboard_measurement_protocol.admin.inc
@@ -9,6 +9,7 @@
  * Page callback for admin settings.
  */
 function springboard_measurement_protocol_admin() {
+  $form = array();
   $form['general_settings'] = array(
     '#type' => 'fieldset',
     '#collapsible' => TRUE,

--- a/springboard_measurement_protocol/includes/springboard_measurement_protocol.admin.inc
+++ b/springboard_measurement_protocol/includes/springboard_measurement_protocol.admin.inc
@@ -9,20 +9,42 @@
  * Page callback for admin settings.
  */
 function springboard_measurement_protocol_admin() {
-  if (module_exists('googleanalytics')) {
-    $form['paypal_events'] = array(
-      '#type' => 'fieldset',
-      '#collapsible' => TRUE,
-      '#collapsed' => FALSE,
-      '#title' => t('PayPal Events'),
-    );
-    $form['paypal_events']['springboard_measurement_protocol_paypal_enable'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Send events for PayPal transactions'),
-      '#description' => t("Send analytics to Google's Measurement Protocol service when a PayPal transaction occurs."),
-      '#default_value' => variable_get('springboard_measurement_protocol_paypal_enable', FALSE),
-    );
-  }
+  $form['general_settings'] = array(
+    '#type' => 'fieldset',
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+    '#title' => t('General Settings'),
+  );
+  $form['general_settings']['springboard_measurement_protocol_ga_account'] = array(
+    '#title' => t('Web Property ID'),
+    '#type' => 'textfield',
+    '#default_value' => variable_get('springboard_measurement_protocol_ga_account', 'UA-'),
+    '#size' => 15,
+    '#maxlength' => 20,
+    '#required' => TRUE,
+    '#description' => t('This ID is unique to each site you want to track separately, and is in the form of UA-xxxxxxx-yy. To get a Web Property ID, <a href="@analytics">register your site with Google Analytics</a>, or if you already have registered your site, go to your Google Analytics Settings page to see the ID next to every site profile. <a href="@webpropertyid">Find more information in the documentation</a>.', array(
+      '@analytics' => 'http://www.google.com/analytics/',
+      '@webpropertyid' => url('https://developers.google.com/analytics/resources/concepts/gaConceptsAccounts', array('fragment' => 'webProperty')),
+    )),
+  );
+  $form['general_settings']['springboard_measurement_protocol_debug'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Log details in watchdog about requests made to the Measurement Protocol service'),
+    '#description' => t('Enable if you are debugging.'),
+    '#default_value' => variable_get('springboard_measurement_protocol_debug', FALSE),
+  );
+  $form['paypal_events'] = array(
+    '#type' => 'fieldset',
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+    '#title' => t('PayPal Events'),
+  );
+  $form['paypal_events']['springboard_measurement_protocol_paypal_enable'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Send events for PayPal transactions'),
+    '#description' => t("Send analytics to Google's Measurement Protocol service when a PayPal transaction occurs."),
+    '#default_value' => variable_get('springboard_measurement_protocol_paypal_enable', FALSE),
+  );
 
   return system_settings_form($form);
 }

--- a/springboard_measurement_protocol/springboard_measurement_protocol.info
+++ b/springboard_measurement_protocol/springboard_measurement_protocol.info
@@ -1,0 +1,4 @@
+name = Springboard Measurement Protocol
+description = A module that acts as a bridge for sending analytic information to Google's Measurement Protocol.
+package = Jackson River Springboard - extras
+core = 7.x

--- a/springboard_measurement_protocol/springboard_measurement_protocol.install
+++ b/springboard_measurement_protocol/springboard_measurement_protocol.install
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @file
+ * Install file for springboard_measurement_protocol.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function springboard_measurement_protocol_install() {
+  // If the googleanalytics module is enabled, copy the GA tracking variable and
+  // set it as a variable for our module.
+  if (module_exists('googleanalytics')) {
+    variable_set('springboard_measurement_protocol_ga_account', variable_get('googleanalytics_account', 'UA-'));
+  }
+}

--- a/springboard_measurement_protocol/springboard_measurement_protocol.module
+++ b/springboard_measurement_protocol/springboard_measurement_protocol.module
@@ -101,21 +101,27 @@ function springboard_measurement_protocol_commerce_paypal_ipn_process($order, $p
       // Check each of the following to prevent php notices/warnings in the
       // watchdog. If any of the following aren't set, the hit will likely fail.
       if (isset($donation->nid)) {
+        // The product ID and transaction item code (SKU).
         $variables['pr1id'] = $variables['ic'] = $donation->nid;
       }
       if (isset($donation->node->title)) {
+        // The product and transaction item name.
         $variables['pr1nm'] = $variables['in'] = $donation->node->title;
       }
       if (isset($donation->donation['amount'])) {
+        // The product and transaction item price.
         $variables['pr1pr'] = $variables['ip'] = $donation->donation['amount'];
       }
       if (isset($donation->did)) {
+        // The transaction ID.
         $variables['ti'] = $donation->did;
       }
       if (isset($donation->donation['recurs_monthly'])) {
+        // The transaction item category.
         $variables['iv'] = ($donation->donation['recurs_monthly'] == 1) ? 'Monthly' : 'One-time';
       }
       if (isset($donation->donation['currency']['code'])) {
+        // The currency type.
         $variables['cu'] = $donation->donation['currency']['code'];
       }
 

--- a/springboard_measurement_protocol/springboard_measurement_protocol.module
+++ b/springboard_measurement_protocol/springboard_measurement_protocol.module
@@ -1,0 +1,157 @@
+<?php
+/**
+ * @file
+ * Module file for springboard_measurement_protocol.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function springboard_measurement_protocol_menu() {
+  $items['admin/config/system/springboard-measurement-protocol'] = array(
+    'title' => 'Springboard Measurement Protocol',
+    'description' => "Google's Measurement Protocol integration.",
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('springboard_measurement_protocol_admin'),
+    'access arguments' => array('administer springboard measurement_protocol'),
+    'file' => 'includes/springboard_measurement_protocol.admin.inc',
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_springboard_admin_menu_items_alter().
+ */
+function springboard_measurement_protocol_springboard_admin_admin_menu_items_alter(&$items) {
+  // Add a menu item for the admin page.
+  $items['admin/springboard/marketing-analytics']['_children']['admin/springboard/measurement-protocol'] = array(
+    'link_path' => 'admin/config/system/springboard-measurement-protocol',
+    'link_title' => t('Measurement Protocol'),
+    'menu_name' => 'springboard_admin_menu',
+    'expanded' => 1,
+    'customized' => 1,
+    'weight' => 20,
+  );
+}
+
+/**
+ * Implements hook_commerce_paypal_ipn_process().
+ */
+function springboard_measurement_protocol_commerce_paypal_ipn_process($order, $payment_method, $ipn) {
+  // The googleanalytics module needs to be enabled in order to use its UA
+  // variable.
+  if (module_exists('googleanalytics') && variable_get('springboard_measurement_protocol_paypal_enable', FALSE)) {
+    // @todo Support refund events.
+    if ($ipn['payment_status'] == 'Completed') {
+      // Load the donation object using the order id from $ipn.
+      $donation = fundraiser_donation_get_donation($ipn['order_id']);
+      // The Measurement Protocol API requires a client ID value in the form of
+      // a UUID (https://www.ietf.org/rfc/rfc4122.txt). If the UUID module is
+      // available, we'll just use that. Otherwise we will generate a UUID using
+      // code from a generator function from the UUID module.
+      $cid = NULL;
+      if (module_exists('uuid')) {
+        module_load_include('inc', 'uuid', 'uuid');
+        $cid = uuid_generate();
+      }
+      else {
+        // The following code comes from the UUID module and is available at
+        // http://cgit.drupalcode.org/uuid/tree/uuid.inc#n181.
+        $cid = sprintf('%04x%04x-%04x-4%03x-%04x-%04x%04x%04x',
+          // 32 bits for "time_low".
+          mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+          // 16 bits for "time_mid".
+          mt_rand(0, 0xffff),
+          // 12 bits after the initial 0100 (version 4) for
+          // "time_hi_and_version".
+          mt_rand(0, 0x0fff),
+          // 16 bits in total for "clk_seq_hi_res" and "clk_seq_low", with the
+          // most significant 2 bits of clk_seq_hi_res set to '10'. We do a
+          // bitwise OR of a random 14-bit value (maximum 0x3fff) with 0x8000
+          // (a 16-bit integer with only the most significant bit set).
+          mt_rand(0, 0x3fff) | 0x8000,
+          // 48 bits for "node".
+          mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
+        );
+      }
+
+      $variables = array(
+        // The Measurement Protocol version.
+        'v' => 1,
+        // The Tracking ID.
+        'tid' => variable_get('googleanalytics_account', ''),
+        // The client ID.
+        'cid' => $cid,
+        // The type of event.
+        't' => 'event',
+        // The event category.
+        'ec' => 'Transaction',
+        // The event action.
+        'ea' => 'purchase',
+        // The product action.
+        'pa' => 'purchase',
+        // The product ID.
+        'pr1id' => $donation->nid,
+        // The product name.
+        'pr1nm' => $donation->node->title,
+        // The product price.
+        'pr1pr' => $donation->donation['amount'],
+        // The product quantity.
+        'pr1qt' => 1,
+        // The transaction ID.
+        'ti' => $donation->did,
+        // The transaction revenue.
+        'tr' => $donation->donation['amount'],
+        // The transaction item code (SKU).
+        'ic' => $donation->nid,
+        // The transaction item name.
+        'in' => $donation->node->title,
+        // The transaction item quantity.
+        'iq' => 1,
+        // The transaction item price.
+        'ip' => $donation->donation['amount'],
+        // The transaction item category.
+        'iv' => ($donation->donation['recurs_monthly'] == 1) ? 'Monthly' : 'One-time',
+        // The currency type.
+        'cu' => $donation->donation['currency']['code'],
+      );
+
+      $variables = http_build_query($variables);
+      $host = 'https://www.google-analytics.com/collect';
+
+      if (module_exists('chr')) {
+        chr_curl_http_request($host, array(
+          'method' => 'POST',
+          'data' => $variables,
+          'verify_ssl' => TRUE,
+        ));
+      }
+      else {
+        // Setup the cURL request.
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $host);
+        curl_setopt($ch, CURLOPT_VERBOSE, 0);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $variables);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_NOPROGRESS, 1);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
+        curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+
+        $response = curl_exec($ch);
+
+        // If an error occurred during processing, log the message and exit.
+        if ($error = curl_error($ch)) {
+          watchdog('springboard_measurement_protocol', "Attempt to send data to Google's Measurement Protocol failed with cURL error: @error", array('@error' => $error), WATCHDOG_ERROR);
+          return FALSE;
+        }
+        curl_close($ch);
+      }
+
+      watchdog('springboard_measurement_protocol', 'Sent the following to GA Message Protocol: !message', array('!message' => $host . '/?' . $variables), WATCHDOG_NOTICE);
+    }
+  }
+}

--- a/springboard_measurement_protocol/springboard_measurement_protocol.module
+++ b/springboard_measurement_protocol/springboard_measurement_protocol.module
@@ -4,6 +4,16 @@
  * Module file for springboard_measurement_protocol.
  */
 
+// @codingStandardsIgnoreStart
+/**
+ * For older versions of PHP (< 5.5.19, < 5.6.3), we need to manually define
+ * this constant.
+ */
+if (!defined('CURL_SSLVERSION_TLSv1_2')) {
+  define('CURL_SSLVERSION_TLSv1_2', 6);
+}
+// @codingStandardsIgnoreEnd
+
 /**
  * Implements hook_menu().
  */

--- a/springboard_measurement_protocol/springboard_measurement_protocol.module
+++ b/springboard_measurement_protocol/springboard_measurement_protocol.module
@@ -40,9 +40,11 @@ function springboard_measurement_protocol_springboard_admin_admin_menu_items_alt
  * Implements hook_commerce_paypal_ipn_process().
  */
 function springboard_measurement_protocol_commerce_paypal_ipn_process($order, $payment_method, $ipn) {
-  // The googleanalytics module needs to be enabled in order to use its UA
-  // variable.
-  if (module_exists('googleanalytics') && variable_get('springboard_measurement_protocol_paypal_enable', FALSE)) {
+  if (variable_get('springboard_measurement_protocol_paypal_enable', FALSE)) {
+    if (variable_get('springboard_measurement_protocol_ga_account', 'UA-') == 'UA-') {
+      drupal_set_message(t('The Springboard Measurement Protocol module must be configured before PayPal IPN messages can be processed.'), 'warning');
+      return;
+    }
     // @todo Support refund events.
     if ($ipn['payment_status'] == 'Completed') {
       // Load the donation object using the order id from $ipn.
@@ -81,7 +83,7 @@ function springboard_measurement_protocol_commerce_paypal_ipn_process($order, $p
         // The Measurement Protocol version.
         'v' => 1,
         // The Tracking ID.
-        'tid' => variable_get('googleanalytics_account', ''),
+        'tid' => variable_get('springboard_measurement_protocol_ga_account', ''),
         // The client ID.
         'cid' => $cid,
         // The type of event.
@@ -92,31 +94,30 @@ function springboard_measurement_protocol_commerce_paypal_ipn_process($order, $p
         'ea' => 'purchase',
         // The product action.
         'pa' => 'purchase',
-        // The product ID.
-        'pr1id' => $donation->nid,
-        // The product name.
-        'pr1nm' => $donation->node->title,
-        // The product price.
-        'pr1pr' => $donation->donation['amount'],
-        // The product quantity.
-        'pr1qt' => 1,
-        // The transaction ID.
-        'ti' => $donation->did,
-        // The transaction revenue.
-        'tr' => $donation->donation['amount'],
-        // The transaction item code (SKU).
-        'ic' => $donation->nid,
-        // The transaction item name.
-        'in' => $donation->node->title,
         // The transaction item quantity.
         'iq' => 1,
-        // The transaction item price.
-        'ip' => $donation->donation['amount'],
-        // The transaction item category.
-        'iv' => ($donation->donation['recurs_monthly'] == 1) ? 'Monthly' : 'One-time',
-        // The currency type.
-        'cu' => $donation->donation['currency']['code'],
       );
+
+      // Check each of the following to prevent php notices/warnings in the
+      // watchdog. If any of the following aren't set, the hit will likely fail.
+      if (isset($donation->nid)) {
+        $variables['pr1id'] = $variables['ic'] = $donation->nid;
+      }
+      if (isset($donation->node->title)) {
+        $variables['pr1nm'] = $variables['in'] = $donation->node->title;
+      }
+      if (isset($donation->donation['amount'])) {
+        $variables['pr1pr'] = $variables['ip'] = $donation->donation['amount'];
+      }
+      if (isset($donation->did)) {
+        $variables['ti'] = $donation->did;
+      }
+      if (isset($donation->donation['recurs_monthly'])) {
+        $variables['iv'] = ($donation->donation['recurs_monthly'] == 1) ? 'Monthly' : 'One-time';
+      }
+      if (isset($donation->donation['currency']['code'])) {
+        $variables['cu'] = $donation->donation['currency']['code'];
+      }
 
       $variables = http_build_query($variables);
       $host = 'https://www.google-analytics.com/collect';
@@ -139,7 +140,7 @@ function springboard_measurement_protocol_commerce_paypal_ipn_process($order, $p
         curl_setopt($ch, CURLOPT_NOPROGRESS, 1);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
-        curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+        curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 
         $response = curl_exec($ch);
 
@@ -151,7 +152,14 @@ function springboard_measurement_protocol_commerce_paypal_ipn_process($order, $p
         curl_close($ch);
       }
 
-      watchdog('springboard_measurement_protocol', 'Sent the following to GA Message Protocol: !message', array('!message' => $host . '/?' . $variables), WATCHDOG_NOTICE);
+      if (variable_get('springboard_measurement_protocol_debug', FALSE)) {
+        watchdog('springboard_measurement_protocol', 'Sent the following to the GA Measurement Protocol service: %message<br /><br />To verify this was a valid hit, in your terminal execute the following command: !curl', array(
+          '%message' => $host . '?' . $variables,
+          '!curl' => '<pre>' . format_string('curl --http1.1 --data "@variables" "https://www.google-analytics.com/debug/collect"', array(
+            '@variables' => $variables,
+          )) . '</pre>',
+        ), WATCHDOG_NOTICE);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds a module, "springboard_measurement_protocol", which allows tracking PayPal events in GA by utilizing Google's Measurement Protocol service.

@pcave I had more work done, and I might commit it to another branch, but it involves abstracting some of the Measurement Protocol functionality into a different module and providing a class to construct and deliver a payload to the service. But I think this would be classified as "scope creep" so stopped and can work on it later if desired.