### PR TITLE
Do not create user accounts for submissions with empty $submission['mail']

### DIFF
--- a/webform_user/includes/webform_user.drush.inc
+++ b/webform_user/includes/webform_user.drush.inc
@@ -106,6 +106,13 @@ function webform_user_create_missing_users_batch_process($chunk, $node_id, $oper
 
   // Create users from the webform submissions.
   foreach ($submissions as $sid => $submission) {
+    // Skip this submission if mail is empty, otherwise we create a user account
+    // with a blank name, mail, and init field.
+    if (empty($submission['mail'])) {
+      drush_log(dt('Submission @sid missing $submission[\'mail\'], skipping user creation', array('@sid' => $sid)), 'warning');
+      continue;
+    }
+
     $account = user_load_by_mail($submission['mail']);
 
     // Remove empty string values from submission to avoid datatype exceptions.


### PR DESCRIPTION
See https://www.assembla.com/spaces/springboard/tickets/1092-webform_user_create_missing_users-drush-command-can-create-users-with-blank--quot-name-quot--value--throw-p---/details