### PR TITLE
Cs 288 7.x 4.x upsell auth only

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_sage_payments/commerce_sage_payments.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_sage_payments/commerce_sage_payments.module
@@ -367,7 +367,7 @@ function commerce_sage_payments_cc_vault_submit_form_submit($payment_method, $pa
  */
 function commerce_sage_payments_cc_vault_cardonfile_charge($payment_method, $card_data, $order, $charge = NULL) {
   $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
-  $txn_type = COMMERCE_CREDIT_AUTH_CAPTURE;
+  $txn_type = $payment_method['settings']['transaction_type'];
 
   // Format order total for transaction.
   if (!isset($charge)) {
@@ -448,7 +448,7 @@ function commerce_sage_payments_cc_vault_cardonfile_charge($payment_method, $car
   }
 
   // Store the type of transaction in the remote status.
-  $transaction->remote_status = COMMERCE_CREDIT_AUTH_CAPTURE;
+  $transaction->remote_status = $txn_type;
 
   // Store the remote id.
   $transaction->remote_id = !empty($transaction_response['REFERENCE']) ? $transaction_response['REFERENCE'] : '';
@@ -1131,7 +1131,12 @@ function _commerce_sage_payments_vault_request_sale($gateway, $request_parameter
   switch($gateway['method_id']) {
     case 'commerce_sage_payments_cc' :
       $sage_client = _commerce_sage_payments_get_sage_payments_vault_bankcard_client();
-      $type = 'VAULT_BANKCARD_SALE';
+      if ($gateway['settings']['transaction_type'] == COMMERCE_CREDIT_AUTH_ONLY) {
+        $type = 'VAULT_BANKCARD_AUTHONLY';
+      }
+      else {
+        $type = 'VAULT_BANKCARD_SALE';
+      }
       break;
     case 'commerce_sage_payments_eft' :
       $sage_client = _commerce_sage_payments_get_sage_payments_vault_virtual_check_client();

--- a/fundraiser/modules/fundraiser_upsell/fundraiser_upsell.api.php
+++ b/fundraiser/modules/fundraiser_upsell/fundraiser_upsell.api.php
@@ -99,3 +99,21 @@ function hook_upsell_master_donation_alter(&$master_donation) {
 function hook_fundraiser_upsell_create_recurring_success($donation) {
 
 }
+
+/**
+ * Prevent creation of donation series.
+ *
+ * If any module returns a value, upsell will NOT create a sustainer series.
+ *
+ * @param object $master_donation
+ *   Master donation, the result of the upsell.
+ * @param object $upsold_donation
+ *   Original donation that the upsell was generated from.
+ *
+ * @return string
+ *   Name of module implementing the hook, mainly for identifying which module
+ *   prevents the series creation.
+ */
+function hook_fundraiser_upsell_prevent_series($master_donation, $upsold_donation) {
+  return 'my_module';
+}

--- a/fundraiser/modules/fundraiser_upsell/fundraiser_upsell.module
+++ b/fundraiser/modules/fundraiser_upsell/fundraiser_upsell.module
@@ -652,7 +652,7 @@ function fundraiser_upsell_upsell_ajax_submit($did, $amount) {
   drupal_alter('upsold_donation', $upsold_donation);
 
   // Allow modules to prevent the creation of this series.
-  $prevent_series = fundraiser_upsell_prevent_series($master_donation, $upsold_donation);
+  $prevent_series = module_invoke_all('fundraiser_upsell_prevent_series', $master_donation, $upsold_donation);
   if ($prevent_series) {
     $success = TRUE;
   }
@@ -681,25 +681,6 @@ function fundraiser_upsell_upsell_ajax_submit($did, $amount) {
   }
 
   return $content;
-}
-
-/**
- * Find out if any modules want to prevent the creation of this series.
- *
- * @return array
- *   Names of modules preventing the series creation.
- */
-function fundraiser_upsell_prevent_series($master_donation, $upsold_donation) {
-  $result = array();
-
-  foreach(module_implements('fundraiser_upsell_prevent_series') as $module) {
-    $answer = module_invoke($module, 'fundraiser_upsell_prevent_series', $master_donation, $upsold_donation);
-    if ($answer) {
-      $result[$module] = $answer;
-    }
-  }
-
-  return $result;
 }
 
 /**

--- a/fundraiser/modules/fundraiser_upsell/fundraiser_upsell.module
+++ b/fundraiser/modules/fundraiser_upsell/fundraiser_upsell.module
@@ -651,8 +651,15 @@ function fundraiser_upsell_upsell_ajax_submit($did, $amount) {
   // Allow modules to modify the original upsold donation.
   drupal_alter('upsold_donation', $upsold_donation);
 
-  // Create the recurring donation series.
-  $success = fundraiser_upsell_create_recurring_series($master_donation);
+  // Allow modules to prevent the creation of this series.
+  $prevent_series = fundraiser_upsell_prevent_series($master_donation, $upsold_donation);
+  if ($prevent_series) {
+    $success = TRUE;
+  }
+  else {
+    // Create the recurring donation series.
+    $success = fundraiser_upsell_create_recurring_series($master_donation);
+  }
 
   // Grab and process the thank you content if successful.
   if ($success) {
@@ -674,6 +681,25 @@ function fundraiser_upsell_upsell_ajax_submit($did, $amount) {
   }
 
   return $content;
+}
+
+/**
+ * Find out if any modules want to prevent the creation of this series.
+ *
+ * @return array
+ *   Names of modules preventing the series creation.
+ */
+function fundraiser_upsell_prevent_series($master_donation, $upsold_donation) {
+  $result = array();
+
+  foreach(module_implements('fundraiser_upsell_prevent_series') as $module) {
+    $answer = module_invoke($module, 'fundraiser_upsell_prevent_series', $master_donation, $upsold_donation);
+    if ($answer) {
+      $result[$module] = $answer;
+    }
+  }
+
+  return $result;
 }
 
 /**


### PR DESCRIPTION
- Fixes sage cardonfile processing to respect the gateway's configured transaction type. e.g. auth only versus auth & capture.
- Allows modules to prevent upsell creating a sustainer series.