### PR TITLE
re #1100 - updating inline validation JS to account for multiple “oth…

### DIFF
--- a/fundraiser/js/donation_validation.js
+++ b/fundraiser/js/donation_validation.js
@@ -140,7 +140,8 @@
         }
         // Other Amount
         if ($('input[name*="other_amount"]')[0]) {
-          $('input[name*="other_amount"]').rules("add", {
+          $('input[name*="other_amount"]').each(function() {
+            $(this).rules("add", {
             required: {
               depends: function(element) {
                 if ($('input[type="radio"][name$="[amount]"][value="other"]:visible').is(":checked"))
@@ -157,6 +158,7 @@
               min: "The amount entered is less than the minimum donation amount."
             }
           });
+        });
         }
 
         // Focus and Blur conditional functions for non-recurring other amount


### PR DESCRIPTION
Currently, the JS for inline validation on donation forms only validates the first field that matches the criteria for an "other amount" field (i.e. it has the words "other amount" in the name attribute). This causes any value entered into the one-time other amount field to always validate.

I have updated the code to use jQuery.each() to iterate over each other amount field and add the validation rules that were previously only added to the first field.

Assembla Ticket: https://app.assembla.com/spaces/springboard/tickets/1100-inline-validation-does-not-execute-for-both--quot-other-quot--amount-fields/details