### PR TITLE
restore internal name field on petitions

### DIFF
--- a/springboard_advocacy/modules/springboard_petition/springboard_petition.install
+++ b/springboard_advocacy/modules/springboard_petition/springboard_petition.install
@@ -80,6 +80,20 @@ function springboard_petition_add_content_type() {
   $default_fields[] = 'sbp_rps_optin';
   variable_set('webform_user_default_fields_springboard_petition', $default_fields);
 
+  require_once drupal_get_path('module', 'webform_user') . '/includes/webform_user.fields.inc';
+  _webform_user_add_default_fields('springboard_petition');
+
+  $instance_info = field_read_instance('node', 'field_webform_user_internal_name', 'springboard_petition');
+  if ($instance_info) {
+    $instance_info['widget']['weight'] = 0;
+    field_update_instance($instance_info);
+  }
+  $instance_info = field_read_instance('node', 'body', 'springboard_petition');
+  if ($instance_info) {
+    $instance_info['widget']['weight'] = 1;
+    field_update_instance($instance_info);
+  }
+
   // Weighting the module to ensure submission handlers run after Webform User.
   // This ensures that the user id in webform_submissions has been updated by
   // Webform User before we get to it.
@@ -343,5 +357,25 @@ function springboard_petition_update_7002() {
 function springboard_petition_update_7003() {
   if(db_table_exists('springboard_quicksign')) {
       module_enable(array('sba_quicksign'));
+  }
+}
+
+/**
+ * Add the internal name field if it is missing.
+ */
+function springboard_petition_update_7004() {
+
+  require_once drupal_get_path('module', 'webform_user') . '/includes/webform_user.fields.inc';
+  _webform_user_add_default_fields('springboard_petition');
+
+  $instance_info = field_read_instance('node', 'field_webform_user_internal_name', 'springboard_petition');
+  if ($instance_info) {
+    $instance_info['widget']['weight'] = 0;
+    field_update_instance($instance_info);
+  }
+  $instance_info = field_read_instance('node', 'body', 'springboard_petition');
+  if ($instance_info) {
+    $instance_info['widget']['weight'] = 1;
+    field_update_instance($instance_info);
   }
 }


### PR DESCRIPTION
This patch adds and re-weights the webform user internal name field on petition nodes, on install and in an update hook (if it does not exist already);

