### PR TITLE
limit message action subject line to 70 chars

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.form.inc
@@ -201,6 +201,7 @@ function sba_message_action_message_form(&$form, $message, $action_type) {
       '#default_value' => $subject,
       '#description' => !empty($description) ? $description : '',
       '#access' => $access,
+      '#maxlength' => 70,
     );
 
   }

--- a/springboard_advocacy/modules/sba_message_action/sba_message_action.module
+++ b/springboard_advocacy/modules/sba_message_action/sba_message_action.module
@@ -754,12 +754,17 @@ function sba_message_action_form_sba_message_edit_form_alter(&$form, &$form_stat
   $node = menu_get_object();
 
   if (isset($node->type) && $node->type == 'sba_message_action') {
+
+    $lang = $form['field_sba_subject']['#language'];
+    $form['field_sba_subject'][$lang][0]['value']['#maxlength'] = 70;
+
     $sba_message = $form_state['sba_message'];
     $node_wrapper = entity_metadata_wrapper('node', $node);
     $multi_flow = $node_wrapper->field_sba_action_flow->value() == 'multi' ? TRUE : FALSE;
     $form['field_sba_subject_editable'][$form['field_sba_subject_editable']['#language']]['#title'] = t('Subject editable by advocate?');
 
-    // Disable the subject and body editable fields if this is a singe step action, and other messages already exist.
+    // Disable the subject and body editable fields if this is a singe step
+    // action, and other messages already exist.
     if ((isset($node->message_ids) && empty($sba_message->sba_message_id)) || (isset($node->message_ids) && count($node->message_ids) > 1)) {
       if (!$multi_flow) {
         $form['field_sba_subject_editable'][$form['field_sba_subject_editable']['#language']]['#description'] = t('This option is only available for multi-step messages, or single-step messages without multiple messages.');

--- a/springboard_advocacy/modules/sba_message_action/sba_message_action.module
+++ b/springboard_advocacy/modules/sba_message_action/sba_message_action.module
@@ -763,7 +763,7 @@ function sba_message_action_form_sba_message_edit_form_alter(&$form, &$form_stat
     $multi_flow = $node_wrapper->field_sba_action_flow->value() == 'multi' ? TRUE : FALSE;
     $form['field_sba_subject_editable'][$form['field_sba_subject_editable']['#language']]['#title'] = t('Subject editable by advocate?');
 
-    // Disable the subject and body editable fields if this is a singe step
+    // Disable the subject and body editable fields if this is a single step
     // action, and other messages already exist.
     if ((isset($node->message_ids) && empty($sba_message->sba_message_id)) || (isset($node->message_ids) && count($node->message_ids) > 1)) {
       if (!$multi_flow) {


### PR DESCRIPTION
This patch limits the subject field length to 70 characters on the message action message edit form, and on the webform client form if the subject is editable.