### PR TITLE
7.x 4.x 46 correctly handle goal data after node deletion reroll

### DIFF
--- a/fundraiser/modules/fundraiser_webform/includes/fundraiser_webform.goals.inc
+++ b/fundraiser/modules/fundraiser_webform/includes/fundraiser_webform.goals.inc
@@ -125,6 +125,10 @@ function fundraiser_webform_is_fundraiser_goal($selected_context, $form_state, $
 
     if ($selected_context['id'] == 'single' && $nid) {
       $node = node_load($nid);
+      // If this goal's node no longer exists then return false:
+      if (!$node) {
+        return FALSE;
+      }
       $type = $node->type;
     }
     elseif ($selected_context['id'] == 'group') {

--- a/webform_goals/webform_goals.admin.inc
+++ b/webform_goals/webform_goals.admin.inc
@@ -15,6 +15,10 @@ function webform_goals_admin_list($form, $form_state = array()) {
 
     if ($selected_context['id'] == 'single') {
       $node = node_load($goal['extra']['selected_form_id']);
+      // Do not display data for this goal if its node does not exist:
+      if (!$node) {
+        continue;
+      }
       $selected_context['name'] .= ' : ' . l($node->title, 'node/' . $node->nid);
     }
     elseif ($selected_context['id'] == 'group') {

--- a/webform_goals/webform_goals.module
+++ b/webform_goals/webform_goals.module
@@ -488,15 +488,10 @@ function webform_goals_save_goal_nids($goal) {
  */
 function webform_goals_delete_goal($gid) {
   require_once 'includes/webform_goals.files.inc';
-  db_query('
-    DELETE FROM {webform_goals
-    WHERE gid = :gid
-  ', array(':gid' => $gid));
 
-  db_query('
-    DELETE FROM {webform_goals_node}
-    WHERE gid = :gid
-  ', array(':gid' => $gid));
+  db_query("DELETE FROM {webform_goals} WHERE gid = :gid", array(':gid' => $gid));
+  db_query("DELETE FROM {webform_goals_node} WHERE gid = :gid", array(':gid' => $gid));
+  db_query("DELETE FROM {webform_goals_widget} WHERE gid = :gid", array(':gid' => $gid));
 
   $path = _webform_goals_base_path();
   $uri = $path . '/template-' . $gid . '.txt';
@@ -1448,10 +1443,15 @@ function webform_goals_node_update($node) {
 /**
  * Implements hook_node_delete().
  *
- * Delete a quick goal when node is deleted.
+ * Delete all goal data related to the node being deleted.
  */
 function webform_goals_node_delete($node) {
   if (webform_goals_is_goal_type($node->type)) {
+    $gids_query = db_query("SELECT gid FROM {webform_goals_node} WHERE nid = :nid",
+      array(':nid' => $node->nid));
+    foreach ($gids_query as $gids_data) {
+      webform_goals_delete_goal($gids_data->gid);
+    }
     webform_goals_quick_goal_delete($node->nid);
   }
 }

--- a/webform_goals/webform_goals.module
+++ b/webform_goals/webform_goals.module
@@ -1002,7 +1002,7 @@ function _webform_goals_get_selected_metric($selected_context, $form_state, $goa
   if (!empty($form_state['values']['metrics'])) {
     $selected_metric = $metrics[$form_state['values']['metrics']];
   }
-  elseif (!empty($goal['metric'])) {
+  elseif (!empty($goal['metric']) && isset($metrics[$goal['metric']])) {
     $selected_metric = $metrics[$goal['metric']];
   }
   return $selected_metric;


### PR DESCRIPTION
- Corrects errors on the goals list page which occur when the node associated with a goal has been deleted.

- Updates node deletion so any associate goal data will also be removed from the database.