### PR TITLE
Personal campaign default values pass-through

### DIFF
--- a/springboard_p2p/includes/springboard_p2p.register.inc
+++ b/springboard_p2p/includes/springboard_p2p.register.inc
@@ -110,6 +110,24 @@ function springboard_p2p_user_register_form($form, &$form_state) {
     springboard_p2p_add_state_and_country_ajax($form);
   }
 
+  // Check for POST values from previous page and store them in COOKIE.
+  $campaign_values = array(
+    'campaign_name' => FALSE,
+    'campaign_goal' => FALSE,
+    'campaign_url' => FALSE,
+  );
+  foreach ($campaign_values as $key => $value) {
+    if (isset($_POST[$key])) {
+      $campaign_values[$key] = check_plain($_POST[$key]);
+    }
+    else {
+      unset($campaign_values[$key]);
+    }
+  }
+  if (count($campaign_values)) {
+    user_cookie_save($campaign_values);
+  }
+
   return $form;
 }
 

--- a/springboard_p2p/plugins/content_types/login_intro.inc
+++ b/springboard_p2p/plugins/content_types/login_intro.inc
@@ -45,36 +45,60 @@ function springboard_p2p_login_intro_render($subtype, $conf, $args, $contexts) {
   $logintext = variable_get('springboard_p2p_login_message_area');
 
   // Define the reg link passing the string id.
-  $loginlink = '/p2p/login';
+  $login_url = 'p2p/login';
+
+  $parameters = drupal_get_query_parameters();
+  $query = array();
+  $output = array();
 
   // Query the url string campaign id if it's not empty. Confirm
   // input is numeric to prevent XSS.
-  if (!empty($_GET['p2p_cid']) && is_numeric($_GET['p2p_cid'])) {
-    $urlstring = $_GET['p2p_cid'];
-    $loginlinkid = '?p2p_cid=' . $urlstring;
+  if (!empty($parameters['p2p_cid']) && is_numeric($parameters['p2p_cid'])) {
+    $query['p2p_cid'] = filter_xss($parameters['p2p_cid']);
+  }
+  if (isset($parameters['campaign_name'])) {
+    $query['campaign_name'] = filter_xss($parameters['campaign_name']);
+  }
+  if (isset($parameters['campaign_url'])) {
+    $query['campaign_url'] = filter_xss($parameters['campaign_url']);
+  }
+  if (isset($parameters['campaign_goal'])) {
+    $query['campaign_goal'] = filter_xss($parameters['campaign_goal']);
   }
 
-  $output = array();
-
-  // Create the output to be rendered.
-  if (empty($_GET['p2p_cid']) || !is_numeric($_GET['p2p_cid'])) {
-    $output[] = '<a class="get-started-link" href=" ' . $loginlink . ' ">' . t('Login') . '<i class="fa fa-cog  get-started-spinner"></i></a>';
-  }
-
-  else {
-    $output[] = '<a class="get-started-link" href=" ' . $loginlink . $loginlinkid . ' ">' . t('Login') . '<i class="fa fa-cog  get-started-spinner"></i></a>';
-  }
-
-  // Render the login message text.
-  $output[] = '<div class="login-text-wrapper"> ';
-  $output[] = $logintext['value'];
-  $output[] = '</div>';
+  $icon = array(
+    '#type' => 'html_tag',
+    '#tag' => 'i',
+    '#attributes' => array(
+      'class' => array('fa', 'fa-cog', 'get-started-spinner'),
+    ),
+    '#value' => '',
+  );
+  $link = array(
+    '#theme' => 'link',
+    '#path' => $login_url,
+    '#text' => t('Login') . render($icon),
+    '#options' => array(
+      'attributes' => array(
+        'class' => array('get-started-link'),
+      ),
+      'html' => TRUE,
+      'query' => $query,
+    ),
+  );
+  $output = array(
+    '#type' => 'container',
+    '#attributes' => array(
+      'class' => array('login-text-wrapper'),
+    ),
+    'link' => $link,
+  );
 
   // Initial content is blank.
   // Build the content type block.
   $block = new stdClass();
   $block->title = $title;
-  $block->content = implode('', $output);
+  $block->content = render($output);
   return $block;
 
 }

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -373,7 +373,6 @@ function springboard_p2p_ajax($form, $form_state) {
  * Implements hook_form_FORM_ID_alter().
  */
 function springboard_p2p_form_p2p_personal_campaign_node_form_alter(&$form, &$form_state, $form_id) {
-
   // Create a function to unset the filter choice and tips area.
   $form['body']['#after_build'][] = '_filter_tips_p2p_campaign_intro';
 
@@ -437,11 +436,35 @@ function springboard_p2p_form_p2p_personal_campaign_node_form_alter(&$form, &$fo
 
       $language = $campaign_node->language;
 
+      $parameters = drupal_get_query_parameters();
+      $clear_cookies = FALSE;
+      if (isset($_COOKIE['Drupal_visitor_campaign_name'])) {
+        $parameters['campaign_name'] = check_plain($_COOKIE['Drupal_visitor_campaign_name']);
+        $clear_cookies = TRUE;
+      }
+      if (isset($_COOKIE['Drupal_visitor_campaign_goal'])) {
+        $parameters['campaign_goal'] = check_plain($_COOKIE['Drupal_visitor_campaign_goal']);
+        $clear_cookies = TRUE;
+      }
+      if (isset($_COOKIE['Drupal_visitor_campaign_url'])) {
+        $parameters['campaign_url'] = check_plain($_COOKIE['Drupal_visitor_campaign_url']);
+        $clear_cookies = TRUE;
+      }
+
+      if ($clear_cookies) {
+        $form['#submit'][] = '_springboard_p2p_form_p2p_personal_campaign_node_form_submit_clear_cookies';
+      }
+
       // Prefill the title with a suggestion.
-      $form['title']['#default_value'] = springboard_p2p_get_personal_campaign_title_suggestion($campaign_node->title);
+      $form['title']['#default_value'] = !isset($parameters['campaign_name']) ? springboard_p2p_get_personal_campaign_title_suggestion($campaign_node->title) : check_url($parameters['campaign_name']);
 
       // Prefill the url with a suggestion based on title.
-      $form['field_p2p_personal_campaign_url'][$language][0]['value']['#default_value'] = springboard_p2p_create_alias_from_title($campaign_node->title);
+      $form['field_p2p_personal_campaign_url'][$language][0]['value']['#default_value'] = !isset($parameters['campaign_url']) ? springboard_p2p_create_alias_from_title($campaign_node->title) : check_url($parameters['campaign_url']);
+
+      // Prefill the goal amount if the parameter in the URL is set.
+      if (isset($parameters['campaign_goal'])) {
+        $form['field_p2p_personal_campaign_goal'][$language][0]['value']['#default_value'] = $parameters['campaign_goal'];
+      }
 
       // Campaign intro, default from parent campaign, display disabled content
       // preview if edit is disabled.
@@ -586,6 +609,18 @@ function springboard_p2p_form_p2p_personal_campaign_node_form_alter(&$form, &$fo
   // Hide progress fields.
   $form['field_p2p_campaign_progress']['#access'] = FALSE;
   $form['#validate'][] = 'springboard_p2p_personal_campaign_validate';
+}
+
+/**
+ * Submission callback to delete any campaign-related cookies on submission.
+ *
+ * @see _springboard_p2p_form_p2p_personal_campaign_node_form_alter()
+ */
+function _springboard_p2p_form_p2p_personal_campaign_node_form_submit_clear_cookies($form, &$form_state) {
+  $cookies = array('campaign_name', 'campaign_goal', 'campaign_url');
+  foreach ($cookies as $cookie) {
+    user_cookie_delete($cookie);
+  }
 }
 
 /**

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -1499,7 +1499,6 @@ function springboard_p2p_get_campaign_id_from_request() {
  * Saves the campaign approval status and changes the redirect.
  */
 function springboard_p2p_set_redirect($form, &$form_state) {
-
   if (!empty($form_state['uid'])) {
     $uid = $form_state['uid'];
   }
@@ -1548,12 +1547,26 @@ function springboard_p2p_set_redirect($form, &$form_state) {
       else {
         drupal_set_message('You can now create a personal campaign in ' . $campaign->title);
 
+        $parameters = drupal_get_query_parameters();
+        // We only want to deal with the campaign_name, campaign_url, and
+        // campaign_goal parameters, and ignore any others.
+        $pass = array();
+        if (isset($parameters['campaign_name'])) {
+          $pass['campaign_name'] = $parameters['campaign_name'];
+        }
+        if (isset($parameters['campaign_url'])) {
+          $pass['campaign_url'] = $parameters['campaign_url'];
+        }
+        if (isset($parameters['campaign_goal'])) {
+          $pass['campaign_goal'] = $parameters['campaign_goal'];
+        }
+
         $form_state['redirect'] = array(
           'node/add/p2p-personal-campaign',
           array(
-            'query' => array(
+            'query' => array_merge($pass, array(
               'p2p_cid' => $campaign_id,
-            ),
+            )),
           ),
         );
 
@@ -2008,7 +2021,7 @@ function springboard_p2p_webform_client_form_submit($form, &$form_state) {
       $sbp_last_name = _webform_user_find_field($form, $component_hierarchy['sbp_last_name']);
       $action['donor_name'] = $sbp_first_name['#value'] . ' ' . $sbp_last_name['#value'];
     }
-        
+
 
     springboard_p2p_save_personal_campaign_action($action);
 
@@ -2160,12 +2173,12 @@ function springboard_p2p_fundraiser_donation_success($donation) {
 
     // Now that the donation is successful, mark the action as visible.
     $action['status'] = 1;
-    
+
     // If the donor has opted to show their name, save it with the action.
     if ($action['show_name']) {
       $action['donor_name'] = $donation->donation['first_name'] . ' ' . $donation->donation['last_name'];
     }
-    
+
     springboard_p2p_save_personal_campaign_action($action, array('sid'));
   }
 }
@@ -2210,10 +2223,10 @@ function springboard_p2p_save_personal_campaign_action($record, $key = NULL) {
   if (empty($record['created'])) {
     $record['created'] = REQUEST_TIME;
   }
-  
+
   // Allow other modules to update the action before saving.
   drupal_alter('springboard_p2p_save_personal_campaign_action', $record, $key);
-  
+
   if (!empty($key)) {
     drupal_write_record('springboard_p2p_personal_campaign_action', $record, $key);
   }

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -1552,13 +1552,13 @@ function springboard_p2p_set_redirect($form, &$form_state) {
         // campaign_goal parameters, and ignore any others.
         $pass = array();
         if (isset($parameters['campaign_name'])) {
-          $pass['campaign_name'] = $parameters['campaign_name'];
+          $pass['campaign_name'] = filter_xss($parameters['campaign_name']);
         }
         if (isset($parameters['campaign_url'])) {
-          $pass['campaign_url'] = $parameters['campaign_url'];
+          $pass['campaign_url'] = filter_xss($parameters['campaign_url']);
         }
         if (isset($parameters['campaign_goal'])) {
-          $pass['campaign_goal'] = $parameters['campaign_goal'];
+          $pass['campaign_goal'] = filter_xss($parameters['campaign_goal']);
         }
 
         $form_state['redirect'] = array(


### PR DESCRIPTION
This change allows a handful of default values to be passed-through the registration process. Passed through values will be used to pre-populate the personal campaign node add form.