### PR TITLE
re #1080 - adding ‘create user’ button

### DIFF
--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -1072,6 +1072,19 @@ function springboard_admin_springboard_admin_alias_patterns() {
         'replacement' => 'springboard/user/$1$2',
       ),
     ),
+
+    // User creation page
+    'admin/people/create' => array(
+      'path' => array(
+        'regex' => '|^/admin/people/create$|',
+        'replacement' => 'admin/people/create',
+      ),
+      'alias' => array(
+        'regex' => '|^springboard/settings/administrators/add$|',
+        'replacement' => 'springboard/settings/administrators/add',
+      ),
+    ),
+
     // Donation reports.
     'admin/reports/salesforce/donations' => array(
       'path' => array(

--- a/springboard/modules/springboard_views/springboard_views.views_default.inc
+++ b/springboard/modules/springboard_views/springboard_views.views_default.inc
@@ -4271,6 +4271,12 @@ function springboard_views_views_default_views() {
       'empty_column' => 0,
     ),
   );
+  /* Header: Global: Text area */
+  $handler->display->display_options['header']['area']['id'] = 'area';
+  $handler->display->display_options['header']['area']['table'] = 'views';
+  $handler->display->display_options['header']['area']['field'] = 'area';
+  $handler->display->display_options['header']['area']['content'] = '<a href="/admin/people/create" class="button add-button">Create User</a>';
+  $handler->display->display_options['header']['area']['format'] = 'raw_html';
   /* Field: User: Uid */
   $handler->display->display_options['fields']['uid']['id'] = 'uid';
   $handler->display->display_options['fields']['uid']['table'] = 'users';


### PR DESCRIPTION
Adding ‘create user’ button to Administrators view and corresponding Admin UI alias for user creation page.

https://app.assembla.com/spaces/springboard/tickets/1080-administrator-view--add---39-create-new-user--39--button/details