### PR TITLE
limit springboard admin settings to the built-in administrator role

### DIFF
--- a/springboard/modules/springboard_admin/springboard_admin.menu.inc
+++ b/springboard/modules/springboard_admin/springboard_admin.menu.inc
@@ -268,7 +268,8 @@ function springboard_admin_admin_menu_items() {
     '_children' => array(),
   );
 
-  if (user_access('administer springboard')) {
+  global $user;
+  if (is_array($user->roles) && in_array('Administrator', array_values($user->roles))) {
     $items['admin/springboard/settings']['_children']['admin/springboard/settings/config']['_children']['admin/springboard/settings/springboard'] = array(
       'link_path' => 'admin/springboard/settings/springboard',
       'link_title' => 'Springboard Admin Settings',


### PR DESCRIPTION
Limit the springboard admin link to "Adminstrator" role rather than "administer springboard" permission because "Springboard Admin" should not be able to access this link.