### PR TITLE
7.x 4.11 beta 1061 message download

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.reports.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.reports.inc
@@ -101,7 +101,7 @@ function sba_message_action_performance_targets_table($responses, $node) {
     'tabs'                           => $tabs,
     'deliverability_cache_timestamp' => $responses['deliverability_cache_timestamp'],
     'legislative_results_download_link' =>
-      $springboard_advocacy_endpoint . preg_replace("@//@", "/", "/api/v1/deliverability/action/$advocacy_id/download?access_token=$auth_token"),
+      preg_replace("@[^://]//@", "/", "$springboard_advocacy_endpoint/api/v1/deliverability/action/$advocacy_id/download?access_token=$auth_token"),
     'form_url_with_input'            => $form_url_with_input,
   ));
 

--- a/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.reports.inc
+++ b/springboard_advocacy/modules/sba_message_action/includes/sba_message_action.reports.inc
@@ -101,8 +101,7 @@ function sba_message_action_performance_targets_table($responses, $node) {
     'tabs'                           => $tabs,
     'deliverability_cache_timestamp' => $responses['deliverability_cache_timestamp'],
     'legislative_results_download_link' =>
-      preg_replace("@//@", "/", "$springboard_advocacy_endpoint/api/v1
-      /deliverability/action/$advocacy_id/download?access_token=$auth_token"),
+      $springboard_advocacy_endpoint . preg_replace("@//@", "/", "/api/v1/deliverability/action/$advocacy_id/download?access_token=$auth_token"),
     'form_url_with_input'            => $form_url_with_input,
   ));
 


### PR DESCRIPTION
extra white space and a bad regex mangled the download url.

presumably  preg_replace("@//@", "/", ...

was meant to remove double / at the end of the url, not in the "https://"