### PR TITLE
re #683 - make donation form’s page wraper apply to fundraiser-redirect

### DIFF
--- a/page_wrappers/page_wrappers.module
+++ b/page_wrappers/page_wrappers.module
@@ -855,13 +855,13 @@ function _page_wrappers_node_assigned_wrapper($node) {
  */
 function _page_wrappers_page_node() {
   $node = NULL;
-
+  $subpages = array('done', 'fundraiser-redirect');
   // Check if this in ajax request form submit
   if (arg(0) == 'system' && arg(1) == 'ajax' && !empty($_POST['form_build_id'])) {
     $node = _page_wrappers_cached_form_node($_POST['form_build_id']);
   }
   // If this is a node page load it up, also cover webform 'done' page
-  elseif (arg(0) == 'node' && is_numeric(arg(1)) && (arg(2) == 'done' || !arg(2))) {
+  elseif (arg(0) == 'node' && is_numeric(arg(1)) && (in_array(arg(2), $subpages) || !arg(2))) {
     $node = node_load(arg(1));
   }
 


### PR DESCRIPTION
Currently, fundraiser-redirect pages do not get a page wrapper, leaving them to have the bare-bones springboard_frontend theme styling (pretty much none). This patch applies the donation form's page wrapper to the fundraiser-redirect page and will make it easier to add other donation form sub-pages (via code) in the future.

https://app.assembla.com/spaces/springboard/tickets/683-paypal-cancellation-screen-is-not-themed/details