### PR TITLE
add unlocked status to stuck sustainers vbo and action

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -4308,6 +4308,7 @@ function fundraiser_sustainers_unlock_sustainer_action(&$sustainer_record, $cont
 
   switch ($sustainer_record->gateway_resp) {
     case FUNDRAISER_SUSTAINERS_PROCESSING_STATUS:
+    case FUNDRAISER_SUSTAINERS_LOCKED_STATUS:
       $sustainer_record->lock_id = 0;
       $sustainer_record->gateway_resp = FUNDRAISER_SUSTAINERS_RETRY_STATUS;
       $log->logUnlockedDonation($sustainer_record->did, $sustainer_record->gateway_resp);

--- a/fundraiser/modules/fundraiser_sustainers/includes/fundraiser_sustainers.views_default.inc
+++ b/fundraiser/modules/fundraiser_sustainers/includes/fundraiser_sustainers.views_default.inc
@@ -608,6 +608,12 @@ function fundraiser_sustainers_views_default_views() {
   $handler->display->display_options['filters']['gateway_resp_1']['value'] = 'processing';
   $handler->display->display_options['filters']['gateway_resp_1']['group'] = 2;
   /* Filter criterion: Fundraiser sustainer record: Gateway response */
+  $handler->display->display_options['filters']['gateway_resp_4']['id'] = 'gateway_resp_4';
+  $handler->display->display_options['filters']['gateway_resp_4']['table'] = 'fundraiser_sustainers';
+  $handler->display->display_options['filters']['gateway_resp_4']['field'] = 'gateway_resp';
+  $handler->display->display_options['filters']['gateway_resp_4']['value'] = 'locked';
+  $handler->display->display_options['filters']['gateway_resp_4']['group'] = 2;
+  /* Filter criterion: Fundraiser sustainer record: Gateway response */
   $handler->display->display_options['filters']['gateway_resp_2']['id'] = 'gateway_resp_2';
   $handler->display->display_options['filters']['gateway_resp_2']['table'] = 'fundraiser_sustainers';
   $handler->display->display_options['filters']['gateway_resp_2']['field'] = 'gateway_resp';
@@ -620,6 +626,7 @@ function fundraiser_sustainers_views_default_views() {
   $handler->display->display_options['filters']['next_charge']['operator'] = '<';
   $handler->display->display_options['filters']['next_charge']['value']['value'] = '-1 hour';
   $handler->display->display_options['filters']['next_charge']['value']['type'] = 'offset';
+  $handler->display->display_options['filters']['next_charge']['group'] = 1;
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');


### PR DESCRIPTION
The unlock sustainers action and VBO were created 5 weeks prior to the addition of the "locked" status code on July 31. The omission of the locked status from the action and VBO was an oversight. This patch restores the ability to unluck sustainers with a status of "locked" in addition to the prior eliglbe statuses "processing" and NULL.