### PR TITLE
7.x 4.x salesforce login

### DIFF
--- a/salesforce/salesforce_login/salesforce_login.admin.inc
+++ b/salesforce/salesforce_login/salesforce_login.admin.inc
@@ -27,5 +27,14 @@ function salesforce_login_admin_form($form, $form_state) {
     '#required' => TRUE,
   );
 
+  $form['salesforce_login_query_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Query field override.'),
+    '#default_value' => variable_get('salesforce_login_query_field'),
+    '#description' => t('Specify the Salesforce email field that should be queried when looking up a new user. This can usually be left blank, as it defaults to the email field in the <a href="@user-to-contact-link">user_to_contact</a> Salesforce mapping.', array('@user-to-contact-link' => '/springboard/settings/config/mappings/manage/user_to_contact')),
+    '#size' => 60,
+    '#maxlength' => 128,
+  );
+
   return system_settings_form($form);
 }

--- a/salesforce/salesforce_login/salesforce_login.admin.inc
+++ b/salesforce/salesforce_login/salesforce_login.admin.inc
@@ -11,7 +11,7 @@
 function salesforce_login_admin_form($form, $form_state) {
   $form = array();
 
-  if (!variable_get('email_registration_login_with_username')) {
+  if (!variable_get('email_registration_login_with_username', TRUE)) {
     drupal_set_message(t('Salesforce Login: It is reccomended that you enable the "Allow users login with e-mail or username." option on the <a href="/admin/config/people/accounts">Account Settings</a> page.'), 'warning');
   }
 

--- a/salesforce/salesforce_login/salesforce_login.admin.inc
+++ b/salesforce/salesforce_login/salesforce_login.admin.inc
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Administration.
+ */
+
+/**
+ * Form callback for admin page.
+ */
+function salesforce_login_admin_form($form, $form_state) {
+  $form = array();
+
+  $form['salesforce_login_multiple_contacts_error'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Multiple contacts error message'),
+    '#default_value' => variable_get('salesforce_login_multiple_contacts_error'),
+    '#description' => t('Display this error message when a new user tries to login for the first time but multiple contacts are found in salesforce.'),
+    '#required' => TRUE,
+  );
+
+  $form['salesforce_login_no_contacts_error'] = array(
+    '#type' => 'textarea',
+    '#title' => t('No contact found error message'),
+    '#default_value' => variable_get('salesforce_login_no_contact_found_error'),
+    '#description' => t('Display this error message when a new user tries to login for the first time but multiple contacts are found in salesforce.'),
+    '#required' => TRUE,
+  );
+
+  return system_settings_form($form);
+}

--- a/salesforce/salesforce_login/salesforce_login.admin.inc
+++ b/salesforce/salesforce_login/salesforce_login.admin.inc
@@ -11,6 +11,10 @@
 function salesforce_login_admin_form($form, $form_state) {
   $form = array();
 
+  if (!variable_get('email_registration_login_with_username')) {
+    drupal_set_message(t('Salesforce Login: It is reccomended that you enable the "Allow users login with e-mail or username." option on the <a href="/admin/config/people/accounts">Account Settings</a> page.'), 'warning');
+  }
+
   $form['salesforce_login_multiple_contacts_error'] = array(
     '#type' => 'textarea',
     '#title' => t('Multiple contacts error message'),

--- a/salesforce/salesforce_login/salesforce_login.info
+++ b/salesforce/salesforce_login/salesforce_login.info
@@ -3,6 +3,6 @@ description =  Create Drupal users from Salesforce contacts on-demand.
 package = Salesforce
 core = 7.x
 
-dependencies[] = salesforce
+dependencies[] = salesforce_sync
 
 configure = admin/config/salesforce/salesforce-login

--- a/salesforce/salesforce_login/salesforce_login.info
+++ b/salesforce/salesforce_login/salesforce_login.info
@@ -1,0 +1,8 @@
+name = Salesforce Login
+description =  Create Drupal users from Salesforce contacts on-demand.
+package = Salesforce
+core = 7.x
+
+dependencies[] = salesforce
+
+configure = admin/config/salesforce/salesforce-login

--- a/salesforce/salesforce_login/salesforce_login.info
+++ b/salesforce/salesforce_login/salesforce_login.info
@@ -3,6 +3,7 @@ description =  Create Drupal users from Salesforce contacts on-demand.
 package = Salesforce
 core = 7.x
 
+dependencies[] = email_registration
 dependencies[] = salesforce_sync
 
 configure = admin/config/salesforce/salesforce-login

--- a/salesforce/salesforce_login/salesforce_login.install
+++ b/salesforce/salesforce_login/salesforce_login.install
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @file
+ * Sets default values for salesforce_login.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function salesforce_login_install() {
+  variable_set('salesforce_login_multiple_contacts_error', t('More than one contact exists for this email. Please contact the site administrator for assistance.'));
+  variable_set('salesforce_login_no_contact_found_error', t('No information was found for this email address. Please try again or contact the site administrator for assistance.'));
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function salesforce_login_uninstall() {
+  variable_del('salesforce_login_multiple_contacts_error');
+  variable_del('salesforce_login_no_contact_found_error');
+}

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -137,9 +137,15 @@ function salesforce_login_user_save($mail, $contact) {
   // $account->sbp_last_name[LANGUAGE_NONE][0]['value'].
   $user_to_contact_mapping = salesforce_mapping_load('user_to_contact');
   foreach ($user_to_contact_mapping->field_mappings as $field_mapping) {
+    // Only grab fields that should be synced from Salesforce to Drupal.
     if ($field_mapping['direction'] == 'sf_drupal') {
+      // Only grab mapped fields returned in the query from Salesforce.
       if (isset($contact->{$field_mapping['salesforce_field']['name']})) {
-        $account->{$field_mapping['drupal_field']['fieldmap_value']}['und'][0]['value'] = $contact->{$field_mapping['salesforce_field']['name']};
+        // We explicitly set $account->mail above, so don't change it here.
+        if ($field_mapping['drupal_field']['fieldmap_value'] != 'mail') {
+          // Add the profile field to the $account object.
+          $account->{$field_mapping['drupal_field']['fieldmap_value']}['und'][0]['value'] = $contact->{$field_mapping['salesforce_field']['name']};
+        }
       }
     }
   }

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -35,9 +35,9 @@ function salesforce_login_permission() {
 }
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_FORM_ID_alter().
  */
-function salesforce_login_form_alter(&$form, $form_state, $form_id) {
+function salesforce_login_form_user_pass_alter(&$form, $form_state, $form_id) {
   // Search for and replace the user_pass_validate() and user_pass_submit()
   // callbacks with our own.
   $form['#validate'] = str_replace('user_pass_validate', 'salesforce_login_pass_validate', $form['#validate']);

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -128,7 +128,7 @@ function salesforce_login_user_save($mail, $contact) {
   $account = new stdClass();
   $account->is_new = TRUE;
   // @TODO How are we going to handle user names?
-  $account->name = $mail;
+  $account->name = salesforce_login_cleanup_username($mail);
   $account->mail = $mail;
   $account->status = TRUE;
   // Get user_to_contact field mapping and save profile field values in
@@ -185,4 +185,23 @@ function salesforce_login_get_contacts_by_email($email) {
   $soap = new SalesforceSoapPartner($sfapi);
   $salesforce_sync = new SalesforceSync($sfapi, $soap);
   return $salesforce_sync->fetchByField('Contact', $salesforce_fields, $salesforce_mail_field, array($email));
+}
+
+/**
+ * Clean name using functions from email_registration.module, if present.
+ *
+ * @param string $name
+ *   A dirty username.
+ *
+ * @return string
+ *   A valid and unique username.
+ */
+function salesforce_login_cleanup_username($name) {
+  if (module_exists('email_registration')) {
+    // Strip off everything after the @ sign.
+    $name = preg_replace('/@.*$/', '', $name);
+    $name = email_registration_cleanup_username($name);
+    $name = email_registration_unique_username($name);
+  }
+  return $name;
 }

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -127,7 +127,6 @@ function salesforce_login_pass_validate($form, &$form_state) {
 function salesforce_login_user_save($mail, $contact) {
   $account = new stdClass();
   $account->is_new = TRUE;
-  // @TODO How are we going to handle user names?
   $account->name = salesforce_login_cleanup_username($mail);
   $account->mail = $mail;
   $account->status = TRUE;

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -104,7 +104,9 @@ function salesforce_login_pass_validate($form, &$form_state) {
     }
     elseif ($contacts_count == 1) {
       // One corresponding Contact found in Salesforce. Create Drupal user.
-      $account = salesforce_login_user_save($name, $contacts);
+      // We know there is only one contact now so pass that one using
+      // array_shit().
+      $account = salesforce_login_user_save($name, array_shift($contacts));
       if ($account) {
         $form_state['values']['account'] = $account;
         $form_state['values']['salesforce_login_created_account'] = TRUE;
@@ -129,7 +131,18 @@ function salesforce_login_user_save($mail, $contact) {
   $account->name = $mail;
   $account->mail = $mail;
   $account->status = TRUE;
-  // @TODO Handle saving user profile fields.
+  // Get user_to_contact field mapping and save profile field values in
+  // the appropriate places. eg
+  // $account->sbp_address[LANGUAGE_NONE][0]['value'].
+  // $account->sbp_last_name[LANGUAGE_NONE][0]['value'].
+  $user_to_contact_mapping = salesforce_mapping_load('user_to_contact');
+  foreach ($user_to_contact_mapping->field_mappings as $field_mapping) {
+    if ($field_mapping['direction'] == 'sf_drupal') {
+      if (isset($contact->{$field_mapping['salesforce_field']['name']})) {
+        $account->{$field_mapping['drupal_field']['fieldmap_value']}['und'][0]['value'] = $contact->{$field_mapping['salesforce_field']['name']};
+      }
+    }
+  }
   return user_save($account);
 }
 /**

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -104,12 +104,14 @@ function salesforce_login_pass_validate($form, &$form_state) {
     }
     elseif ($contacts_count == 1) {
       // One corresponding Contact found in Salesforce. Create Drupal user.
-      // We know there is only one contact now so pass that one using
-      // array_shit().
-      $account = salesforce_login_user_save($name, array_shift($contacts));
+      $account = salesforce_login_user_save($name, $contacts[0]);
       if ($account) {
         $form_state['values']['account'] = $account;
         $form_state['values']['salesforce_login_created_account'] = TRUE;
+        // Save salesforce_sync_map records for Account and Contact immediately
+        // so that My Donation History can be populated with donations before
+        // the next salesforce sync job runs.
+        salesforce_login_sync_map_save($account->uid, $contacts);
       }
       else {
         form_set_error('name', t('There was a problem creating your account.'));
@@ -150,6 +152,29 @@ function salesforce_login_user_save($mail, $contact) {
   }
   return user_save($account);
 }
+
+/**
+ *
+ */
+function salesforce_login_sync_map_save($uid, $contacts) {
+    $account_record = array(
+      'sfid' => $contacts[0]->fields->AccountId,
+      'drupal_id' => $uid,
+      'module' => 'user',
+      'delta' => 'user',
+      'object_type' => 'Account',
+    );
+    $contact_record = array(
+      'sfid' => $contacts[0]->fields->Id,
+      'drupal_id' => $uid,
+      'module' => 'user',
+      'delta' => 'user',
+      'object_type' => 'Contact',
+    );
+    salesforce_sync_save_map($account_record);
+    salesforce_sync_save_map($contact_record);
+}
+
 /**
  * Helper function that queries Salesforce for Contact by email address.
  *

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -144,17 +144,22 @@ function salesforce_login_user_save($mail, $contact) {
  */
 function salesforce_login_get_contacts_by_email($email) {
   // Find the Salesforce fields that map to Drupal user fields so we can return
-  // them all in the query.
+  // them all those values in the query.
   $user_to_contact_mapping = salesforce_mapping_load('user_to_contact');
   $salesforce_fields = array();
   foreach ($user_to_contact_mapping->field_mappings as $mapping) {
     if ($mapping['direction'] == 'sf_drupal') {
       $salesforce_fields[] = $mapping['salesforce_field']['name'];
-      // Find the Salesforce field mapps to the Drupal's user's mail field.
+      // Find the Salesforce field that maps to the Drupal's user's mail field.
       if ($mapping['drupal_field']['fieldmap_value'] == 'mail') {
         $salesforce_mail_field = $mapping['salesforce_field']['name'];
       }
     }
+  }
+  // Provide opportunity to override the email field that is queried.
+  $salesforce_login_query_field = variable_get('salesforce_login_query_field');
+  if (!empty($salesforce_login_query_field)) {
+    $salesforce_mail_field = $salesforce_login_query_field;
   }
   // Query Salesforce.
   $sfapi = salesforce_get_api();

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -10,7 +10,7 @@
 function salesforce_login_menu() {
   // Settings form.
   $items['admin/config/salesforce/salesforce-login'] = array(
-    'title' => 'Login',
+    'title' => 'Salesforce Login',
     'description' => 'Configuration settings for Salesforce Login.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('salesforce_login_admin_form'),

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @file
+ * Provides support from creating new Drupal users from Salesforce contacts.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function salesforce_login_menu() {
+  // Settings form.
+  $items['admin/config/salesforce/salesforce-login'] = array(
+    'title' => 'Login',
+    'description' => 'Configuration settings for Salesforce Login.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('salesforce_login_admin_form'),
+    'access arguments' => array('administer salesforce login'),
+    'type' => MENU_NORMAL_ITEM,
+    'file' => 'salesforce_login.admin.inc',
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function salesforce_login_permission() {
+  return array(
+    'administer salesforce login' => array(
+      'description' => t('Configure settings for creating Drupal users from Salesforce.'),
+      'title' => t('Configure Salesforce Login'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function salesforce_login_form_alter(&$form, $form_state, $form_id) {
+  // Search for and replace the user_pass_validate() callback with our own.
+  $form['#validate'] = str_replace('user_pass_validate', 'salesforce_login_pass_validate', $form['#validate']);
+}
+
+/**
+ * Validation function.
+ *
+ * This function is adapted from and overrides user_pass_validate().
+ */
+function salesforce_login_pass_validate($form, &$form_state) {
+  $name = trim($form_state['values']['name']);
+  // Try to load by email.
+  $users = user_load_multiple(array(), array('mail' => $name, 'status' => '1'));
+  $account = reset($users);
+  if (!$account) {
+    // No success, try to load by name.
+    $users = user_load_multiple(array(), array('name' => $name, 'status' => '1'));
+    $account = reset($users);
+  }
+  if (isset($account->uid)) {
+    form_set_value(array('#parents' => array('account')), $account, $form_state);
+  }
+  else {
+    // @TODO This is where we'll look in salesforce for a corresponding contact.
+    form_set_error('name', t('Sorry, %name is not recognized as a user name or an e-mail address.', array('%name' => $name)));
+  }
+}

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -38,14 +38,49 @@ function salesforce_login_permission() {
  * Implements hook_form_alter().
  */
 function salesforce_login_form_alter(&$form, $form_state, $form_id) {
-  // Search for and replace the user_pass_validate() callback with our own.
+  // Search for and replace the user_pass_validate() and user_pass_submit()
+  // callbacks with our own.
   $form['#validate'] = str_replace('user_pass_validate', 'salesforce_login_pass_validate', $form['#validate']);
+  $form['#submit'] = str_replace('user_pass_submit', 'salesforce_login_pass_submit', $form['#submit']);
 }
 
 /**
- * Validation function.
+ * Submit handler.
  *
- * This function is adapted from and overrides user_pass_validate().
+ * This function is adapted from and overrides user_pass_submit(). This is done
+ * in order to send the account activation email (rather than the password
+ * recovery email) when a new user is created from a Salesforce Contact.
+ */
+function salesforce_login_pass_submit($form, &$form_state) {
+  global $language;
+
+  $account = $form_state['values']['account'];
+  if (isset($form_state['values']['salesforce_login_created_account'])) {
+    // Mail one time login URL and instructions using current language.
+    $mail = _user_mail_notify('status_activated', $account, $language);
+    if (!empty($mail)) {
+      watchdog('salesforce_login', 'Account activation instructions mailed to %name at %email.', array('%name' => $account->name, '%email' => $account->mail));
+      drupal_set_message(t('Further instructions have been sent to your e-mail address.'));
+    }
+  }
+  else {
+    // Mail one time login URL and instructions using current language.
+    $mail = _user_mail_notify('password_reset', $account, $language);
+    if (!empty($mail)) {
+      watchdog('salesforce_login', 'Password reset instructions mailed to %name at %email.', array('%name' => $account->name, '%email' => $account->mail));
+      drupal_set_message(t('Further instructions have been sent to your e-mail address.'));
+    }
+  }
+
+  $form_state['redirect'] = 'user';
+}
+
+/**
+ * Validation handler.
+ *
+ * This function is adapted from and overrides user_pass_validate(). If no
+ * Drupal user is found, Salesforce is queried and a corresponding Drupal user
+ * created on success.
  */
 function salesforce_login_pass_validate($form, &$form_state) {
   $name = trim($form_state['values']['name']);
@@ -61,15 +96,18 @@ function salesforce_login_pass_validate($form, &$form_state) {
     form_set_value(array('#parents' => array('account')), $account, $form_state);
   }
   else {
+    // No Drupal user found. Try Salesforce.
     $contacts = salesforce_login_get_contacts_by_email($name);
     $contacts_count = count($contacts);
     if ($contacts_count == 0) {
       form_set_error('name', variable_get('salesforce_login_no_contact_found_error'));
     }
     elseif ($contacts_count == 1) {
+      // One corresponding Contact found in Salesforce. Create Drupal user.
       $account = salesforce_login_user_save($name, $contacts);
       if ($account) {
         $form_state['values']['account'] = $account;
+        $form_state['values']['salesforce_login_created_account'] = TRUE;
       }
       else {
         form_set_error('name', t('There was a problem creating your account.'));

--- a/salesforce/salesforce_login/salesforce_login.module
+++ b/salesforce/salesforce_login/salesforce_login.module
@@ -61,7 +61,66 @@ function salesforce_login_pass_validate($form, &$form_state) {
     form_set_value(array('#parents' => array('account')), $account, $form_state);
   }
   else {
-    // @TODO This is where we'll look in salesforce for a corresponding contact.
-    form_set_error('name', t('Sorry, %name is not recognized as a user name or an e-mail address.', array('%name' => $name)));
+    $contacts = salesforce_login_get_contacts_by_email($name);
+    $contacts_count = count($contacts);
+    if ($contacts_count == 0) {
+      form_set_error('name', variable_get('salesforce_login_no_contact_found_error'));
+    }
+    elseif ($contacts_count == 1) {
+      $account = salesforce_login_user_save($name, $contacts);
+      if ($account) {
+        $form_state['values']['account'] = $account;
+      }
+      else {
+        form_set_error('name', t('There was a problem creating your account.'));
+      }
+    }
+    elseif ($contacts_count > 1) {
+      form_set_error('name', variable_get('salesforce_login_multiple_contacts_error'));
+    }
   }
+}
+
+/**
+ * Creates Drupal user from returned Salesforce Contact.
+ */
+function salesforce_login_user_save($mail, $contact) {
+  $account = new stdClass();
+  $account->is_new = TRUE;
+  // @TODO How are we going to handle user names?
+  $account->name = $mail;
+  $account->mail = $mail;
+  $account->status = TRUE;
+  // @TODO Handle saving user profile fields.
+  return user_save($account);
+}
+/**
+ * Helper function that queries Salesforce for Contact by email address.
+ *
+ * @param string $email
+ *   Email address to be queried for in Salesforce.
+ *
+ * @return array
+ *   Returns array of Salesforce Objects containing all fields mapped in the
+ *   user_to_contact record of the salesforce_mapping module.
+ */
+function salesforce_login_get_contacts_by_email($email) {
+  // Find the Salesforce fields that map to Drupal user fields so we can return
+  // them all in the query.
+  $user_to_contact_mapping = salesforce_mapping_load('user_to_contact');
+  $salesforce_fields = array();
+  foreach ($user_to_contact_mapping->field_mappings as $mapping) {
+    if ($mapping['direction'] == 'sf_drupal') {
+      $salesforce_fields[] = $mapping['salesforce_field']['name'];
+      // Find the Salesforce field mapps to the Drupal's user's mail field.
+      if ($mapping['drupal_field']['fieldmap_value'] == 'mail') {
+        $salesforce_mail_field = $mapping['salesforce_field']['name'];
+      }
+    }
+  }
+  // Query Salesforce.
+  $sfapi = salesforce_get_api();
+  $soap = new SalesforceSoapPartner($sfapi);
+  $salesforce_sync = new SalesforceSync($sfapi, $soap);
+  return $salesforce_sync->fetchByField('Contact', $salesforce_fields, $salesforce_mail_field, array($email));
 }

--- a/secure_prepopulate/springboard_cookie/springboard_cookie.module
+++ b/secure_prepopulate/springboard_cookie/springboard_cookie.module
@@ -34,8 +34,17 @@ function springboard_cookie_init() {
       // Quietly create a user account for this email, if there isn't one already.
       $account = user_load_by_mail($email);
       if (!$account) {
+          if (module_exists('email_registration')) {
+            // Strip off everything after the @ sign.
+            $name = preg_replace('/@.*$/', '', $name);
+            $name = email_registration_cleanup_username($name);
+            $name = email_registration_unique_username($name);
+          }
+          else {
+            $name = $email;
+          }
         $user_fields = array(
-          'name' => $email,
+          'name' => $name,
           'mail' => $email,
           'init' => $email,
           'pass' => user_password(8),

--- a/webform_user/includes/webform_user.drush.inc
+++ b/webform_user/includes/webform_user.drush.inc
@@ -111,6 +111,15 @@ function webform_user_create_missing_users_batch_process($chunk, $node_id, $oper
     // Remove empty string values from submission to avoid datatype exceptions.
     $submission = array_filter($submission, 'strlen');
     if (empty($account)) {
+        if (module_exists('email_registration')) {
+          // Strip off everything after the @ sign.
+          $name = preg_replace('/@.*$/', '', $submission['mail']);
+          $name = email_registration_cleanup_username($name);
+          $name = email_registration_unique_username($name);
+        }
+        else {
+          $name = $submission['mail'];
+        }
       $user_fields = array(
         'name' => $submission['mail'],
         'mail' => $submission['mail'],

--- a/webform_user/webform_user.module
+++ b/webform_user/webform_user.module
@@ -573,9 +573,20 @@ function webform_user_webform_submit($form, &$form_state) {
     }
     // Anonymous user, new email to Drupal.
     elseif ($form_state['redirect']) {
+      if (module_exists('email_registration')) {
+        // Strip off everything after the @ sign.
+        $name = preg_replace('/@.*$/', '', $fields['mail']);
+        $name = email_registration_cleanup_username($name);
+        $name = email_registration_unique_username($name);
+      }
+      else {
+        // If email_registration is not enabled, fall back to using email for
+        // the drupal username.
+        $name = $fields['mail'];
+      }
       $account = new stdClass();
       $account->is_new = TRUE;
-      $account->name = $fields['mail'];
+      $account->name = $name;
       $account->status = TRUE;
       // Create the new user account.
       $account = _webform_user_save_profile_map($account, $map);


### PR DESCRIPTION
This module allows users that have a Salesforce Contact record but not a Drupal user account to login into Drupal by querying Salesforce.

There are several places in Springboard (webform_user.module, webform_user.drush.inc, and springboard_cookie.module) that create users with a username that equals the email address. This poses a problem for some users because their email addresses have characters that are not allowed in Drupal user names. When this module is enabled, email addresses will be "sanitized" and the result used as the Drupal username. Using the module email_registration, users can then login using either their Drupal username OR email address.

For example sam+bingo@gmail.com will end up with a username of "sambingo". Or, if "sambingo1" if the former is already taken.

Note that webform_user.module, webform_user.drush.inc, and springboard_cookie.module have all been altered to *optionally* support the sanitizing functions from email_registration.module so that username are created consistently once it is enabled.