### PR TITLE
Springboard API extension for Advocacy message actions

### DIFF
--- a/springboard_api/resources/springboard_api.form_resources.inc
+++ b/springboard_api/resources/springboard_api.form_resources.inc
@@ -71,9 +71,18 @@ function springboard_api_form_action_submit($nid, $app_id = NULL, $submission = 
     $node = node_load($nid);
     // Typecast in case the submission was JSON encoded as an object.
     $submission = (array) $submission;
+    // If we have an advocacy type, handle non-webform fields.
+    if (module_exists('springboard_advocacy')) {
+      if (springboard_advocacy_is_action_type($node->type)) {
+        $action_submission = _springboard_api_convert_action_submission($submission, $node);
+        if (is_array($action_submission) && !empty($action_submission)) {
+          $action_type = TRUE;	
+        }
+      }
+    }
+    
     // Convert submission values to nested array.
     $submission = _springboard_api_convert_submission($submission, $node);
-
     // The op value must match the configured submit_text value.
     $submit_text = empty($node->webform['submit_text']) ? t('Submit') : t($node->webform['submit_text']);
 
@@ -92,6 +101,10 @@ function springboard_api_form_action_submit($nid, $app_id = NULL, $submission = 
       ),
       'values' => array(),
     );
+    if ($action_type === TRUE) {
+      // Merge in any submitted advocacy fields.
+      $form_state['values'] += $action_submission;
+    }
     $form_state['clicked_button']['#parents'] = NULL;
     $form_state['values']['submitted'] = springboard_api_submission_tree_build($submission, $node->webform['components'], $tree, 0);
     $webform_submission = array(
@@ -117,7 +130,7 @@ function springboard_api_form_action_submit($nid, $app_id = NULL, $submission = 
       }
     }
     drupal_form_submit($form_id, $form_state, $node, (object)$webform_submission);
-    // Taken from node_resources.inc, if errors are encountered during form
+    
     // submission we return a 406 HTTP response code and any errors encountered.
     if ($errors = form_get_errors()) {
       // Strip down error keys to form key.
@@ -128,7 +141,13 @@ function springboard_api_form_action_submit($nid, $app_id = NULL, $submission = 
       // Since $form_state is passed by reference, we have full access to all
       // of the additional data that Webform and Fundraiser have added.
       $sid = $form_state['values']['details']['sid'];
-      return array('status' => t('Submission successful'), 'submission id' => $sid);
+      $response = array(
+        'status' => t('Submission successful'),
+        'submission_id' => $sid,
+      );
+      // Allow other modules to alter the response.
+      drupal_alter('springboard_api_response', $response);
+      return array($response);
     }
   }
 }

--- a/springboard_api/springboard_api.module
+++ b/springboard_api/springboard_api.module
@@ -349,6 +349,12 @@ function springboard_api_get_form_details($nid) {
       'fields' => array(),
       'token' => drupal_get_token('services'),
     );
+    // Handle advocacy fields if enabled.
+    if (module_exists('springboard_advocacy')) {
+      if (springboard_advocacy_is_action_type($node->type)) {
+        springboard_api_get_action_form_details($node, $form_details);
+      }
+    }
     // Build form field list.
     foreach ($node->webform['components'] as $cid => $component) {
       // Skip fieldsets.
@@ -387,6 +393,64 @@ function springboard_api_get_form_details($nid) {
   }
   else {
     return FALSE;
+  }
+}
+
+/**
+ * Get form node & field information for a requested advocacy form.
+ */
+function springboard_api_get_action_form_details($node, &$form_details) {
+  switch ($node->type) {
+    case 'sba_message_action':
+      $form = array(
+        '#node' => $node,
+      );
+      // Add fields from springboard_advocacy_form_alter().
+      if (!empty($node->message_ids)) {
+        $form['messages'] = array();
+        $form['messages']['#tree'] = TRUE;
+        foreach ($node->message_ids as $id) {
+          $form['messages'][$id] = array(
+              '#type' => 'hidden',
+              '#value' => $id,
+          );
+        }
+      } 
+      $form['advocacy_id'] = array('#type' => 'hidden', '#value' => $node->advocacy_id);
+      // Pass-thru to populate advocacy fields.
+      module_load_include('inc', 'sba_message_action', 'includes/sba_message_action.form');
+      sba_message_action_additional_elements($form, $form_state);
+      
+      // If this is a single step, check for editable message subject or body.
+      if (isset($form['sba_messages']['single_not_multi_flow'])) {
+        // Subject or body editable and required?
+        $message = current($form['sba_messages']['message']);
+        $message_id = $message['sba_message_id']['#value'];
+        $message = &$form['sba_messages']['message'][$message_id];
+        // Denote the actual subject and edit_body fields as required in the form details. 
+        if (isset($message['subject_required'])) {
+          $message['subject']['#required'] = $message['subject_required']['#value'];
+        }
+        if (isset($message['body_required'])) {
+          $message['edited_body']['#required'] = $message['body_required']['#value'];
+        }
+        if ($message['edited_body']['#required'] || $message['subject']['#required']) {
+          // If subject or body is required, mark their containers required.
+          $form['sba_messages']['#required'] = TRUE;
+          $form['sba_messages']['message']['#required'] = TRUE;
+        }
+      }
+      // Parse the form built by advocacy.
+      foreach (element_children($form) as $key) {
+        // Skip fieldsets & markup.
+        if (isset($form[$key]['#type']) && ($form[$key]['#type'] == 'fieldset' || $form[$key]['#type'] == 'markup')) {
+          continue;
+        }
+        $save = &$form_details['fields'][$key];
+        $fapi = $form[$key];
+        _springboard_api_parse_component_fapi($save, $fapi);
+      }
+      break;
   }
 }
 
@@ -444,7 +508,7 @@ function _springboard_api_parse_component_fapi(&$save, $fapi, $component_type = 
  */
 function _springboard_api_convert_submission($submission, $node) {
   $converted_submission = array();
-
+  
   foreach ($node->webform['components'] as $cid => $component) {
     $form_key = $component['form_key'];
     // Skip fieldsets & markup.
@@ -504,14 +568,33 @@ function _springboard_api_convert_fapi(&$converted_submission, $fapi, $submissio
 }
 
 /**
- * Unpack webform component "extra" data.
+ * Convert submission flat array to nested array.
  *
- * @param string $items
- *   Raw "extra" string.
+ * @param array $submission
+ *   Associative array of field keys and submitted values.
  *
- * @return mixed
- *   Returns unpacked array of data.
+ * @param mixed $node
+ *   Webform node the data will be submitted to.
+ *
+ * @return array
+ *   Returns a nested array of submission values formatted for consumption by
+ *   the submit endpoint.
  */
+function _springboard_api_convert_action_submission($submission, $node) {
+  $converted_submission = array();
+  switch ($node->type) {
+    case 'sba_message_action':
+      $keys = array('advocacy_id', 'message_ids', 'messages', 'sba_messages');
+      foreach ($keys as $key) {
+        if (isset($submission[$key])) {
+          $converted_submission[$key] = $submission[$key];
+        }
+      }
+      break;
+  }
+  return $converted_submission;
+}
+  
 function _springboard_api_parse_extra_items($items) {
   $parts = explode("\n", $items);
   foreach ($parts as $part) {
@@ -573,4 +656,24 @@ function springboard_api_log_service_usage($op, $access, $data = NULL, $api_key 
  */
 function _springboard_api_is_secure() {
   return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? TRUE : FALSE;
+}
+
+/**
+ * Implements hook_springboard_api_response_alter().
+ * TODO: Move this somewhere else, 
+ */
+function springboard_api_springboard_api_response_alter(&$response) {
+  // If advocacy is enabled, check for transaction server response in session.
+  if (module_exists('springboard_advocacy')) {
+    $delivered_html = theme('webform_confirmations_delivered', $_SESSION['delivered_messages']);
+    $undelivered_html = theme('webform_confirmations_undelivered', $_SESSION['undelivered_messages']);
+    // Add the transaction server results to the response to the client.
+    $data = array(
+      'confirmations_delivered' => $delivered_html,
+      'confirmations_undelivered' => $undelivered_html,
+      'raw_confirmations_delivered' => $_SESSION['delivered_messages'],
+      'raw_confirmations_undelivered' => $_SESSION['undelivered_messages'],
+    );
+    $response['data'] = $data;
+  }
 }


### PR DESCRIPTION
Add handling for Advocacy message actions (single-step) to springboard API.
Modify springboard api to handle non-webform fields.
Alter output returned from API server if advocacy is enabled to include transaction server response.