### PR TITLE
move action node form submit logic to helper function and insert hook

### DIFF
--- a/springboard_advocacy/modules/sba_message_action/sba_message_action.module
+++ b/springboard_advocacy/modules/sba_message_action/sba_message_action.module
@@ -250,6 +250,7 @@ function sba_message_action_node_insert($node) {
         drupal_write_record('sba_message_action_confirm', $record);
       }
     }
+    springboard_advocacy_node_form_post_save($node);
   }
 }
 
@@ -259,6 +260,7 @@ function sba_message_action_node_insert($node) {
 function sba_message_action_node_update($node) {
   if ($node->type == 'sba_message_action') {
     sba_message_action_update_multiflow_component($node);
+    springboard_advocacy_node_form_post_save($node);
   }
 }
 
@@ -673,9 +675,7 @@ function sba_message_action_form_sba_message_action_node_form_alter(&$form, &$fo
     '#weight' => -4,
   );
 
-  $form['actions']['submit']['#validate'][] = 'sba_message_action_form_sba_message_action_node_form_validate';
-  $form['actions']['submit']['#submit'][] = 'sba_message_action_form_sba_message_action_node_form_submit';
-
+  $form['#validate'][] = 'sba_message_action_form_sba_message_action_node_form_validate';
 }
 
 /**
@@ -710,39 +710,6 @@ function sba_message_action_form_sba_message_action_node_form_validate(&$form, &
     }
   }
 }
-
-/**
- * Redirect to the messages tab instead of webform tab.
- *
- * @param $form
- * @param $form_state
- */
-function sba_message_action_form_sba_message_action_node_form_submit(&$form, &$form_state) {
-  $data = array(
-    'nid' => $form_state['values']['nid'],
-    'visibility' => $form_state['values']['show_participants']
-  );
-  $visibility = db_query('select visibility from {springboard_action_opt_in_block} WHERE nid=:nid', array(':nid' => $form_state['values']['nid']))->fetchCol();
-  if (empty($visibility)) {
-    drupal_write_record('springboard_action_opt_in_block', $data);
-  }
-  else {
-    drupal_write_record('springboard_action_opt_in_block', $data, 'nid');
-  }
-
-  $submit = array(
-    'nid' => $form_state['values']['nid'],
-    'submit_text' => $form_state['values']['action_submit_button_text']
-  );
-
-  drupal_write_record('webform', $submit, 'nid');
-
-  if (empty($form['#node']->nid)) {
-    $path = 'node/'.$form_state['nid'].'/messages';
-    $form_state['redirect'] = $path;
-  }
-}
-
 
 /**
  * Implements hook_FORMID_form_alter().

--- a/springboard_advocacy/modules/sba_social_action/sba_social_action.module
+++ b/springboard_advocacy/modules/sba_social_action/sba_social_action.module
@@ -265,6 +265,17 @@ function sba_social_action_node_insert($node) {
   if ($node->type == 'sba_social_action') {
     module_load_include('inc', 'sba_social_action', 'includes/sba_social_action.components');
     sba_social_action_insert_components($node);
+    springboard_advocacy_node_form_post_save($node);
+  }
+}
+
+
+/**
+ * Implements hook_node_update().
+ */
+function sba_social_action_node_update($node) {
+  if ($node->type == 'sba_social_action') {
+    springboard_advocacy_node_form_post_save($node);
   }
 }
 
@@ -455,8 +466,6 @@ function sba_social_action_form_sba_social_action_node_form_alter(&$form, &$form
     '#weight' => -4,
   );
   $form['#attached']['css'][] = drupal_get_path('module', 'sba_social_action') . '/css/sba-social-node-form.css';
-  $form['actions']['submit']['#validate'][] = 'sba_social_action_form_sba_social_action_node_form_validate';
-  $form['actions']['submit']['#submit'][] = 'sba_social_action_form_sba_social_action_node_form_submit';
 
   // Hide field_sba_social_require_auth field if twitter configuration is not
   // complete at admin/config/services/advocacy.
@@ -467,56 +476,6 @@ function sba_social_action_form_sba_social_action_node_form_alter(&$form, &$form
     $form['field_sba_social_require_auth'][LANGUAGE_NONE]['#default_value'][0] = 0;
   }
 }
-
-/**
- * Force test mode on unpublished actions.
- *
- * @param $form
- * @param $form_state
- */
-function sba_social_action_form_sba_social_action_node_form_validate(&$form, &$form_state) {
-
-  // Require test_mode_email if test_mode is checked.
-//  $lang = $form['field_sba_test_mode']['#language'];
-//
-//  if ($form_state['values']['field_sba_test_mode'][$lang][0]['value'] == 0) {
-//    if ($form_state['values']['status'] == 0) {
-//      form_set_error("field_sba_test_mode", t('Test mode must be enabled for unpublished actions.'));
-//    }
-//  }
-}
-
-/**
- * Redirect to the messages tab instead of webform tab.
- *
- * @param $form
- * @param $form_state
- */
-function sba_social_action_form_sba_social_action_node_form_submit(&$form, &$form_state) {
-  $data = array(
-    'nid' => $form_state['values']['nid'],
-    'visibility' => $form_state['values']['show_participants']
-  );
-  $visibility = db_query('select visibility from {springboard_action_opt_in_block} WHERE nid=:nid', array(':nid' => $form_state['values']['nid']))->fetchCol();
-  if (empty($visibility)) {
-    drupal_write_record('springboard_action_opt_in_block', $data);
-  }
-  else {
-    drupal_write_record('springboard_action_opt_in_block', $data, 'nid');
-  }
-  $submit = array(
-    'nid' => $form_state['values']['nid'],
-    'submit_text' => $form_state['values']['social_submit_button_text']
-  );
-
-  drupal_write_record('webform', $submit, 'nid');
-
-  if (empty($form['#node']->nid)) {
-    $path = 'node/'.$form_state['nid'].'/messages';
-    $form_state['redirect'] = $path;
-  }
-}
-
 
 /**
  * Build redirect for multi-step form.

--- a/springboard_advocacy/springboard_advocacy.module
+++ b/springboard_advocacy/springboard_advocacy.module
@@ -1005,7 +1005,7 @@ function springboard_advocacy_node_form_post_save($node) {
     drupal_write_record('webform', $submit, 'nid');
   }
 
-  if (empty($node->is_new)) {
+  if (!empty($node->is_new)) {
     $path = 'node/' . $node->nid . '/messages';
     $form_state['redirect'] = $path;
   }

--- a/springboard_advocacy/springboard_advocacy.module
+++ b/springboard_advocacy/springboard_advocacy.module
@@ -343,7 +343,6 @@ function springboard_advocacy_views_api() {
        }
      }
    }
-
  }
 
 
@@ -976,4 +975,38 @@ function springboard_advocacy_update_multistep_components($sid, $node, $changed)
  */
 function springboard_advocacy_success($node, $contact, $data, $sid) {
   module_invoke_all('action_success', $node, $contact, $data, $sid);
+}
+
+
+function springboard_advocacy_node_form_post_save($node) {
+  if (!empty($node->show_my_name)) {
+    $data = array(
+      'nid' => $node->nid,
+      'visibility' => $node->show_my_name,
+    );
+
+    $visibility = db_query('select visibility from {springboard_action_opt_in_block} WHERE nid=:nid', array(':nid' => $node->nid))->fetchCol();
+
+    if (empty($visibility)) {
+      drupal_write_record('springboard_action_opt_in_block', $data);
+    }
+    else {
+      drupal_write_record('springboard_action_opt_in_block', $data, 'nid');
+    }
+  }
+
+  if (!empty($node->action_submit_button_text) || !empty($node->social_submit_button_text)) {
+    $text = empty($node->action_submit_button_text) ? $node->social_submit_button_text : $node->action_submit_button_text;
+    $submit = array(
+      'nid' => $node->nid,
+      'submit_text' => $text,
+    );
+
+    drupal_write_record('webform', $submit, 'nid');
+  }
+
+  if (empty($node->is_new)) {
+    $path = 'node/' . $node->nid . '/messages';
+    $form_state['redirect'] = $path;
+  }
 }


### PR DESCRIPTION
The node form submit and validate hooks on message and social actions we're improperly assigned to the submit button, which would cause Drupal to ignore any other custom validate and submit hooks defined elsewhere for those forms. Move the submit logic to a helper function called from hook_node_insert() and hook_node_update()

https://github.com/JacksonRiver/springboard_modules/pull/1154 won't work without this.
