### PR TITLE
Remove errant comment in Litle module

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle.inc
@@ -514,7 +514,7 @@ function commerce_litle_fundraiser_commerce_cardonfile($donation) {
 
     // If we have a profile for this user update it locally.
     if ($card_data) {
-      // Make the update request to authorize.net
+      // Make a card update request to Litle.
       commerce_litle_fundraiser_commerce_update($donation, $card_data);
     }
   }


### PR DESCRIPTION
It seems like the comment on line 517, before a call to commerce_litle_fundraiser_commerce_update, is written in error: it references authorize.net. I've updated that comment in this PR.