### PR TITLE
re #1193 - add support for authnet echeck.net

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -2668,6 +2668,7 @@ function fundraiser_commerce_commerce_authnet_cim_request_alter($api_request_ele
     $config = $donation->gateway['gateway_details']['settings'];
     $extra = (string) $api_request_element->extraOptions;
     $extra = substr($extra, 9, -3);
+    module_load_include('inc', 'fundraiser_commerce', 'gateways/commerce_authnet');
     $fields = _commerce_authnet_extra_fields();
     unset($fields[0]);
     $i = 1;

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
@@ -11,11 +11,15 @@
 function commerce_authnet_echeck_fundraiser_commerce_fundraiser_gateway_info() {
   return array(
     'payment_method' => array('bank account'),
+    'allow_recurring' => array('bank account'),
     'form callback' => 'commerce_authnet_echeck_fundraiser_commerce_submit_form',
     'cleanup callback' => 'commerce_authnet_echeck_fundraiser_commerce_cleanup',
     'scrub callback' => 'commerce_authnet_echeck_fundraiser_commerce_scrub',
     'validate callback' => 'commerce_authnet_echeck_fundraiser_commerce_validate',
+    'expire callback' => 'commerce_authnet_echeck_fundraiser_commerce_expire',
     'charge callback' => 'commerce_authnet_echeck_fundraiser_commerce_charge',
+    'update callback' => 'commerce_authnet_echeck_fundraiser_commerce_update',
+    'cardonfile callback' => 'commerce_authnet_echeck_fundraiser_commerce_cardonfile',
   );
 }
 
@@ -53,10 +57,9 @@ function commerce_authnet_echeck_fundraiser_gateway_status_cron_check($details) 
  * @param array $config
  *   Configuration options for this field.
  */
-function commerce_authnet_echeck_fundraiser_commerce_submit_form($payment_method, $config) {
+function commerce_authnet_echeck_fundraiser_commerce_submit_form($payment_method) {
   module_load_include('inc', 'commerce_authnet_echeck', 'includes/commerce_authnet_echeck.echeck');
-  $method_instance = commerce_payment_method_instance_load($config['id']);
-  $form = commerce_authnet_echeck_submit_form($method_instance);
+  $form = commerce_authnet_echeck_submit_form($payment_method);
   // Remove the required flag for the fields
   foreach (element_children($form['bank account']) as $field_name) {
     $form['bank account'][$field_name]['#required'] = FALSE;
@@ -103,15 +106,18 @@ function commerce_authnet_echeck_fundraiser_commerce_validate($submission_fields
  *   Whether the charge was successful.
  */
 function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $donation) {
+  module_load_include('inc', 'commerce_authnet_echeck', 'includes/commerce_authnet_echeck.echeck');
   // Translate from donation settings to the correct values for the plugin.
   $order = commerce_order_load($donation->did);
   $wrapper = entity_metadata_wrapper('commerce_order', $order);
   $charge = $wrapper->commerce_order_total->value();
   // Not actually used anywhere in this system, so ignore it.
   $pane_form = array();
-  $pane_values = array(
-    'bank account' => $donation->donation['payment_fields']['bank account']
-  );
+  $pane_values = commerce_authnet_echeck_pane_values($donation);
+
+  // Add fundraiser commerce data to the pane values array.
+  _fundraiser_commerce_submit_handler_pane_values($pane_values, $donation, 'bank account');
+
   // Execute call to Authnet, only returns FALSE if the payment failed,
   // returns nothing if successful.
   $success = FALSE;
@@ -119,6 +125,382 @@ function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $d
   if ($result !== FALSE) {
     $success = TRUE;
   }
+
+  if ($success == TRUE) {
+    // Update expiration date and generate the next donation.
+    $donation = fundraiser_donation_get_donation($donation->did);
+    $card_data = commerce_cardonfile_load($pane_values['cardonfile']);
+
+    if (!empty($card_data)) {
+      // If the next recurring series entry doesn't exist, create one.
+      if (($donation->status <> 'failed') && _fundraiser_sustainers_count_donations_recurr_remaining($donation->recurring->master_did) < 1) {
+
+        // Move card expiration date ahead one month.
+        $new_expire_time = mktime(0, 0, 0, ($card_data->card_exp_month + 1), 1, $card_data->card_exp_year);
+
+        $card_data->card_exp_month = date('m', $new_expire_time);
+        $card_data->card_exp_year = date('Y', $new_expire_time);
+
+        $master_donation = fundraiser_donation_get_donation($donation->recurring->master_did);
+        // Update card using master donation so transaction ID is available.
+        commerce_paywithmybank_fundraiser_commerce_update($master_donation, $card_data);
+
+        $submission_fields = array(
+          'payment_fields' => array(
+            'bank account' => array(
+              'card_expiration_month' => $card_data->card_exp_month,
+              'card_expiration_year' => $card_data->card_exp_year,
+            ),
+          ),
+        );
+        fundraiser_sustainers_update_billing_info_create_new_donations($master_donation, $donation, $submission_fields);
+      }
+    }
+  }
+
   return $success;
 }
 
+
+/**
+ * Card on file callback
+ *
+ * We use a custom callback since we may need to update an existing CIM profile
+ */
+function commerce_authnet_echeck_fundraiser_commerce_cardonfile($donation) {
+  $cardonfile_fields = commerce_authnet_echeck_cardonfile_fields($donation);
+
+  return $cardonfile_fields;
+}
+
+/**
+ * Expiration date callback.
+ */
+function commerce_authnet_echeck_fundraiser_commerce_expire($submission_fields) {
+  $expires = array();
+
+  $expire_time = strtotime("now + 1 month");
+
+  $expires['month'] = date('m', $expire_time);
+  $expires['year'] = date('Y', $expire_time);
+
+  return $expires;
+}
+
+/**
+ * Callback function, update card data stored at the gateway and locally
+ *
+ * @param $donation Object
+ *    Fundraiser commerce donation object which should include the new/updated card data
+ * @param $card_data Object
+ *    Card on file entity, this should be the current entity for the donation,
+ *    new data should be passed in the donation object
+ *
+ * @return Object
+ *    Card on file entity for the new/updated card data
+ */
+function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_data = NULL) {
+  $payment_method = $donation->gateway['gateway_details'];
+
+  // If no card data was passed load the profile from the donation if its set
+  if (empty($card_data) && !empty($donation->data['cardonfile'])) {
+    $card_data = commerce_cardonfile_load($donation->data['cardonfile']);
+  }
+
+  if (empty($card_data)) {
+    // Log the missing card data
+    watchdog(
+      'fundraiser',
+      'A card update was attempted on donation @id but no stored card data was found.',
+      array('@id' => $donation->did),
+      WATCHDOG_CRITICAL
+    );
+
+    return;
+  }
+
+  // Pull the new credit card values from the donation
+  $pane_values = commerce_authnet_echeck_pane_values($donation);
+
+  // Load the card on file values for this donation
+  $cardonfile_fields = _fundraiser_commerce_credit_card_cardonfile_fields($donation);
+
+  // Get card expiration date.
+  $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
+
+  // Check the card number to see if it matches the current card data number
+  // If it does then we use the update function
+  // if its a new card check if we should create a new CIM profile
+  $action = 'update';
+  if ($cardonfile_fields['card_number'] != $card_data->card_number) {
+    // This is a new card for this donation, make sure we don't have an existing profile
+    // First check with the card number and date
+    if ($existing = _fundraiser_commerce_cardonfile_match($cardonfile_fields)) {
+      // Set the existing card on the donation and return it
+      $donation->data['cardonfile'] = $existing->card_id;
+      $card_data = $existing;
+    }
+    // Check if we have a mismatched exp date record
+    elseif ($mismatch =  _fundraiser_commerce_cardonfile_exp_date_mismatch($cardonfile_fields)) {
+      $donation->data['cardonfile'] = $mismatch->card_id;
+      $card_data = $mismatch;
+    }
+    // Nothing stored locally so create a new profile
+    else {
+      $action = 'new';
+    }
+  }
+  if ($action == 'update') {
+    $card_data->card_number = $cardonfile_fields['card_number'];
+
+    // We're mirroring the commerce_authnet_cim_cardonfile_update function so setup values that function uses, see that function for details
+    $form['bank account']['number']['#default_value'] = '';
+    $form_state['values']['bank account']['number'] = $pane_values['bank account']['acct_num'];
+    $form_state['values']['bank account']['owner'] = isset($donation->donation['first_name']) ? $donation->donation['first_name'] : '';
+    $form_state['values']['bank account']['owner'] .= isset($donation->donation['last_name']) ? ' ' . $donation->donation['last_name'] : '';
+    $form_state['values']['bank account']['address'] = isset($donation->donation['address']) ? $donation->donation['address'] : '';
+    $form_state['values']['bank account']['address'] .= isset($donation->donation['address_line_2']) ? ' ' . $donation->donation['address_line_2'] : '';
+    $form_state['values']['bank account']['city'] = isset($donation->donation['city']) ? $donation->donation['city'] : '';
+    $form_state['values']['bank account']['state'] = isset($donation->donation['state']) ? $donation->donation['state'] : '';
+    $form_state['values']['bank account']['zip'] = isset($donation->donation['zip']) ? $donation->donation['zip'] : '';
+    $form_state['values']['bank account']['country'] = isset($donation->donation['country']) ? $donation->donation['country'] : '';
+
+    $response = _commerce_authnet_echeck_fundraiser_commerce_authnet_cim_cardonfile_update($form, $form_state, $payment_method, $card_data);
+
+    if ($response) {
+      commerce_cardonfile_save($card_data);
+      return $card_data;
+    }
+  }
+  // Create a new card on file record
+  elseif ($action == 'new') {
+    // We're using the built in function that requires a payment details array and the order
+    $payment_details = array(
+      'routingNumber' => $pane_values['bank account']['aba_code'],
+      'accountNumber' => $pane_values['bank account']['acct_num'],
+      'nameOnAccount' => $pane_values['bank account']['acct_name']
+    );
+
+    // Load the order
+    $order = commerce_order_load($donation->did);
+    $response = commerce_authnet_echeck_cim_create_customer_profile_request($payment_method, $order, $payment_details);
+
+    // If the Customer Profile creation was a success, store the new card on file data locally.
+    if ($response && (string) $response->messages->resultCode == 'Ok') {
+      // Build a remote ID that includes the Customer Profile ID and the
+      // Payment Profile ID.
+      $remote_id = (string) $response->customerProfileId . '|' . (string) $response->customerPaymentProfileIdList->numericString;
+
+      // Get the card type
+      $card_type = commerce_payment_validate_credit_card_type($pane_values['credit_card']['number'], array_keys(commerce_payment_credit_card_types()));
+      $all_types = commerce_payment_credit_card_types();
+      $card_type = !empty($all_types[$card_type]) ? $all_types[$card_type] : 'card';
+
+      // Create a new cardonfile entity
+      $new_data = commerce_cardonfile_new();
+      $new_data->uid = $order->uid;
+      $new_data->payment_method = $payment_method['method_id'];
+      $new_data->instance_id = $payment_method['instance_id'];
+      $new_data->remote_id = $remote_id;
+      $new_data->card_type = $card_type;
+      $new_data->card_name = !empty($card_data->card_name) ? $card_data->card_name : '';
+      $new_data->card_number = $cardonfile_fields['card_number'];
+      $new_data->card_exp_month = $expires['month'];
+      $new_data->card_exp_year = $expires['year'];
+      $new_data->status = 1;
+
+      // Save and log the creation of the new card on file.
+      commerce_cardonfile_save($new_data);
+      // Set the value on the donation
+      $donation->data['cardonfile'] = $new_data->card_id;
+      watchdog('commerce_authnet', 'CIM Customer Profile @profile_id created and saved to user @uid.', array('@profile_id' => (string) $response->customerProfileId, '@uid' => $order->uid));
+      return $new_data;
+    }
+  }
+}
+
+/**
+ * COPY: commerce_authnet_cim_cardonfile_update
+ * Card on file callback: updates the associated customer payment profile.
+ *
+ * The original function at commerce_authnet_cim_cardonfile_update(), doesn't update the user
+ * address fields - instead referencing the cim values saved, so not even updating the customer profile
+ * in advance would do it. So we need to copy this over and make the changes we need for fall through.
+ */
+function _commerce_authnet_echeck_fundraiser_commerce_authnet_cim_cardonfile_update($form, &$form_state, $payment_method, $card_data) {
+  // Extract the Customer Profile and Payment Profile IDs from the remote_id.
+  list($cim_customer_profile_id, $cim_payment_profile_id) = explode('|', $card_data->remote_id);
+
+  if ($form_state['values']['bank account']['acct_num'] != $form['bank account']['acct_num']['#default_value']) {
+    $number = $form_state['values']['bank account']['acct_num'];
+  }
+  else {
+    $number = 'XXXX' . $card_data->card_number;
+  }
+
+  // Load the payment profile so that billTo can be updated.
+  $payment_profile_xml = commerce_authnet_cim_get_customer_payment_profile_request($payment_method, $cim_customer_profile_id, $cim_payment_profile_id);
+  $billto = $payment_profile_xml->paymentProfile->billTo;
+  $first_name = (string) $billto->firstName;
+  $last_name = (string) $billto->lastName;
+  $address = (string) $billto->address;
+  $city = (string) $billto->city;
+  $state = (string) $billto->state;
+  $zip = (string) $billto->zip;
+  $country = (string) $billto->country;
+
+  // Extract the first and last name from form values.
+  if (!empty($form_state['values']['bank account']['owner'])) {
+    $name_parts = explode(' ', $form_state['values']['bank account']['owner']);
+    $first_name = array_shift($name_parts);
+    $last_name = implode(' ', $name_parts);
+    $address = $form_state['values']['bank account']['address'];
+    $city = $form_state['values']['bank account']['city'];
+    $state = $form_state['values']['bank account']['state'];
+    $zip = $form_state['values']['bank account']['zip'];
+    $country = $form_state['values']['bank account']['country'];
+  }
+
+  // Build the base profile update data.
+  $api_request_data = array(
+    'customerProfileId' => $cim_customer_profile_id,
+    'paymentProfile' => array(
+      'billTo' => array(
+        'firstName' => substr($first_name, 0, 50),
+        'lastName' => substr($last_name, 0, 50),
+        'company' => (string) $billto->company,
+        'address' => $address,
+        'city' => $city,
+        'state' => $state,
+        'zip' => $zip,
+        'country' => $country,
+      ),
+      'payment' => array(
+        'bankAccount' => array(
+          'accountNumber' => $number
+        ),
+      ),
+      'customerPaymentProfileId' => $cim_payment_profile_id,
+    ),
+  );
+  // Fetch the response from the API server and let Card on File know if the update was successful.
+  $xml_response = commerce_authnet_cim_request($payment_method, 'updateCustomerPaymentProfileRequest', $api_request_data);
+  return (string) $xml_response->messages->message->code == 'I00001';
+}
+
+/**
+ * Get Authorize.net eCheck pane values from a donation.
+ *
+ * @param object $donation
+ *   The donation to grab the pane values from.
+ *
+ * @return array
+ *   The pane values.
+ */
+function commerce_authnet_echeck_pane_values($donation) {
+  $pane_values = array(
+    'bank account' => $donation->donation['payment_fields']['bank account']
+  );
+
+  return $pane_values;
+}
+
+/**
+ * Returns the values need to load a card on file profile for Authnet eCheck.
+ *
+ * @param object $donation
+ *   Fundraiser donation object.
+ *
+ * @return array
+ *   Values ready to be passed into a card on file profile query.
+ */
+function commerce_authnet_echeck_cardonfile_fields($donation) {
+  $pane_values = commerce_authnet_echeck_pane_values($donation);
+
+  $data = array(
+    'card_number' => $pane_values['bank account']['acct_num'],
+  );
+
+  return $data + array('instance_id' => $donation->gateway['id'], 'uid' => $donation->uid);
+}
+
+/**
+ * Submits a createCustomerProfileRequest XML CIM API request to Authorize.Net.
+ *
+ * This function will attempt to create a CIM Customer Profile and a default
+ * Payment Profile for it using the given payment details.
+ *
+ * @param $payment_method
+ *   The payment method instance array containing the API credentials for a CIM
+ *   enabled Authorize.Net account.
+ * @param $order
+ *   The order object containing the billing address and e-mail to use for the
+ *   customer profile.
+ * @param $payment_details
+ *   An array of payment details to use in the default payment profile. See the
+ *   respective helper array functions for possible keys.
+ *
+ * @return
+ *   A SimpleXMLElement containing the API response.
+ *
+ * @see commerce_authnet_cim_credit_card_array()
+ */
+function commerce_authnet_echeck_cim_create_customer_profile_request($payment_method, $order, $payment_details) {
+  $billto = commerce_authnet_cim_billto_array($order);
+
+  // Build the base profile request data.
+  $api_request_data = array(
+    'profile' => array(
+      'merchantCustomerId' => $order->uid,
+      'description' => $billto['firstName'] . ' ' . $billto['lastName'],
+      'email' => $order->mail,
+      'paymentProfiles' => array(
+        'billTo' => $billto,
+        'payment' => array(),
+      ),
+    ),
+  );
+
+  // If the order is anonymous, unset the merchantCustomerId from the request.
+  if (empty($api_request_data['profile']['merchantCustomerId'])) {
+    unset($api_request_data['profile']['merchantCustomerId']);
+  }
+
+  // Add credit card payment details to the default payment profile if given.
+  $bank_account = commerce_authnet_echeck_cim_bank_account_array($payment_details);
+
+  if (!empty($bank_account)) {
+    $api_request_data['profile']['paymentProfiles']['payment']['bankAccount'] = $bank_account;
+  }
+
+  return commerce_authnet_cim_request($payment_method, 'createCustomerProfileRequest', $api_request_data);
+}
+
+/**
+ * Generates a bankAccount array for CIM API requests.
+ *
+ * @param $payment_details
+ *   An array of payment details used in a CIM API request that doesn't have to
+ *   include bank card data. If it does, the following keys are expected:
+ *   - routingNumber: The routing number of the customer’s bank.
+ *   - accountNumber: The customer’s bank account number.
+ *   - nameOnAccount: The customer’s full name as listed on the bank account.
+ *
+ *   The following options are optional and currently not supported:
+ *   - accountType: The type of bank account for the payment profile
+ *   - echeckType: The type of electronic check transaction.
+ *   - bankName: The name of the bank associated with the bank account number.
+ *
+ * @see http://www.authorize.net/content/dam/authorize/documents/CIM_XML_guide.pdf
+ */
+function commerce_authnet_echeck_cim_bank_account_array($payment_details) {
+  $bank_account = array();
+
+  foreach (array('routingNumber', 'accountNumber', 'nameOnAccount') as $key) {
+    if (!empty($payment_details[$key])) {
+      $bank_account[$key] = $payment_details[$key];
+    }
+  }
+
+  return $bank_account;
+}

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
@@ -143,7 +143,7 @@ function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $d
 
         $master_donation = fundraiser_donation_get_donation($donation->recurring->master_did);
         // Update card using master donation so transaction ID is available.
-        commerce_paywithmybank_fundraiser_commerce_update($master_donation, $card_data);
+        commerce_authnet_echeck_fundraiser_commerce_update($master_donation, $card_data);
 
         $submission_fields = array(
           'payment_fields' => array(
@@ -158,6 +158,9 @@ function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $d
     }
   }
 
+  // Perform post processing functions.
+  _fundraiser_commerce_charge_submit_form_process($success, $method_instance, $pane_values, $donation);
+
   return $success;
 }
 
@@ -169,6 +172,21 @@ function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $d
  */
 function commerce_authnet_echeck_fundraiser_commerce_cardonfile($donation) {
   $cardonfile_fields = commerce_authnet_echeck_cardonfile_fields($donation);
+
+  // So we need to search locally to see if we have an existing profile for
+  // a card number.
+  // Only perform this when we're in an active non-reference charge.
+  if (isset($donation->reference_charge) && $donation->reference_charge === FALSE) {
+    // Query the db for an existing record.
+    $card_data = _fundraiser_commerce_cardonfile_match($cardonfile_fields);
+
+    // If we have a profile for this user update it locally.
+    if ($card_data) {
+      // Make the update request to authorize.net
+      commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_data);
+    }
+  }
+
 
   return $cardonfile_fields;
 }
@@ -206,6 +224,9 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
   if (empty($card_data) && !empty($donation->data['cardonfile'])) {
     $card_data = commerce_cardonfile_load($donation->data['cardonfile']);
   }
+  else {
+    // TODO try to load card data
+  }
 
   if (empty($card_data)) {
     // Log the missing card data
@@ -223,7 +244,7 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
   $pane_values = commerce_authnet_echeck_pane_values($donation);
 
   // Load the card on file values for this donation
-  $cardonfile_fields = _fundraiser_commerce_credit_card_cardonfile_fields($donation);
+  $cardonfile_fields = commerce_authnet_echeck_cardonfile_fields($donation);
 
   // Get card expiration date.
   $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
@@ -240,22 +261,21 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
       $donation->data['cardonfile'] = $existing->card_id;
       $card_data = $existing;
     }
-    // Check if we have a mismatched exp date record
-    elseif ($mismatch =  _fundraiser_commerce_cardonfile_exp_date_mismatch($cardonfile_fields)) {
-      $donation->data['cardonfile'] = $mismatch->card_id;
-      $card_data = $mismatch;
-    }
     // Nothing stored locally so create a new profile
     else {
       $action = 'new';
     }
   }
+  else {
+    // If cardonfile matched, set it here
+    $donation->data['cardonfile'] = $card_data->card_id;
+  }
   if ($action == 'update') {
     $card_data->card_number = $cardonfile_fields['card_number'];
 
     // We're mirroring the commerce_authnet_cim_cardonfile_update function so setup values that function uses, see that function for details
-    $form['bank account']['number']['#default_value'] = '';
-    $form_state['values']['bank account']['number'] = $pane_values['bank account']['acct_num'];
+    $form['bank account']['acct_num']['#default_value'] = '';
+    $form_state['values']['bank account']['acct_num'] = $pane_values['bank account']['acct_num'];
     $form_state['values']['bank account']['owner'] = isset($donation->donation['first_name']) ? $donation->donation['first_name'] : '';
     $form_state['values']['bank account']['owner'] .= isset($donation->donation['last_name']) ? ' ' . $donation->donation['last_name'] : '';
     $form_state['values']['bank account']['address'] = isset($donation->donation['address']) ? $donation->donation['address'] : '';
@@ -297,20 +317,20 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
       $card_type = !empty($all_types[$card_type]) ? $all_types[$card_type] : 'card';
 
       // Create a new cardonfile entity
-      $new_data = commerce_cardonfile_new();
-      $new_data->uid = $order->uid;
-      $new_data->payment_method = $payment_method['method_id'];
-      $new_data->instance_id = $payment_method['instance_id'];
-      $new_data->remote_id = $remote_id;
-      $new_data->card_type = $card_type;
-      $new_data->card_name = !empty($card_data->card_name) ? $card_data->card_name : '';
-      $new_data->card_number = $cardonfile_fields['card_number'];
-      $new_data->card_exp_month = $expires['month'];
-      $new_data->card_exp_year = $expires['year'];
-      $new_data->status = 1;
+      $card_data = commerce_cardonfile_new();
+      $card_data->uid = $order->uid;
+      $card_data->payment_method = $payment_method['method_id'];
+      $card_data->instance_id = $payment_method['instance_id'];
+      $card_data->remote_id = $remote_id;
+      $card_data->card_type = $card_type;
+      $card_data->card_name = !empty($card_data->card_name) ? $card_data->card_name : '';
+      $card_data->card_number = $cardonfile_fields['card_number'];
+      $card_data->card_exp_month = $expires['month'];
+      $card_data->card_exp_year = $expires['year'];
+      $card_data->status = 1;
 
       // Save and log the creation of the new card on file.
-      commerce_cardonfile_save($new_data);
+      commerce_cardonfile_save($card_data);
       // Set the value on the donation
       $donation->data['cardonfile'] = $new_data->card_id;
       watchdog('commerce_authnet', 'CIM Customer Profile @profile_id created and saved to user @uid.', array('@profile_id' => (string) $response->customerProfileId, '@uid' => $order->uid));
@@ -418,7 +438,7 @@ function commerce_authnet_echeck_cardonfile_fields($donation) {
   $pane_values = commerce_authnet_echeck_pane_values($donation);
 
   $data = array(
-    'card_number' => $pane_values['bank account']['acct_num'],
+    'card_number' => substr($pane_values['bank account']['acct_num'], -3),
   );
 
   return $data + array('instance_id' => $donation->gateway['id'], 'uid' => $donation->uid);

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
@@ -126,6 +126,9 @@ function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $d
     $success = TRUE;
   }
 
+  // Perform post processing functions.
+  _fundraiser_commerce_charge_submit_form_process($success, $method_instance, $pane_values, $donation, 'bank account');
+
   if ($success == TRUE && isset($donation->recurring) && !empty($donation->recurring)) {
     // Update expiration date and generate the next donation.
     $cardonfile_fields = commerce_authnet_echeck_cardonfile_fields($donation);
@@ -159,9 +162,6 @@ function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $d
       }
     }
   }
-
-  // Perform post processing functions.
-  _fundraiser_commerce_charge_submit_form_process($success, $method_instance, $pane_values, $donation);
 
   return $success;
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
@@ -205,6 +205,7 @@ function commerce_authnet_echeck_fundraiser_commerce_expire($submission_fields) 
     $expires['year'] = $submission_fields['payment_fields']['bank account']['card_expiration_year'];
   }
   else {
+    // TODO this is causing a problem on billing updates, wherein future orders are deleted
     // If no expiration date given, use current date + 1 month
     $expire_time = strtotime("now + 1 month");
 
@@ -234,22 +235,10 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
   if (empty($card_data) && !empty($donation->data['cardonfile'])) {
     $card_data = commerce_cardonfile_load($donation->data['cardonfile']);
   }
-  else {
+  elseif (empty($card_data)) {
     // If there wasn't card data on the donation, try to load it for user/payment method
     $cardonfile_fields = commerce_authnet_echeck_cardonfile_fields($donation);
     $card_data = _fundraiser_commerce_cardonfile_match($cardonfile_fields);
-  }
-
-  if (empty($card_data)) {
-    // Log the missing card data
-    watchdog(
-      'fundraiser',
-      'A card update was attempted on donation @id but no stored card data was found.',
-      array('@id' => $donation->did),
-      WATCHDOG_CRITICAL
-    );
-
-    return;
   }
 
   // Pull the new credit card values from the donation
@@ -262,7 +251,7 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
   // If it does then we use the update function
   // if its a new card check if we should create a new CIM profile
   $action = 'update';
-  if ($cardonfile_fields['card_number'] != $card_data->card_number) {
+  if (!isset($card_data) || $cardonfile_fields['card_number'] != $card_data->card_number) {
     // This is a new card for this donation, make sure we don't have an existing profile
     // First check with the card number and date
     if ($existing = _fundraiser_commerce_cardonfile_match($cardonfile_fields)) {
@@ -325,28 +314,27 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
       $remote_id = (string) $response->customerProfileId . '|' . (string) $response->customerPaymentProfileIdList->numericString;
 
       // Get the card type
-      $card_type = commerce_payment_validate_credit_card_type($pane_values['credit_card']['number'], array_keys(commerce_payment_credit_card_types()));
-      $all_types = commerce_payment_credit_card_types();
-      $card_type = !empty($all_types[$card_type]) ? $all_types[$card_type] : 'card';
+      $card_type = 'card';
 
       // Get card expiration date to use if we don't have one
-      $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
+      $expires = commerce_authnet_echeck_fundraiser_commerce_expire();
 
       // Create a new cardonfile entity
-      $card_data = commerce_cardonfile_new();
-      $card_data->uid = $order->uid;
-      $card_data->payment_method = $payment_method['method_id'];
-      $card_data->instance_id = $payment_method['instance_id'];
-      $card_data->remote_id = $remote_id;
-      $card_data->card_type = $card_type;
-      $card_data->card_name = !empty($card_data->card_name) ? $card_data->card_name : '';
-      $card_data->card_number = $cardonfile_fields['card_number'];
-      $card_data->card_exp_month = !empty($card_data->card_exp_month) ? $card_data->card_exp_month : $expires['month'];
-      $card_data->card_exp_year = !empty($card_data->card_exp_year) ? $card_data->card_exp_year : $expires['year'];
-      $card_data->status = 1;
+      $new_data = commerce_cardonfile_new();
+      $new_data->uid = $order->uid;
+      $new_data->payment_method = $payment_method['method_id'];
+      $new_data->instance_id = $payment_method['instance_id'];
+      $new_data->remote_id = $remote_id;
+      $new_data->card_type = $card_type;
+      $new_data->card_name = !empty($card_data->card_name) ? $card_data->card_name : '';
+      $new_data->card_number = $cardonfile_fields['card_number'];
+      // We want to use the exp date and month from the old card, so that sustainers won't delete any orders
+      $new_data->card_exp_month = !empty($card_data->card_exp_month) ? $card_data->card_exp_month : $expires['month'];
+      $new_data->card_exp_year = !empty($card_data->card_exp_year) ? $card_data->card_exp_year : $expires['year'];
+      $new_data->status = 1;
 
       // Save and log the creation of the new card on file.
-      commerce_cardonfile_save($card_data);
+      commerce_cardonfile_save($new_data);
       // Set the value on the donation
       $donation->data['cardonfile'] = $new_data->card_id;
       watchdog('commerce_authnet', 'CIM Customer Profile @profile_id created and saved to user @uid.', array('@profile_id' => (string) $response->customerProfileId, '@uid' => $order->uid));

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
@@ -425,9 +425,11 @@ function _commerce_authnet_echeck_fundraiser_commerce_authnet_cim_cardonfile_upd
  *   The pane values.
  */
 function commerce_authnet_echeck_pane_values($donation) {
-  $pane_values = array(
-    'bank account' => $donation->donation['payment_fields']['bank account']
-  );
+  $pane_values = array();
+
+  if (isset($donation) && isset($donation->donation['payment_fields']['bank account'])) {
+    $pane_values['bank account'] = $donation->donation['payment_fields']['bank account'];
+  }
 
   return $pane_values;
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
@@ -317,7 +317,7 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
       $card_type = 'card';
 
       // Get card expiration date to use if we don't have one
-      $expires = commerce_authnet_echeck_fundraiser_commerce_expire();
+      $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
 
       // Create a new cardonfile entity
       $new_data = commerce_cardonfile_new();

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
@@ -30,7 +30,7 @@ function commerce_authnet_echeck_fundraiser_donation_form_config_check($node) {
   foreach ($node->gateways as $method => $gateway) {
     if (!empty($gateway['id']) && !empty($gateway['status'])) {
       $gateway_config = _fundraiser_gateway_info($gateway['id']);
-      if ($gateway_config['gateway_details']['method_id'] == 'commerce_authnet_echeck' &&
+      if ($gateway_config['gateway_details']['method_id'] == 'authnet_echeck' &&
         $gateway_config['gateway_details']['settings']['txn_mode'] != AUTHNET_TXN_MODE_LIVE) {
         return array(t('The authnet EFT payment gateway is currently in !mode mode and will not process live transactions.', array('!mode' => $gateway_config['gateway_details']['settings']['txn_mode'])));
       }
@@ -39,7 +39,7 @@ function commerce_authnet_echeck_fundraiser_donation_form_config_check($node) {
 }
 
 function commerce_authnet_echeck_fundraiser_gateway_status_cron_check($details) {
-  if ($details['method_id'] == 'commerce_authnet_echeck') {
+  if ($details['method_id'] == 'authnet_echeck') {
     if ($details['settings']['txn_mode'] != AUTHNET_TXN_MODE_LIVE) {
       return $details['settings']['txn_mode'];
     }
@@ -126,24 +126,20 @@ function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $d
     $success = TRUE;
   }
 
-  if ($success == TRUE) {
+  if ($success == TRUE && isset($donation->recurring) && !empty($donation->recurring)) {
     // Update expiration date and generate the next donation.
-    $donation = fundraiser_donation_get_donation($donation->did);
-    $card_data = commerce_cardonfile_load($pane_values['cardonfile']);
+    $cardonfile_fields = commerce_authnet_echeck_cardonfile_fields($donation);
+    $card_data = _fundraiser_commerce_cardonfile_match($cardonfile_fields);
 
-    if (!empty($card_data)) {
+    if (!empty($card_data) && $donation->status <> 'failed') {
       // If the next recurring series entry doesn't exist, create one.
-      if (($donation->status <> 'failed') && _fundraiser_sustainers_count_donations_recurr_remaining($donation->recurring->master_did) < 1) {
+      if (_fundraiser_sustainers_count_donations_recurr_remaining($donation->recurring->master_did) < 1) {
 
         // Move card expiration date ahead one month.
         $new_expire_time = mktime(0, 0, 0, ($card_data->card_exp_month + 1), 1, $card_data->card_exp_year);
 
         $card_data->card_exp_month = date('m', $new_expire_time);
         $card_data->card_exp_year = date('Y', $new_expire_time);
-
-        $master_donation = fundraiser_donation_get_donation($donation->recurring->master_did);
-        // Update card using master donation so transaction ID is available.
-        commerce_authnet_echeck_fundraiser_commerce_update($master_donation, $card_data);
 
         $submission_fields = array(
           'payment_fields' => array(
@@ -153,6 +149,12 @@ function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $d
             ),
           ),
         );
+
+        // Update card data
+        commerce_cardonfile_save($card_data);
+
+        // Create new orders
+        $master_donation = fundraiser_donation_get_donation($donation->recurring->master_did);
         fundraiser_sustainers_update_billing_info_create_new_donations($master_donation, $donation, $submission_fields);
       }
     }
@@ -197,10 +199,18 @@ function commerce_authnet_echeck_fundraiser_commerce_cardonfile($donation) {
 function commerce_authnet_echeck_fundraiser_commerce_expire($submission_fields) {
   $expires = array();
 
-  $expire_time = strtotime("now + 1 month");
+  if (!empty($submission_fields) && array_key_exists('card_expiration_month', $submission_fields['payment_fields']['bank account']) && array_key_exists('card_expiration_year', $submission_fields['payment_fields']['bank account'])) {
+    // Donation passed
+    $expires['month'] = $submission_fields['payment_fields']['bank account']['card_expiration_month'];
+    $expires['year'] = $submission_fields['payment_fields']['bank account']['card_expiration_year'];
+  }
+  else {
+    // If no expiration date given, use current date + 1 month
+    $expire_time = strtotime("now + 1 month");
 
-  $expires['month'] = date('m', $expire_time);
-  $expires['year'] = date('Y', $expire_time);
+    $expires['month'] = date('m', $expire_time);
+    $expires['year'] = date('Y', $expire_time);
+  }
 
   return $expires;
 }
@@ -225,7 +235,9 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
     $card_data = commerce_cardonfile_load($donation->data['cardonfile']);
   }
   else {
-    // TODO try to load card data
+    // If there wasn't card data on the donation, try to load it for user/payment method
+    $cardonfile_fields = commerce_authnet_echeck_cardonfile_fields($donation);
+    $card_data = _fundraiser_commerce_cardonfile_match($cardonfile_fields);
   }
 
   if (empty($card_data)) {
@@ -245,9 +257,6 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
 
   // Load the card on file values for this donation
   $cardonfile_fields = commerce_authnet_echeck_cardonfile_fields($donation);
-
-  // Get card expiration date.
-  $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
 
   // Check the card number to see if it matches the current card data number
   // If it does then we use the update function
@@ -270,12 +279,15 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
     // If cardonfile matched, set it here
     $donation->data['cardonfile'] = $card_data->card_id;
   }
+
   if ($action == 'update') {
     $card_data->card_number = $cardonfile_fields['card_number'];
 
     // We're mirroring the commerce_authnet_cim_cardonfile_update function so setup values that function uses, see that function for details
     $form['bank account']['acct_num']['#default_value'] = '';
     $form_state['values']['bank account']['acct_num'] = $pane_values['bank account']['acct_num'];
+    $form_state['values']['bank account']['aba_code'] = $pane_values['bank account']['aba_code'];
+    $form_state['values']['bank account']['acct_name'] = $pane_values['bank account']['acct_name'];
     $form_state['values']['bank account']['owner'] = isset($donation->donation['first_name']) ? $donation->donation['first_name'] : '';
     $form_state['values']['bank account']['owner'] .= isset($donation->donation['last_name']) ? ' ' . $donation->donation['last_name'] : '';
     $form_state['values']['bank account']['address'] = isset($donation->donation['address']) ? $donation->donation['address'] : '';
@@ -288,6 +300,7 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
     $response = _commerce_authnet_echeck_fundraiser_commerce_authnet_cim_cardonfile_update($form, $form_state, $payment_method, $card_data);
 
     if ($response) {
+      $donation->data['cardonfile'] = $card_data->card_id;
       commerce_cardonfile_save($card_data);
       return $card_data;
     }
@@ -316,6 +329,9 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
       $all_types = commerce_payment_credit_card_types();
       $card_type = !empty($all_types[$card_type]) ? $all_types[$card_type] : 'card';
 
+      // Get card expiration date to use if we don't have one
+      $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
+
       // Create a new cardonfile entity
       $card_data = commerce_cardonfile_new();
       $card_data->uid = $order->uid;
@@ -325,8 +341,8 @@ function commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_dat
       $card_data->card_type = $card_type;
       $card_data->card_name = !empty($card_data->card_name) ? $card_data->card_name : '';
       $card_data->card_number = $cardonfile_fields['card_number'];
-      $card_data->card_exp_month = $expires['month'];
-      $card_data->card_exp_year = $expires['year'];
+      $card_data->card_exp_month = !empty($card_data->card_exp_month) ? $card_data->card_exp_month : $expires['month'];
+      $card_data->card_exp_year = !empty($card_data->card_exp_year) ? $card_data->card_exp_year : $expires['year'];
       $card_data->status = 1;
 
       // Save and log the creation of the new card on file.
@@ -397,12 +413,15 @@ function _commerce_authnet_echeck_fundraiser_commerce_authnet_cim_cardonfile_upd
       ),
       'payment' => array(
         'bankAccount' => array(
-          'accountNumber' => $number
+          'routingNumber' => $form_state['values']['bank account']['aba_code'],
+          'accountNumber' => $form_state['values']['bank account']['acct_num'],
+          'nameOnAccount' => $form_state['values']['bank account']['acct_name']
         ),
       ),
       'customerPaymentProfileId' => $cim_payment_profile_id,
     ),
   );
+
   // Fetch the response from the API server and let Card on File know if the update was successful.
   $xml_response = commerce_authnet_cim_request($payment_method, 'updateCustomerPaymentProfileRequest', $api_request_data);
   return (string) $xml_response->messages->message->code == 'I00001';
@@ -486,7 +505,7 @@ function commerce_authnet_echeck_cim_create_customer_profile_request($payment_me
     unset($api_request_data['profile']['merchantCustomerId']);
   }
 
-  // Add credit card payment details to the default payment profile if given.
+  // Add bank account payment details to the default payment profile if given.
   $bank_account = commerce_authnet_echeck_cim_bank_account_array($payment_details);
 
   if (!empty($bank_account)) {

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
@@ -175,21 +175,6 @@ function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $d
 function commerce_authnet_echeck_fundraiser_commerce_cardonfile($donation) {
   $cardonfile_fields = commerce_authnet_echeck_cardonfile_fields($donation);
 
-  // So we need to search locally to see if we have an existing profile for
-  // a card number.
-  // Only perform this when we're in an active non-reference charge.
-  if (isset($donation->reference_charge) && $donation->reference_charge === FALSE) {
-    // Query the db for an existing record.
-    $card_data = _fundraiser_commerce_cardonfile_match($cardonfile_fields);
-
-    // If we have a profile for this user update it locally.
-    if ($card_data) {
-      // Make the update request to authorize.net
-      commerce_authnet_echeck_fundraiser_commerce_update($donation, $card_data);
-    }
-  }
-
-
   return $cardonfile_fields;
 }
 

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck.inc
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * @file
+ * Commerce based hook for commerce_authnet EFT.
+ */
+
+/**
+ * Implements hook_fundraiser_commerce_fundraiser_gateway_info().
+ */
+function commerce_authnet_echeck_fundraiser_commerce_fundraiser_gateway_info() {
+  return array(
+    'payment_method' => array('bank account'),
+    'form callback' => 'commerce_authnet_echeck_fundraiser_commerce_submit_form',
+    'cleanup callback' => 'commerce_authnet_echeck_fundraiser_commerce_cleanup',
+    'scrub callback' => 'commerce_authnet_echeck_fundraiser_commerce_scrub',
+    'validate callback' => 'commerce_authnet_echeck_fundraiser_commerce_validate',
+    'charge callback' => 'commerce_authnet_echeck_fundraiser_commerce_charge',
+  );
+}
+
+/**
+ * Implements hook_fundraiser_donation_form_config_check().
+ */
+function commerce_authnet_echeck_fundraiser_donation_form_config_check($node) {
+  foreach ($node->gateways as $method => $gateway) {
+    if (!empty($gateway['id']) && !empty($gateway['status'])) {
+      $gateway_config = _fundraiser_gateway_info($gateway['id']);
+      if ($gateway_config['gateway_details']['method_id'] == 'commerce_authnet_echeck' &&
+        $gateway_config['gateway_details']['settings']['txn_mode'] != AUTHNET_TXN_MODE_LIVE) {
+        return array(t('The authnet EFT payment gateway is currently in !mode mode and will not process live transactions.', array('!mode' => $gateway_config['gateway_details']['settings']['txn_mode'])));
+      }
+    }
+  }
+}
+
+function commerce_authnet_echeck_fundraiser_gateway_status_cron_check($details) {
+  if ($details['method_id'] == 'commerce_authnet_echeck') {
+    if ($details['settings']['txn_mode'] != AUTHNET_TXN_MODE_LIVE) {
+      return $details['settings']['txn_mode'];
+    }
+    else {
+      return 'live';
+    }
+  }
+}
+
+/**
+ * Returns the form fields for this method.
+ *
+ * @param string $payment_method
+ *   Credit, bank account, paypal, etc.
+ * @param array $config
+ *   Configuration options for this field.
+ */
+function commerce_authnet_echeck_fundraiser_commerce_submit_form($payment_method, $config) {
+  module_load_include('inc', 'commerce_authnet_echeck', 'includes/commerce_authnet_echeck.echeck');
+  $method_instance = commerce_payment_method_instance_load($config['id']);
+  $form = commerce_authnet_echeck_submit_form($method_instance);
+  // Remove the required flag for the fields
+  foreach (element_children($form['bank account']) as $field_name) {
+    $form['bank account'][$field_name]['#required'] = FALSE;
+  }
+  return $form['bank account'];
+}
+
+/**
+ * Callback function, scrub the data before saving.
+ */
+function commerce_authnet_echeck_fundraiser_commerce_scrub($fields) {
+  // Scrub sensitive donation fields if they exists.
+  if (isset($fields['bank account']['aba_code'])) {
+    $fields['bank account']['aba_code'] = substr($fields['bank account']['aba_code'], -3);
+  }
+  if (isset($fields['bank account']['acct_num'])) {
+    $fields['bank account']['acct_num'] = substr($fields['bank account']['acct_num'], -3);
+  }
+  // Unset confirmation for account number
+  unset($fields['bank account']['confirm_acct_num']);
+  return $fields;
+}
+
+/**
+ * Validate the submitted values with the authnet_commerce validate function.
+ */
+function commerce_authnet_echeck_fundraiser_commerce_validate($submission_fields, $payment_fields) {
+  module_load_include('inc', 'commerce_authnet_echeck', 'includes/commerce_authnet_echeck.echeck');
+  $form_parents = array_merge($payment_fields['#parents'], array('bank account'));
+  $values = array('bank account' => $submission_fields['payment_fields']['bank account']);
+  commerce_authnet_echeck_submit_form_validate(NULL, $payment_fields, $values, NULL, $form_parents);
+  return $submission_fields;
+}
+
+/**
+ * Submit the donation values to the Authnet Echeck charge handler.
+ *
+ * @param array $method_instance
+ *   Commerce loaded method instance.
+ * @param object $donation
+ *   The donation to charge.
+ *
+ * @return bool
+ *   Whether the charge was successful.
+ */
+function commerce_authnet_echeck_fundraiser_commerce_charge($method_instance, $donation) {
+  // Translate from donation settings to the correct values for the plugin.
+  $order = commerce_order_load($donation->did);
+  $wrapper = entity_metadata_wrapper('commerce_order', $order);
+  $charge = $wrapper->commerce_order_total->value();
+  // Not actually used anywhere in this system, so ignore it.
+  $pane_form = array();
+  $pane_values = array(
+    'bank account' => $donation->donation['payment_fields']['bank account']
+  );
+  // Execute call to Authnet, only returns FALSE if the payment failed,
+  // returns nothing if successful.
+  $success = FALSE;
+  $result = commerce_authnet_echeck_submit_form_submit($method_instance, $pane_form, $pane_values, $order, $charge);
+  if ($result !== FALSE) {
+    $success = TRUE;
+  }
+  return $success;
+}
+

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.info
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.info
@@ -1,0 +1,11 @@
+name = Authorize.Net eCheck
+description = Implements Authorize.Net eCheck payment services for use with Drupal Commerce
+package = Commerce (contrib)
+core = 7.x
+version = 7.x-4.x-dev
+
+dependencies[] = commerce
+dependencies[] = commerce_ui
+dependencies[] = commerce_payment
+dependencies[] = commerce_order
+dependencies[] = commerce_authnet

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
@@ -21,6 +21,11 @@ function commerce_authnet_echeck_commerce_payment_method_info() {
     'description' => t('Integrates Authorize.Net Advanced Integration Method
        for eCheck transactions.'),
     'file' => 'includes/commerce_authnet_echeck.echeck.inc',
+    'cardonfile' => array(
+      'charge callback' => 'commerce_authnet_echeck_cardonfile_charge',
+      'update callback' => 'commerce_authnet_echeck_cardonfile_update',
+      'delete callback' => 'commerce_authnet_echeck_cardonfile_delete',
+    ),
   );
 
   return $payment_methods;

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
@@ -51,7 +51,7 @@ function commerce_authnet_echeck_mail_alter(&$message) {
 }
 
 /**
- * Implements hook_fundraiser_donation_update()
+ * Implements hook_fundraiser_donation_update().
  */
 function commerce_authnet_echeck_fundraiser_donation_update($donation) {
   $gateway_config = _fundraiser_gateway_info($donation->gateway['id']);

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Implements Authorize.Net eCheck payment services for use in Drupal Commerce.
+ *
+ * Based on https://www.drupal.org/sandbox/actorrunning/2716153
+ */
+
+/**
+ * Implements hook_commerce_payment_method_info().
+ */
+function commerce_authnet_echeck_commerce_payment_method_info() {
+  $payment_methods = array();
+
+  $payment_methods['authnet_echeck'] = array(
+    'base' => 'commerce_authnet_echeck',
+    'title' => t('Authorize.Net AIM - eCheck.Net'),
+    'short_title' => t('eCheck.Net'),
+    'display_title' => t('eCheck'),
+    'description' => t('Integrates Authorize.Net Advanced Integration Method
+       for eCheck transactions.'),
+    'file' => 'includes/commerce_authnet_echeck.echeck.inc',
+  );
+
+  return $payment_methods;
+}

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
@@ -248,9 +248,18 @@ function commerce_authnet_echeck_fundraiser_sustainers_series_end_date_alter(&$e
   if ($master_donation->gateway['gateway_details']['method_id'] == 'authnet_echeck') {
     // Get the count of series entries.
     $charge_count = db_query('SELECT count(did) FROM {fundraiser_sustainers} WHERE master_did = :master_did', array(':master_did' => $master_donation->did))->fetchField();
-    // Set the date so that a new series entry is created.
-    $new_exp = strtotime("now +" . $charge_count ." months");
-    $end_date['month'] = date('m', $new_exp);
-    $end_date['year'] = date('y', $new_exp);
+    // We only want to increment the series if there's one remaining donation.
+    if (_fundraiser_sustainers_count_donations_recurr_remaining($master_donation->did) < 1) {
+      // Set the date so that a new series entry is created.
+      $new_exp = strtotime("now +" . $charge_count ." months");
+      $end_date['month'] = date('m', $new_exp);
+      $end_date['year'] = date('y', $new_exp);
+    }
+    else {
+      // If there's more than one future donation, set the dates so that no entries will be created or deleted.
+      $new_exp = strtotime("now +" . ($charge_count - 1) ." months");
+      $end_date['month'] = date('m', $new_exp);
+      $end_date['year'] = date('y', $new_exp);
+    }
   }
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
@@ -15,7 +15,7 @@ function commerce_authnet_echeck_commerce_payment_method_info() {
 
   $payment_methods['authnet_echeck'] = array(
     'base' => 'commerce_authnet_echeck',
-    'title' => t('Authorize.Net AIM - eCheck.Net'),
+    'title' => t('Authorize.Net - eCheck.Net'),
     'short_title' => t('eCheck.Net'),
     'display_title' => t('eCheck'),
     'description' => t('Integrates Authorize.Net Advanced Integration Method
@@ -29,4 +29,210 @@ function commerce_authnet_echeck_commerce_payment_method_info() {
   );
 
   return $payment_methods;
+}
+
+/**
+ * Implements hook_mail_alter().
+ */
+function commerce_authnet_echeck_mail_alter(&$message) {
+  // Suppress expiration emails for pwmb transactions
+  if ($message['id'] == 'fundraiser_sustainers_fundraiser_cc_notification') {
+    $params = $message['params'];
+    if ($params && array_key_exists('fundraiser_sustainers_token_set', $params) && array_key_exists('donation', $params['fundraiser_sustainers_token_set'])) {
+      $donation = $params['fundraiser_sustainers_token_set']['donation'];
+      $gateway_config = _fundraiser_gateway_info($donation->gateway['id']);
+      if ($donation && $gateway_config['gateway_details']['method_id'] == 'authnet_echeck') {
+        // Suppress email and log
+        watchdog('commerce_authnet_echeck', 'Credit card expiration email suppressed for donation ID @did', array('@did' => $donation->did), WATCHDOG_INFO);
+        $message['send'] = FALSE;
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_fundraiser_donation_update()
+ */
+function commerce_authnet_echeck_fundraiser_donation_update($donation) {
+  $gateway_config = _fundraiser_gateway_info($donation->gateway['id']);
+  if ($gateway_config['gateway_details']['method_id'] == 'authnet_echeck') {
+    // If a recurring donation is skipped, create the next series donation.
+    if (($donation->status == 'skipped') && isset($donation->recurring) && !empty($donation->recurring)) {
+      $master_donation = fundraiser_donation_get_donation($donation->recurring->master_did);
+
+      if (!empty($master_donation)) {
+          // If the next recurring series entry doesn't exist, create one.
+          if (($donation->status <> 'failed') && _fundraiser_sustainers_count_donations_recurr_remaining($donation->recurring->master_did) < 1) {
+          // Update expiration date and generate the next donation.
+          $cardonfile_fields = commerce_authnet_echeck_cardonfile_fields($donation);
+          $card_data = _fundraiser_commerce_cardonfile_match($cardonfile_fields);
+
+          if (!empty($card_data)) {
+
+            // Move card expiration date ahead one month.
+            $new_expire_time = mktime(0, 0, 0, ($card_data->card_exp_month + 1), 1, $card_data->card_exp_year);
+
+            $card_data->card_exp_month = date('m', $new_expire_time);
+            $card_data->card_exp_year = date('Y', $new_expire_time);
+
+            $submission_fields = array(
+              'payment_fields' => array(
+                'bank account' => array(
+                  'card_expiration_month' => $card_data->card_exp_month,
+                  'card_expiration_year' => $card_data->card_exp_year,
+                ),
+              ),
+            );
+
+            // Update card data
+            commerce_cardonfile_save($card_data);
+
+            fundraiser_sustainers_update_billing_info_create_new_donations($master_donation, $donation, $submission_fields);
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Card on file callback: background charge payment
+ *
+ * @param object $payment_method
+ *  The payment method instance definition array.
+ * @param object $card_data
+ *   The stored credit card data array to be processed
+ * @param object $order
+ *   The order object that is being processed
+ * @param array $charge
+ *   The price array for the charge amount with keys of 'amount' and 'currency'
+ *   If null the total value of the order is used.
+ *
+ * @return
+ *   TRUE if the transaction was successful
+ */
+function commerce_authnet_echeck_cardonfile_charge($payment_method, $card_data, $order, $charge = NULL) {
+  // Format order total for transaction.
+  if (!isset($charge)) {
+    $wrapper = entity_metadata_wrapper('commerce_order', $order);
+    $charge = commerce_line_items_total($wrapper->commerce_line_items);
+  }
+
+  // Extract the Customer Profile and Payment Profile IDs from the remote_id.
+  list($cim_customer_profile_id, $cim_payment_profile_id) = explode('|', $card_data->remote_id);
+
+  // Determine the proper transaction element to use inside the XML.
+  $element_name = commerce_authnet_cim_transaction_element_name($payment_method['settings']['txn_type']);
+
+  // Build a data array for the transaction API request.
+  $api_request_data = array(
+    'transaction' => array(
+      $element_name => array(
+        'amount' => number_format(commerce_currency_amount_to_decimal($charge['amount'], $charge['currency_code']), 2, '.', ''),
+        'customerProfileId' => $cim_customer_profile_id,
+        'customerPaymentProfileId' => $cim_payment_profile_id,
+        'order' => array(
+          'invoiceNumber' => $order->order_number,
+        ),
+      ),
+    ),
+    'extraOptions' => '<![CDATA[x_delim_data=TRUE&amp;x_delim_char=|&amp;x_encap_char="&amp;x_solution_id=A1000009&amp;x_currency_code=' . $charge['currency_code'] . '&amp;x_customer_ip=' . substr(ip_address(), 0, 15) . ']]>',
+  );
+
+  // If we get a response from the API server...
+  $xml_response = commerce_authnet_cim_request($payment_method, 'createCustomerProfileTransactionRequest', $api_request_data);
+
+  if (!empty($xml_response->directResponse)) {
+    // Extract the response data from the XML.
+    $response = explode('|', (string) $xml_response->directResponse);
+
+    for ($i = 0; $i < count($response); $i++) {
+      $response[$i] = substr($response[$i], 1, strlen($response[$i]) - 2);
+    }
+
+    // Prepare a transaction object to represent the transaction attempt.
+    $transaction = commerce_payment_transaction_new('authnet_echeck', $order->order_id);
+    $transaction->instance_id = $payment_method['instance_id'];
+    $transaction->remote_id = $response[6];
+    $transaction->amount = $charge['amount'];
+    $transaction->currency_code = $charge['currency_code'];
+    $transaction->payload[REQUEST_TIME] = $response;
+
+    // If we didn't get an approval response code...
+    if ($response[0] != '1') {
+      // Create a failed transaction with the error message.
+      $transaction->status = COMMERCE_PAYMENT_STATUS_FAILURE;
+    }
+    else {
+      // Set the transaction status based on the type of transaction this was.
+      switch ($payment_method['settings']['txn_type']) {
+        case COMMERCE_CREDIT_AUTH_ONLY:
+          $transaction->status = COMMERCE_PAYMENT_STATUS_PENDING;
+          break;
+
+        case COMMERCE_CREDIT_AUTH_CAPTURE:
+          $transaction->status = COMMERCE_PAYMENT_STATUS_SUCCESS;
+          break;
+      }
+    }
+
+    // Store the type of transaction in the remote status.
+    $transaction->remote_status = $response[11];
+
+    // Build a meaningful response message.
+    $message = array(
+      '<b>' . commerce_authnet_reverse_txn_type(commerce_authnet_txn_type($payment_method['settings']['txn_type'])) . '</b>',
+      '<b>' . ($response[0] != '1' ? t('REJECTED') : t('ACCEPTED')) . ':</b> ' . check_plain($response[3]),
+      t('AVS response: @avs', array('@avs' => commerce_authnet_avs_response($response[5]))),
+    );
+
+    $transaction->message = implode('<br />', $message);
+
+    // Save the transaction information.
+    commerce_payment_transaction_save($transaction);
+
+    // If the payment failed, display an error and rebuild the form.
+    if ($response[0] != '1') {
+      drupal_set_message(t('We received the following error processing your card. Please enter your information again or try a different card.'), 'error');
+      drupal_set_message(check_plain($response[3]), 'error');
+      return FALSE;
+    }
+
+    return;
+  }
+  elseif ((string) $xml_response->messages->message->code == 'E00040') {
+    // If the response indicated a non-existent profile, deactive it now.
+    $card_data->status = 0;
+    commerce_cardonfile_save($card_data);
+
+    drupal_set_message(t('The card you selected is no longer valid. Please use a different card to complete payment.'), 'error');
+    return FALSE;
+  }
+
+  drupal_set_message(t('We could not process your card on file at this time. Please try again or use a different card.'), 'error');
+  return FALSE;
+
+}
+
+/**
+ * Card on file callback: updates the associated customer payment profile.
+ */
+function commerce_authnet_echeck_cardonfile_update($form, &$form_state, $payment_method, $card_data) {
+  // This callback is empty because cardonfile doesn't currently store the bank account info correctly.
+  // It can only be updated by editing the sustainer series.
+}
+
+/**
+ * Card on file callback: deletes the associated customer payment profile.
+ */
+function commerce_authnet_echeck_cardonfile_delete($form, &$form_state, $payment_method, $card_data) {
+  // Extract the Customer Profile and Payment Profile IDs from the remote_id.
+  list($cim_customer_profile_id, $cim_payment_profile_id) = explode('|', $card_data->remote_id);
+
+  // Fetch the response from the API server and let Card on File know that the
+  // delete was either successful or not necessary.
+  $xml_response = commerce_authnet_cim_delete_customer_payment_profile_request($payment_method, $cim_customer_profile_id, $cim_payment_profile_id);
+  $code = (string) $xml_response->messages->message->code;
+
+  return in_array($code, array('I00001', 'E00040'));
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
@@ -241,18 +241,16 @@ function commerce_authnet_echeck_cardonfile_delete($form, &$form_state, $payment
  * Implements hook_fundraiser_sustainers_series_end_date_alter().
  */
 function commerce_authnet_echeck_fundraiser_sustainers_series_end_date_alter(&$end_date, $context) {
-  // Because our expire callback causes sustainers to delete future orders, we want to set the end date of a
-  // recurring series to the month/year of the cardonfile entry of the last recurring donation
+  // Bank account recurring transactions can share a cardonfile entry.
+  // Because bank accounts don't have expiration dates, using the cardonfile date isn't a reliable way to increment a series.
   $master_donation = $context['master_donation'];
-  // Get the last donation in the series
-  $last_donation_did = db_query('SELECT max(did) FROM {fundraiser_sustainers} WHERE master_did = :master_did', array(':master_did' => $master_donation->did))->fetchField();
-  $last_donation = fundraiser_donation_get_donation($last_donation_did);
-  if (module_exists('commerce_cardonfile') && isset($last_donation->data['cardonfile'])) {
-    // If we have a cardonfile entry for this donation, use that for the exp date.
-    $card_data = commerce_cardonfile_load($last_donation->data['cardonfile']);
-    if ($card_data) {
-      $end_date['month'] = $card_data->card_exp_month;
-      $end_date['year'] = $card_data->card_exp_year;
-    }
+  // $source_donation = $context['source_donation'];
+  if ($master_donation->gateway['gateway_details']['method_id'] == 'authnet_echeck') {
+    // Get the count of series entries.
+    $charge_count = db_query('SELECT count(did) FROM {fundraiser_sustainers} WHERE master_did = :master_did', array(':master_did' => $master_donation->did))->fetchField();
+    // Set the date so that a new series entry is created.
+    $new_exp = strtotime("now +" . $charge_count ." months");
+    $end_date['month'] = date('m', $new_exp);
+    $end_date['year'] = date('y', $new_exp);
   }
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/commerce_authnet_echeck.module
@@ -236,3 +236,23 @@ function commerce_authnet_echeck_cardonfile_delete($form, &$form_state, $payment
 
   return in_array($code, array('I00001', 'E00040'));
 }
+
+/**
+ * Implements hook_fundraiser_sustainers_series_end_date_alter().
+ */
+function commerce_authnet_echeck_fundraiser_sustainers_series_end_date_alter(&$end_date, $context) {
+  // Because our expire callback causes sustainers to delete future orders, we want to set the end date of a
+  // recurring series to the month/year of the cardonfile entry of the last recurring donation
+  $master_donation = $context['master_donation'];
+  // Get the last donation in the series
+  $last_donation_did = db_query('SELECT max(did) FROM {fundraiser_sustainers} WHERE master_did = :master_did', array(':master_did' => $master_donation->did))->fetchField();
+  $last_donation = fundraiser_donation_get_donation($last_donation_did);
+  if (module_exists('commerce_cardonfile') && isset($last_donation->data['cardonfile'])) {
+    // If we have a cardonfile entry for this donation, use that for the exp date.
+    $card_data = commerce_cardonfile_load($last_donation->data['cardonfile']);
+    if ($card_data) {
+      $end_date['month'] = $card_data->card_exp_month;
+      $end_date['year'] = $card_data->card_exp_year;
+    }
+  }
+}

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
@@ -15,6 +15,7 @@ function commerce_authnet_echeck_settings_form($settings = NULL) {
   $settings = (array) $settings + array(
     'login' => '',
     'tran_key' => '',
+    'email_customer' => FALSE,
     'txn_mode' => AUTHNET_TXN_MODE_LIVE_TEST,
     'log' => array('request' => '0', 'response' => '0'),
   );
@@ -65,7 +66,42 @@ function commerce_authnet_echeck_settings_form($settings = NULL) {
     '#default_value' => $settings['log'],
   );
 
+  // CIM support in conjunction with AIM requires the Card on File module.
+  if (module_exists('commerce_cardonfile')) {
+    $form['cardonfile'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Enable Card on File functionality with this payment method using Authorize.Net CIM.'),
+      '#description' => t('This requires an Authorize.Net account upgraded to include support for CIM (Customer Information Manager).'),
+      '#default_value' => $settings['cardonfile'],
+    );
+  }
+
+  else {
+    $form['cardonfile'] = array(
+      '#type' => 'markup',
+      '#markup' => t('To enable Card on File funcitionality download and install the Card on File module.'),
+    );
+  }
+
+  $form['email_customer'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Tell Authorize.net to e-mail the customer a receipt based on your account settings.'),
+    '#default_value' => $settings['email_customer'],
+  );
+
   return $form;
+}
+
+function commerce_authnet_echeck_cardonfile_charge($payment_method, $card_data, $order, $charge = NULL) {
+
+}
+
+function commerce_authnet_echeck_cardonfile_update($form, &$form_state, $payment_method, $card_data) {
+
+}
+
+function commerce_authnet_echeck_cardonfile_delete() {
+
 }
 
 /**
@@ -180,12 +216,22 @@ function commerce_authnet_echeck_submit_form($payment_method, $pane_values = arr
  */
 function commerce_authnet_echeck_submit_form_validate($payment_method, $pane_form, $pane_values, $order, $form_parents = array()) {
   // Validate the echeck fields.
-  $settings = array(
-    'form_parents' => array_merge($form_parents, array('bank account')),
-  );
+  $prefix = implode('][', $form_parents) . '][';
 
-  if (!commerce_authnet_echeck_payment_validate($pane_values['bank account'], $settings)) {
-    return FALSE;
+  // Validate the aba (routing) number.
+  if (!commerce_authnet_echeck_payment_validate_aba($pane_values['bank account']['aba_code'])) {
+    form_set_error($prefix . 'aba_code', t('You have entered an invalid routing number.'));
+  }
+
+  // Ensure that the account numbers match.
+  if ($pane_values['bank account']['acct_num'] != $pane_values['bank account']['confirm_acct_num']) {
+    form_set_error($prefix . 'acct_num', t('The account numbers do not match.'));
+    form_set_error($prefix . 'confirm_acct_num');
+  }
+
+  // Validate the account number.
+  if (!commerce_authnet_echeck_payment_validate_account($pane_values['bank account']['acct_num'])) {
+    form_set_error($prefix . 'acct_num', t('You have entered an invalid account number.'));
   }
 }
 
@@ -193,6 +239,13 @@ function commerce_authnet_echeck_submit_form_validate($payment_method, $pane_for
  * Payment method callback: checkout form submission.
  */
 function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form, $pane_values, $order, $charge) {
+  // If the customer specified payment using a card on file, attempt that now
+  // and simply return the result.
+  if (module_exists('commerce_cardonfile') && $payment_method['settings']['cardonfile'] &&
+    !empty($pane_values['cardonfile']) && $pane_values['cardonfile'] !== 'new') {
+    return commerce_authnet_cim_submit_form_submit($payment_method, $pane_form, $pane_values, $order, $charge);
+  }
+
   // Build a name-value pair array for this transaction.
   $nvp = array(
     'x_method' => 'ECHECK',
@@ -202,6 +255,7 @@ function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form,
     'x_bank_name' => isset($pane_values['bank account']['bank_name']) ? substr($pane_values['bank account']['bank_name'], 0, 50) : '',
     'x_bank_acct_name' => isset($pane_values['bank account']['bank_name']) ? substr($pane_values['bank account']['acct_name'], 0, 50) : '',
     'x_echeck_type' => 'WEB',
+    // Recurring should always be false, recurring transactions are handled by CIM
     'x_recurring_billing' => 'FALSE',
     'x_amount' => commerce_currency_amount_to_decimal($charge['amount'], $charge['currency_code']),
   );
@@ -264,6 +318,139 @@ function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form,
     drupal_set_message(check_plain($response[3]), 'error');
     return FALSE;
   }
+
+  // If Card on File storage is enabled via CIM and the form says to store data...
+  if (module_exists('commerce_cardonfile') && !empty($payment_method['settings']['cardonfile']) &&
+    !empty($pane_values['bank account']['cardonfile_store']) && $pane_values['bank account']['cardonfile_store']) {
+    // Build a payment details array for the credit card.
+    $payment_details = array(
+      'accountNumber' => $pane_values['bank account']['acct_num'],
+      'routingNumber' => $pane_values['bank account']['aba_code'],
+      'nameOnAccount' => $pane_values['bank account']['acct_name']
+    );
+
+    // First look to see if we already have cards on file for the user.
+    $stored_cards = commerce_cardonfile_load_multiple_by_uid($order->uid, $payment_method['instance_id']);
+    // If we didn't find any, attempt to make a new Customer Profile now.
+    if (empty($stored_cards)) {
+      // Submit a CIM request to create the Customer Profile.
+      if ($response = commerce_authnet_echeck_cim_create_customer_profile_request($payment_method, $order, $payment_details)) {
+        // If the Customer Profile creation was a success, store the new card on
+        // file data locally.
+        if ((string) $response->messages->resultCode == 'Ok') {
+          // Build a remote ID that includes the Customer Profile ID and the
+          // Payment Profile ID.
+          $remote_id = (string) $response->customerProfileId . '|' . (string) $response->customerPaymentProfileIdList->numericString;
+
+          // Load the card on file values for this donation
+          $cardonfile_fields = _fundraiser_commerce_credit_card_cardonfile_fields($donation);
+          $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
+
+          $card_data = commerce_cardonfile_new();
+          $card_data->uid = $order->uid;
+          $card_data->payment_method = $payment_method['method_id'];
+          $card_data->instance_id = $payment_method['instance_id'];
+          $card_data->remote_id = $remote_id;
+          $card_data->card_type = !empty($card_type) ? $card_type : 'card';
+          $card_data->card_name = !empty($billing_address['name_line']) ? $billing_address['name_line'] : '';
+          $card_data->card_number = $cardonfile_fields['card_number'];
+          $card_data->card_exp_month = $expires['month'];
+          $card_data->card_exp_year = $expires['year'];
+          $card_data->status = 1;
+
+          // Save and log the creation of the new card on file.
+          commerce_cardonfile_save($card_data);
+          watchdog('commerce_authnet_echeck', 'CIM Customer Profile @profile_id created and saved to user @uid.', array('@profile_id' => (string) $response->customerProfileId, '@uid' => $order->uid));
+        }
+        elseif ((string) $response->messages->message->code == 'E00039') {
+          // But if a Customer Profile already existed for this user, attempt
+          // instead to add this card as a new Payment Profile to it.
+          $result = array_filter(explode(' ', (string) $response->messages->message->text), 'is_numeric');
+          $add_to_profile = reset($result);
+        }
+      }
+    }
+    else {
+      // Extract the user's Customer Profile ID from the first card's remote ID.
+      $card_data = reset($stored_cards);
+      list($cim_customer_profile_id, $cim_payment_profile_id) = explode('|', $card_data->remote_id);
+
+      // Attempt to add the card as a new payment profile to this Customer Profile.
+      $add_to_profile = $cim_customer_profile_id;
+    }
+
+    // Attempt to add the card to an existing Customer Profile if specified.
+    if (!empty($add_to_profile)) {
+      $response = commerce_authnet_cim_create_customer_payment_profile_request($payment_method, $add_to_profile, $order, $payment_details);
+
+      // If the Payment Profile creation was a success, store the new card on
+      // file data locally.
+      if ((string) $response->messages->resultCode == 'Ok') {
+        // Build a remote ID that includes the Customer Profile ID and the new
+        // Payment Profile ID.
+        $remote_id = $add_to_profile . '|' . (string) $response->customerPaymentProfileId;
+
+        // Load the card on file values for this donation
+        $cardonfile_fields = _fundraiser_commerce_credit_card_cardonfile_fields($donation);
+        $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
+
+        $card_data = commerce_cardonfile_new();
+        $card_data->uid = $order->uid;
+        $card_data->payment_method = $payment_method['method_id'];
+        $card_data->instance_id = $payment_method['instance_id'];
+        $card_data->remote_id = $remote_id;
+        $card_data->card_type = !empty($card_type) ? $card_type : 'card';
+        $card_data->card_name = !empty($billing_address['name_line']) ? $billing_address['name_line'] : '';
+        $card_data->card_number = $cardonfile_fields['card_number'];
+        $card_data->card_exp_month = $expires['month'];
+        $card_data->card_exp_year = $expires['year'];
+        $card_data->status = 1;
+
+        // Save and log the creation of the new card on file.
+        commerce_cardonfile_save($card_data);
+        watchdog('commerce_authnet_echeck', 'CIM Payment Profile added to Customer Profile @profile_id for user @uid.', array('@profile_id' => $add_to_profile, '@uid' => $order->uid));
+      }
+      elseif (!empty($card_data) && (string) $response->messages->message->code == 'E00040') {
+        // But if we could not find a customer profile, assume the existing
+        // customer profile ID we had is no longer valid and deactivate the card
+        // data that resulted in the error.
+        $card_data->status = 0;
+        commerce_cardonfile_save($card_data);
+
+        // Submit a CIM request to create the Customer Profile.
+        if ($response = commerce_authnet_cim_create_customer_profile_request($payment_method, $order, $payment_details)) {
+          // If the Customer Profile creation was a success, store the new card on
+          // file data locally.
+          if ((string) $response->messages->resultCode == 'Ok') {
+            // Build a remote ID that includes the Customer Profile ID and the
+            // Payment Profile ID.
+            $remote_id = (string) $response->customerProfileId . '|' . (string) $response->customerPaymentProfileIdList->numericString;
+
+            // Load the card on file values for this donation
+            $cardonfile_fields = _fundraiser_commerce_credit_card_cardonfile_fields($donation);
+            $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
+
+            $card_data = commerce_cardonfile_new();
+            $card_data->uid = $order->uid;
+            $card_data->payment_method = $payment_method['method_id'];
+            $card_data->instance_id = $payment_method['instance_id'];
+            $card_data->remote_id = $remote_id;
+            $card_data->card_type = !empty($card_type) ? $card_type : 'card';
+            $card_data->card_name = !empty($billing_address['name_line']) ? $billing_address['name_line'] : '';
+            $card_data->card_number = $cardonfile_fields['card_number'];
+            $card_data->card_exp_month = $expires['month'];
+            $card_data->card_exp_year = $expires['year'];
+            $card_data->status = 1;
+
+            // Save and log the creation of the new card on file.
+            commerce_cardonfile_save($card_data);
+            watchdog('commerce_authnet_echeck', 'CIM Customer Profile @profile_id created and saved to user @uid.', array('@profile_id' => (string) $response->customerProfileId, '@uid' => $order->uid));
+          }
+        }
+      }
+    }
+  }
+
 }
 
 /**
@@ -344,44 +531,49 @@ function commerce_authnet_echeck_request_order_details(&$nvp, $order) {
 }
 
 /**
- * Validates a set of eCheck details entered via the eCheck form.
- *
- * @param array $details
- *   An array of eCheck details as retrieved from the eCheck array in the for
- *   values of a form containing the eCheck form.
- * @param array $settings
- *   Settings used for calling validation functions and setting form errors:
- *     form_parents: an array of parent elements identifying where the eCheck
- *     form was situated in the form array.
- *
- * @return bool
- *   TRUE or FALSE indicating the validity of all the data.
- *
- * @see commerce_payment_echeck_form()
+ * Implements hook_fundraiser_donation_update()
  */
-function commerce_authnet_echeck_payment_validate($details, $settings) {
-  $prefix = implode('][', $settings['form_parents']) . '][';
-  $valid = TRUE;
+function commerce_authnet_echeck_fundraiser_donation_update($donation) {
+  $gateway_config = _fundraiser_gateway_info($donation->gateway['id']);
+  if ($gateway_config['gateway_details']['method_id'] == 'commerce_authnet_echeck') {
+    // If a recurring donation is skipped, create the next series donation.
+    if (($donation->status == 'skipped') && isset($donation->recurring) && !empty($donation->recurring)) {
+      $master_donation = fundraiser_donation_get_donation($donation->recurring->master_did);
 
-  // Validate the aba (routing) number.
-  if (!commerce_authnet_echeck_payment_validate_aba($details['aba_code'])) {
-    form_set_error($prefix . 'aba_code', t('You have entered an invalid routing number.'));
-    $valid = FALSE;
+      if (!empty($master_donation)) {
+          // If the next recurring series entry doesn't exist, create one.
+          if (($donation->status <> 'failed') && _fundraiser_sustainers_count_donations_recurr_remaining($donation->recurring->master_did) < 1) {
+
+          // Update expiration date and generate the next donation.
+          $cards_on_file = commerce_cardonfile_load_multiple_by_remote_id($master_donation->auth_txn_id);
+
+          if (!empty($cards_on_file)) {
+            $card_data = current($cards_on_file);
+
+            // Move card expiration date ahead one month.
+            $new_expire_time = mktime(0, 0, 0, ($card_data->card_exp_month + 1), 1, $card_data->card_exp_year);
+
+            $card_data->card_exp_month = date('m', $new_expire_time);
+            $card_data->card_exp_year = date('Y', $new_expire_time);
+
+            // Update card using master donation so transaction ID is available.
+            commerce_authnet_echeck_fundraiser_commerce_update($master_donation, $card_data);
+
+            $submission_fields = array(
+              'payment_fields' => array(
+                'bank account' => array(
+                  'card_expiration_month' => $card_data->card_exp_month,
+                  'card_expiration_year' => $card_data->card_exp_year,
+                ),
+              ),
+            );
+
+            fundraiser_sustainers_update_billing_info_create_new_donations($master_donation, $donation, $submission_fields);
+          }
+        }
+      }
+    }
   }
-
-  // Ensure that the account numbers match.
-  if ($details['acct_num'] != $details['confirm_acct_num']) {
-    form_set_error($prefix . 'acct_num', t('The account numbers do not match.'));
-    form_set_error($prefix . 'confirm_acct_num');
-  }
-
-  // Validate the account number.
-  if (!commerce_authnet_echeck_payment_validate_account($details['acct_num'])) {
-    form_set_error($prefix . 'acct_num', t('You have entered an invalid account number.'));
-    $valid = FALSE;
-  }
-
-  return $valid;
 }
 
 /**
@@ -438,4 +630,23 @@ function commerce_authnet_echeck_payment_types() {
     'business_checking' => t('Business Checking'),
     'savings' => t('Savings'),
   );
+}
+
+/**
+ * Implements hook_mail_alter().
+ */
+function commerce_authnet_echeck_mail_alter(&$message) {
+  // Suppress expiration emails for pwmb transactions
+  if ($message['id'] == 'fundraiser_sustainers_fundraiser_cc_notification') {
+    $params = $message['params'];
+    if ($params && array_key_exists('fundraiser_sustainers_token_set', $params) && array_key_exists('donation', $params['fundraiser_sustainers_token_set'])) {
+      $donation = $params['fundraiser_sustainers_token_set']['donation'];
+      $gateway_config = _fundraiser_gateway_info($donation->gateway['id']);
+      if ($donation && $gateway_config['gateway_details']['method_id'] == 'commerce_authnet_echeck') {
+        // Suppress email and log
+        watchdog('commerce_authnet_echeck', 'Credit card expiration email suppressed for donation ID @did', array('@did' => $donation->did), WATCHDOG_INFO);
+        $message['send'] = FALSE;
+      }
+    }
+  }
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
@@ -56,6 +56,12 @@ function commerce_authnet_echeck_settings_form($settings = NULL) {
     '#default_value' => $settings['txn_mode'],
   );
 
+  // Transaction type is needed for CIM cardonfile transactions. We always want auth/capture.
+  $form['txn_type'] = array(
+    '#type' => 'hidden',
+    '#value' => COMMERCE_CREDIT_AUTH_CAPTURE,
+  );
+
   $form['log'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Log the following messages for debugging'),
@@ -90,18 +96,6 @@ function commerce_authnet_echeck_settings_form($settings = NULL) {
   );
 
   return $form;
-}
-
-function commerce_authnet_echeck_cardonfile_charge($payment_method, $card_data, $order, $charge = NULL) {
-
-}
-
-function commerce_authnet_echeck_cardonfile_update($form, &$form_state, $payment_method, $card_data) {
-
-}
-
-function commerce_authnet_echeck_cardonfile_delete() {
-
 }
 
 /**
@@ -243,7 +237,7 @@ function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form,
   // and simply return the result.
   if (module_exists('commerce_cardonfile') && $payment_method['settings']['cardonfile'] &&
     !empty($pane_values['cardonfile']) && $pane_values['cardonfile'] !== 'new') {
-    return commerce_authnet_cim_submit_form_submit($payment_method, $pane_form, $pane_values, $order, $charge);
+    return commerce_authnet_echeck_cim_submit_form_submit($payment_method, $pane_form, $pane_values, $order, $charge);
   }
 
   // Build a name-value pair array for this transaction.
@@ -329,69 +323,16 @@ function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form,
       'nameOnAccount' => $pane_values['bank account']['acct_name']
     );
 
-    // First look to see if we already have cards on file for the user.
-    $stored_cards = commerce_cardonfile_load_multiple_by_uid($order->uid, $payment_method['instance_id']);
-    // If we didn't find any, attempt to make a new Customer Profile now.
-    if (empty($stored_cards)) {
-      // Submit a CIM request to create the Customer Profile.
-      if ($response = commerce_authnet_echeck_cim_create_customer_profile_request($payment_method, $order, $payment_details)) {
-        // If the Customer Profile creation was a success, store the new card on
-        // file data locally.
-        if ((string) $response->messages->resultCode == 'Ok') {
-          // Build a remote ID that includes the Customer Profile ID and the
-          // Payment Profile ID.
-          $remote_id = (string) $response->customerProfileId . '|' . (string) $response->customerPaymentProfileIdList->numericString;
-
-          // Load the card on file values for this donation
-          $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
-
-          $card_data = commerce_cardonfile_new();
-          $card_data->uid = $order->uid;
-          $card_data->payment_method = $payment_method['method_id'];
-          $card_data->instance_id = $payment_method['instance_id'];
-          $card_data->remote_id = $remote_id;
-          $card_data->card_type = !empty($card_type) ? $card_type : 'card';
-          $card_data->card_name = !empty($billing_address['name_line']) ? $billing_address['name_line'] : '';
-          $card_data->card_number = substr($pane_values['bank account']['acct_num'], -3);
-          $card_data->card_exp_month = $expires['month'];
-          $card_data->card_exp_year = $expires['year'];
-          $card_data->status = 1;
-
-          // Save and log the creation of the new card on file.
-          commerce_cardonfile_save($card_data);
-          watchdog('commerce_authnet_echeck', 'CIM Customer Profile @profile_id created and saved to user @uid.', array('@profile_id' => (string) $response->customerProfileId, '@uid' => $order->uid));
-        }
-        elseif ((string) $response->messages->message->code == 'E00039') {
-          // But if a Customer Profile already existed for this user, attempt
-          // instead to add this card as a new Payment Profile to it.
-          $result = array_filter(explode(' ', (string) $response->messages->message->text), 'is_numeric');
-          $add_to_profile = reset($result);
-        }
-      }
-    }
-    else {
-      // Extract the user's Customer Profile ID from the first card's remote ID.
-      $card_data = reset($stored_cards);
-      list($cim_customer_profile_id, $cim_payment_profile_id) = explode('|', $card_data->remote_id);
-
-      // Attempt to add the card as a new payment profile to this Customer Profile.
-      $add_to_profile = $cim_customer_profile_id;
-    }
-
-    // Attempt to add the card to an existing Customer Profile if specified.
-    if (!empty($add_to_profile)) {
-      $response = commerce_authnet_cim_create_customer_payment_profile_request($payment_method, $add_to_profile, $order, $payment_details);
-
-      // If the Payment Profile creation was a success, store the new card on
+    // Submit a CIM request to create the Customer Profile.
+    if ($response = commerce_authnet_echeck_cim_create_customer_profile_request($payment_method, $order, $payment_details)) {
+      // If the Customer Profile creation was a success, store the new card on
       // file data locally.
       if ((string) $response->messages->resultCode == 'Ok') {
-        // Build a remote ID that includes the Customer Profile ID and the new
+        // Build a remote ID that includes the Customer Profile ID and the
         // Payment Profile ID.
-        $remote_id = $add_to_profile . '|' . (string) $response->customerPaymentProfileId;
+        $remote_id = (string) $response->customerProfileId . '|' . (string) $response->customerPaymentProfileIdList->numericString;
 
         // Load the card on file values for this donation
-        $donation = fundraiser_donation_get_donation($order->order_id);
-        $cardonfile_fields = _fundraiser_commerce_credit_card_cardonfile_fields($donation);
         $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
 
         $card_data = commerce_cardonfile_new();
@@ -401,56 +342,40 @@ function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form,
         $card_data->remote_id = $remote_id;
         $card_data->card_type = !empty($card_type) ? $card_type : 'card';
         $card_data->card_name = !empty($billing_address['name_line']) ? $billing_address['name_line'] : '';
-        $card_data->card_number = $cardonfile_fields['card_number'];
+        $card_data->card_number = substr($pane_values['bank account']['acct_num'], -3);
         $card_data->card_exp_month = $expires['month'];
         $card_data->card_exp_year = $expires['year'];
         $card_data->status = 1;
 
         // Save and log the creation of the new card on file.
         commerce_cardonfile_save($card_data);
-        watchdog('commerce_authnet_echeck', 'CIM Payment Profile added to Customer Profile @profile_id for user @uid.', array('@profile_id' => $add_to_profile, '@uid' => $order->uid));
+        watchdog('commerce_authnet_echeck', 'CIM Customer Profile @profile_id created and saved to user @uid.', array('@profile_id' => (string) $response->customerProfileId, '@uid' => $order->uid));
       }
-      elseif (!empty($card_data) && (string) $response->messages->message->code == 'E00040') {
-        // But if we could not find a customer profile, assume the existing
-        // customer profile ID we had is no longer valid and deactivate the card
-        // data that resulted in the error.
-        $card_data->status = 0;
-        commerce_cardonfile_save($card_data);
-
-        // Submit a CIM request to create the Customer Profile.
-        if ($response = commerce_authnet_cim_create_customer_profile_request($payment_method, $order, $payment_details)) {
-          // If the Customer Profile creation was a success, store the new card on
-          // file data locally.
-          if ((string) $response->messages->resultCode == 'Ok') {
-            // Build a remote ID that includes the Customer Profile ID and the
-            // Payment Profile ID.
-            $remote_id = (string) $response->customerProfileId . '|' . (string) $response->customerPaymentProfileIdList->numericString;
-
-            // Load the card on file values for this donation
-            $cardonfile_fields = _fundraiser_commerce_credit_card_cardonfile_fields($donation);
-            $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
-
-            $card_data = commerce_cardonfile_new();
-            $card_data->uid = $order->uid;
-            $card_data->payment_method = $payment_method['method_id'];
-            $card_data->instance_id = $payment_method['instance_id'];
-            $card_data->remote_id = $remote_id;
-            $card_data->card_type = !empty($card_type) ? $card_type : 'card';
-            $card_data->card_name = !empty($billing_address['name_line']) ? $billing_address['name_line'] : '';
-            $card_data->card_number = $cardonfile_fields['card_number'];
-            $card_data->card_exp_month = $expires['month'];
-            $card_data->card_exp_year = $expires['year'];
-            $card_data->status = 1;
-
-            // Save and log the creation of the new card on file.
-            commerce_cardonfile_save($card_data);
-            watchdog('commerce_authnet_echeck', 'CIM Customer Profile @profile_id created and saved to user @uid.', array('@profile_id' => (string) $response->customerProfileId, '@uid' => $order->uid));
-          }
-        }
+      elseif ((string) $response->messages->message->code == 'E00039') {
+        // But if a Customer Profile already existed for this user, attempt
+        // instead to add this card as a new Payment Profile to it.
+        $result = array_filter(explode(' ', (string) $response->messages->message->text), 'is_numeric');
+        $add_to_profile = reset($result);
       }
     }
   }
 
+}
+
+/**
+ * Imitates the checkout form submission callback for the AIM payment method.
+ */
+function commerce_authnet_echeck_cim_submit_form_submit($payment_method, $pane_form, $pane_values, $order, $charge) {
+  // First attempt to load the card on file.
+  $card_data = commerce_cardonfile_load($pane_values['cardonfile']);
+
+  // Fail now if it is no longer available or the card is inactive.
+  if (empty($card_data) || $card_data->status == 0) {
+    drupal_set_message(t('The requested card on file is no longer valid.'), 'error');
+    return FALSE;
+  }
+
+  return commerce_authnet_echeck_cardonfile_charge($payment_method, $card_data, $order, $charge);
 }
 
 /**
@@ -531,52 +456,6 @@ function commerce_authnet_echeck_request_order_details(&$nvp, $order) {
 }
 
 /**
- * Implements hook_fundraiser_donation_update()
- */
-function commerce_authnet_echeck_fundraiser_donation_update($donation) {
-  $gateway_config = _fundraiser_gateway_info($donation->gateway['id']);
-  if ($gateway_config['gateway_details']['method_id'] == 'commerce_authnet_echeck') {
-    // If a recurring donation is skipped, create the next series donation.
-    if (($donation->status == 'skipped') && isset($donation->recurring) && !empty($donation->recurring)) {
-      $master_donation = fundraiser_donation_get_donation($donation->recurring->master_did);
-
-      if (!empty($master_donation)) {
-          // If the next recurring series entry doesn't exist, create one.
-          if (($donation->status <> 'failed') && _fundraiser_sustainers_count_donations_recurr_remaining($donation->recurring->master_did) < 1) {
-
-          // Update expiration date and generate the next donation.
-          $cards_on_file = commerce_cardonfile_load_multiple_by_remote_id($master_donation->auth_txn_id);
-
-          if (!empty($cards_on_file)) {
-            $card_data = current($cards_on_file);
-
-            // Move card expiration date ahead one month.
-            $new_expire_time = mktime(0, 0, 0, ($card_data->card_exp_month + 1), 1, $card_data->card_exp_year);
-
-            $card_data->card_exp_month = date('m', $new_expire_time);
-            $card_data->card_exp_year = date('Y', $new_expire_time);
-
-            // Update card using master donation so transaction ID is available.
-            commerce_authnet_echeck_fundraiser_commerce_update($master_donation, $card_data);
-
-            $submission_fields = array(
-              'payment_fields' => array(
-                'bank account' => array(
-                  'card_expiration_month' => $card_data->card_exp_month,
-                  'card_expiration_year' => $card_data->card_exp_year,
-                ),
-              ),
-            );
-
-            fundraiser_sustainers_update_billing_info_create_new_donations($master_donation, $donation, $submission_fields);
-          }
-        }
-      }
-    }
-  }
-}
-
-/**
  * Validates an eCheck aba number.
  *
  * @param int $number
@@ -630,23 +509,4 @@ function commerce_authnet_echeck_payment_types() {
     'business_checking' => t('Business Checking'),
     'savings' => t('Savings'),
   );
-}
-
-/**
- * Implements hook_mail_alter().
- */
-function commerce_authnet_echeck_mail_alter(&$message) {
-  // Suppress expiration emails for pwmb transactions
-  if ($message['id'] == 'fundraiser_sustainers_fundraiser_cc_notification') {
-    $params = $message['params'];
-    if ($params && array_key_exists('fundraiser_sustainers_token_set', $params) && array_key_exists('donation', $params['fundraiser_sustainers_token_set'])) {
-      $donation = $params['fundraiser_sustainers_token_set']['donation'];
-      $gateway_config = _fundraiser_gateway_info($donation->gateway['id']);
-      if ($donation && $gateway_config['gateway_details']['method_id'] == 'commerce_authnet_echeck') {
-        // Suppress email and log
-        watchdog('commerce_authnet_echeck', 'Credit card expiration email suppressed for donation ID @did', array('@did' => $donation->did), WATCHDOG_INFO);
-        $message['send'] = FALSE;
-      }
-    }
-  }
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
@@ -333,7 +333,12 @@ function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form,
         $remote_id = (string) $response->customerProfileId . '|' . (string) $response->customerPaymentProfileIdList->numericString;
 
         // Load the card on file values for this donation
-        $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
+        $expires = array();
+        // If no expiration date given, use current date + 1 month
+        $expire_time = strtotime("now + 1 month");
+
+        $expires['month'] = date('m', $expire_time);
+        $expires['year'] = date('Y', $expire_time);
 
         $card_data = commerce_cardonfile_new();
         $card_data->uid = $order->uid;

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
@@ -106,7 +106,6 @@ function commerce_authnet_echeck_submit_form($payment_method, $pane_values = arr
   $fields = drupal_map_assoc(array('bank_name', 'acct_name'));
   $fields['type'] = drupal_map_assoc(array(
     'checking',
-    'businesschecking',
     'savings',
   ));
 
@@ -512,7 +511,6 @@ function commerce_authnet_echeck_payment_validate_account($number) {
 function commerce_authnet_echeck_payment_types() {
   return array(
     'checking' => t('Checking'),
-    'businesschecking' => t('Business Checking'),
     'savings' => t('Savings'),
   );
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
@@ -1,0 +1,441 @@
+<?php
+
+/**
+ * @file
+ * Commerce Authorize.Net eCheck Payment Methods.
+ */
+
+/**
+ * Payment method callback: settings form.
+ */
+function commerce_authnet_echeck_settings_form($settings = NULL) {
+  $form = array();
+
+  // Merge default settings into the stored settings array.
+  $settings = (array) $settings + array(
+    'login' => '',
+    'tran_key' => '',
+    'txn_mode' => AUTHNET_TXN_MODE_LIVE_TEST,
+    'log' => array('request' => '0', 'response' => '0'),
+  );
+
+  $form['login'] = array(
+    '#type' => 'textfield',
+    '#title' => t('API Login ID'),
+    '#description' => t('Your API Login ID is different from the username you
+       use to login to your Authorize.Net account. Once you login, browse to
+       your Account tab and click the API Login ID and Transaction Key link to
+       find your API Login ID. If you are using a new Authorize.Net account,
+       you may still need to generate an ID.'),
+    '#default_value' => $settings['login'],
+    '#required' => TRUE,
+  );
+
+  $form['tran_key'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Transaction Key'),
+    '#description' => t('Your Transaction Key can be found on the same screen as
+      your API Login ID. However, it will not be readily displayed. You must answer
+      your security question and submit a form to see your Transaction Key.'),
+    '#default_value' => $settings['tran_key'],
+    '#required' => TRUE,
+  );
+
+  $form['txn_mode'] = array(
+    '#type' => 'radios',
+    '#title' => t('Transaction Mode'),
+    '#description' => t('Adjust to live transactions when you are ready to start
+      processing real payments.<br />Only specify a developer test account if
+      you login to your account through https://test.authorize.net.'),
+    '#options' => array(
+      AUTHNET_TXN_MODE_LIVE => t('Live transactions in a live account'),
+      AUTHNET_TXN_MODE_LIVE_TEST => t('Test transactions in a live account'),
+      AUTHNET_TXN_MODE_DEVELOPER => t('Developer test account transactions'),
+    ),
+    '#default_value' => $settings['txn_mode'],
+  );
+
+  $form['log'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Log the following messages for debugging'),
+    '#options' => array(
+      'request' => t('API request messages'),
+      'response' => t('API response messages'),
+    ),
+    '#default_value' => $settings['log'],
+  );
+
+  return $form;
+}
+
+/**
+ * Payment method callback: checkout form.
+ */
+function commerce_authnet_echeck_submit_form($payment_method, $pane_values = array(), $checkout_pane = NULL, $order = NULL) {
+  $fields = drupal_map_assoc(array('bank_name', 'acct_name'));
+  $fields['type'] = drupal_map_assoc(array(
+    'checking',
+    'business_checking',
+    'savings',
+  ));
+
+  // Merge default values into the default array.
+  $default = array(
+    'aba_code' => '',
+    'acct_num' => '',
+    'confirm_acct_num' => '',
+    'type' => '',
+    'bank_name' => '',
+    'acct_name' => '',
+    'code' => '',
+  );
+
+  $form['bank account'] = array(
+    '#tree' => TRUE,
+  );
+
+  // Always add a field for the eCheck routing number.
+  $form['bank account']['aba_code'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Routing Number'),
+    '#default_value' => $default['aba_code'],
+    '#attributes' => array('autocomplete' => 'off'),
+    '#required' => TRUE,
+    '#maxlength' => 9,
+    '#size' => 10,
+  );
+
+  // Always add a field for the eCheck account number and confirmation.
+  $form['bank account']['acct_num'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Account Number'),
+    '#default_value' => $default['acct_num'],
+    '#attributes' => array('autocomplete' => 'off'),
+    '#required' => TRUE,
+    '#maxlength' => 20,
+    '#size' => 21,
+  );
+  $form['bank account']['confirm_acct_num'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Confirm Account Number'),
+    '#default_value' => $default['confirm_acct_num'],
+    '#attributes' => array('autocomplete' => 'off'),
+    '#required' => TRUE,
+    '#maxlength' => 20,
+    '#size' => 21,
+  );
+
+  // Add an account type selector if specified.
+  if (isset($fields['type'])) {
+    $form['bank account']['type'] = array(
+      '#type' => 'select',
+      '#title' => t('Account Type'),
+      '#options' => array_intersect_key(commerce_authnet_echeck_payment_types(), drupal_map_assoc((array) $fields['type'])),
+      '#default_value' => $default['type'],
+      '#required' => TRUE,
+    );
+    $form['bank account']['valid_types'] = array(
+      '#type' => 'value',
+      '#value' => $fields['type'],
+    );
+  }
+  else {
+    $form['bank account']['valid_types'] = array(
+      '#type' => 'value',
+      '#value' => array(),
+    );
+  }
+
+  // Add a field for the bank name if specified.
+  if (isset($fields['bank_name'])) {
+    $form['bank account']['bank_name'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Bank Name'),
+      '#default_value' => $default['bank_name'],
+      '#attributes' => array('autocomplete' => 'off'),
+      '#required' => TRUE,
+      '#maxlength' => 64,
+      '#size' => 32,
+    );
+  }
+
+  // Add a field for the account owner if specified.
+  if (isset($fields['acct_name'])) {
+    $form['bank account']['acct_name'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Account Owner'),
+      '#default_value' => $default['acct_name'],
+      '#attributes' => array('autocomlete' => 'off'),
+      '#required' => TRUE,
+      '#maxlength' => 64,
+      '#size' => 32,
+    );
+  }
+
+  return $form;
+}
+
+/**
+ * Payment method callback: checkout form validation.
+ */
+function commerce_authnet_echeck_submit_form_validate($payment_method, $pane_form, $pane_values, $order, $form_parents = array()) {
+  // Validate the echeck fields.
+  $settings = array(
+    'form_parents' => array_merge($form_parents, array('bank account')),
+  );
+
+  if (!commerce_authnet_echeck_payment_validate($pane_values['bank account'], $settings)) {
+    return FALSE;
+  }
+}
+
+/**
+ * Payment method callback: checkout form submission.
+ */
+function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form, $pane_values, $order, $charge) {
+  // Build a name-value pair array for this transaction.
+  $nvp = array(
+    'x_method' => 'ECHECK',
+    'x_bank_aba_code' => $pane_values['bank account']['aba_code'],
+    'x_bank_acct_num' => $pane_values['bank account']['acct_num'],
+    'x_bank_acct_type' => isset($pane_values['bank account']['type']) ? str_replace('', '_', strtoupper($pane_values['bank account']['type'])) : '',
+    'x_bank_name' => isset($pane_values['bank account']['bank_name']) ? substr($pane_values['bank account']['bank_name'], 0, 50) : '',
+    'x_bank_acct_name' => isset($pane_values['bank account']['bank_name']) ? substr($pane_values['bank account']['acct_name'], 0, 50) : '',
+    'x_echeck_type' => 'WEB',
+    'x_recurring_billing' => 'FALSE',
+    'x_amount' => commerce_currency_amount_to_decimal($charge['amount'], $charge['currency_code']),
+  );
+
+  // Add additional transaction information to the request array.
+  commerce_authnet_echeck_request_order_details($nvp, $order);
+
+  // Submit the request to Authorize.Net.
+  $response = commerce_authnet_aim_request($payment_method, $nvp);
+
+  // Prepare a transaction object to log the API response.
+  $transaction = commerce_payment_transaction_new($payment_method['method_id'], $order->order_id);
+  $transaction->instance_id = $payment_method['instance_id'];
+  $transaction->remote_id = $response[6];
+  $transaction->amount = $charge['amount'];
+  $transaction->currenct_code = $charge['currency_code'];
+  $transaction->payload[REQUEST_TIME] = $response;
+
+  // Set transaction status from response code.
+  if ($response[0] == '1') {
+    $transaction->status = COMMERCE_PAYMENT_STATUS_SUCCESS;
+    $reason_text = t('APPROVED');
+  }
+  elseif ($response[0] == '4') {
+    $transaction->status = COMMERCE_PAYMENT_STATUS_PENDING;
+    $reason_text = t('PENDING');
+  }
+  else {
+    $transaction->status = COMMERCE_PAYMENT_STATUS_FAILURE;
+    $reason_text = t('REJECTED');
+  }
+
+  // Store the type of transaction in the remote status.
+  $transaction->remote_status = $response[11];
+
+  // Build a meaningful response message.
+  $message = array(
+    '<b>ECHECK</b>',
+    '<b>' . $reason_text . ':</b> ' . check_plain($response[3]),
+  );
+
+  // Add the CVV response if enabled.
+  if (!empty($response[6])) {
+    $message[] = t('TransactionID: @txn_id', array('@txn_id' => $response[6]));
+  }
+
+  $transaction->message = implode('<br />', $message);
+
+  // Save the transaction information.
+  commerce_payment_transaction_save($transaction);
+
+  // If the payment failed, display an error and rebuild the form.
+  if ($response[0] == '4') {
+    drupal_set_message(t('We received the following notice processing your eCheck. Please enter your information again or try a different account.'), 'warning');
+    drupal_set_message(check_plain($response[3]), 'warning');
+    return FALSE;
+  }
+  elseif ($response[0] != '1') {
+    drupal_set_message(t('We received the following error processing your eCheck. Please enter your information again or try a different account.'), 'error');
+    drupal_set_message(check_plain($response[3]), 'error');
+    return FALSE;
+  }
+}
+
+/**
+ * Replicates the order details population in commerce_authnet.
+ */
+function commerce_authnet_echeck_request_order_details(&$nvp, $order) {
+  $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
+
+  // Build a description for the order.
+  $description = array();
+  // Descriptions come from products, though not all environments have them.
+  if (function_exists('commerce_product_line_item_types')) {
+    foreach ($order_wrapper->commerce_line_items as $line_item_wrapper) {
+      if (in_array($line_item_wrapper->type->value(), commerce_product_line_item_types())) {
+        $description[] = round($line_item_wrapper->quantity->value(), 2) . 'x '
+          . $line_item_wrapper->line_item_label->value();
+      }
+    }
+  }
+
+  // Add additional transaction invormation to the request array.
+  $nvp += array(
+    // Order Information.
+    'x_invoice_num' => $order->order_number,
+    'x_description' => substr(implode(', ', $description), 0, 255),
+
+    // Customer Information.
+    'x_email' => substr($order->mail, 0, 255),
+    'x_cust_id' => substr($order->uid, 0, 20),
+    'x_customer_ip' => substr(ip_address(), 0, 15),
+  );
+
+  // Prepare the billing address for use in the request.
+  if (isset($order->commerce_customer_billing) && $order_wrapper->commerce_customer_billing->value()) {
+    $billing_address = $order_wrapper->commerce_customer_billing->commerce_customer_address->value();
+
+    if (empty($billing_address['first_name'])) {
+      $name_parts = explode(' ', $billing_address['name_line']);
+      $billing_address['first_name'] = array_shift($name_parts);
+      $billing_address['last_name'] = implode(' ', $name_parts);
+    }
+
+    $nvp += array(
+      // Customer Billing Address.
+      'x_first_name' => substr($billing_address['first_name'], 0, 50),
+      'x_last_name' => substr($billing_address['last_name'], 0, 50),
+      'x_company' => substr($billing_address['organisation_name'], 0, 50),
+      'x_address' => substr($billing_address['thoroughfare'], 0, 60),
+      'x_city' => substr($billing_address['locality'], 0, 40),
+      'x_state' => substr($billing_address['administrative_area'], 0, 40),
+      'x_zip' => substr($billing_address['postal_code'], 0, 20),
+      'x_country' => $billing_address['country'],
+    );
+  }
+
+  // Prepare the shipping address for use in the request.
+  if (isset($order->commerce_customer_shipping) && $order_wrapper->commerce_customer_shipping->value()) {
+    $shipping_address = $order_wrapper->commerce_customer_shipping->commerce_customer_address->value();
+
+    if (empty($shipping_address['first_name'])) {
+      $name_parts = explode(' ', $shipping_address['name_line']);
+      $shipping_address['first_name'] = array_shift($name_parts);
+      $shipping_address['last_name'] = implode(' ', $name_parts);
+    }
+
+    $nvp += array(
+      // Customer shipping Address.
+      'x_ship_to_first_name' => substr($shipping_address['first_name'], 0, 50),
+      'x_ship_to_last_name' => substr($shipping_address['last_name'], 0, 50),
+      'x_ship_to_company' => substr($shipping_address['organisation_name'], 0, 50),
+      'x_ship_to_address' => substr($shipping_address['thoroughfare'], 0, 60),
+      'x_ship_to_city' => substr($shipping_address['locality'], 0, 40),
+      'x_ship_to_state' => substr($shipping_address['administrative_area'], 0, 40),
+      'x_ship_to_zip' => substr($shipping_address['postal_code'], 0, 20),
+      'x_ship_to_country' => $shipping_address['country'],
+    );
+  }
+}
+
+/**
+ * Validates a set of eCheck details entered via the eCheck form.
+ *
+ * @param array $details
+ *   An array of eCheck details as retrieved from the eCheck array in the for
+ *   values of a form containing the eCheck form.
+ * @param array $settings
+ *   Settings used for calling validation functions and setting form errors:
+ *     form_parents: an array of parent elements identifying where the eCheck
+ *     form was situated in the form array.
+ *
+ * @return bool
+ *   TRUE or FALSE indicating the validity of all the data.
+ *
+ * @see commerce_payment_echeck_form()
+ */
+function commerce_authnet_echeck_payment_validate($details, $settings) {
+  $prefix = implode('][', $settings['form_parents']) . '][';
+  $valid = TRUE;
+
+  // Validate the aba (routing) number.
+  if (!commerce_authnet_echeck_payment_validate_aba($details['aba_code'])) {
+    form_set_error($prefix . 'aba_code', t('You have entered an invalid routing number.'));
+    $valid = FALSE;
+  }
+
+  // Ensure that the account numbers match.
+  if ($details['acct_num'] != $details['confirm_acct_num']) {
+    form_set_error($prefix . 'acct_num', t('The account numbers do not match.'));
+    form_set_error($prefix . 'confirm_acct_num');
+  }
+
+  // Validate the account number.
+  if (!commerce_authnet_echeck_payment_validate_account($details['acct_num'])) {
+    form_set_error($prefix . 'acct_num', t('You have entered an invalid account number.'));
+    $valid = FALSE;
+  }
+
+  return $valid;
+}
+
+/**
+ * Validates an eCheck aba number.
+ *
+ * @param int $number
+ *   The eCheck number to validate.
+ *
+ * @return bool
+ *   TRUE or FALSE indicating the number's validity.
+ *
+ * @see http://www.zend.com//code/codex.php?ozid=968&single=1
+ */
+function commerce_authnet_echeck_payment_validate_aba($number) {
+  // First, check for 9 digits and non-numeric characters.
+  if (preg_match("/^[0-9]{9}$/", $number)) {
+    $n = 0;
+    for ($i = 0; $i < 9; $i += 3) {
+      $n += (substr($number, $i, 1) * 3)
+          + (substr($number, $i + 1, 1) * 7)
+          + (substr($number, $i + 2, 1));
+    }
+
+    // If the resulting sum is an even multiple of ten (but not zero),
+    // the aba routing number is good.
+    if ($n != 0 && $n % 10 == 0) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+ * Validates an eCheck account number.
+ *
+ * @param int $number
+ *   The eCheck account number to validate.
+ *
+ * @return bool
+ *   TRUE or FALSE indicating the number's validity.
+ */
+function commerce_authnet_echeck_payment_validate_account($number) {
+  // First, check for up to 20 digits and numeric characters.
+  return preg_match("/^[0-9]{1,20}$/", $number);
+}
+
+/**
+ * Returns an associative array of eCheck types.
+ */
+function commerce_authnet_echeck_payment_types() {
+  return array(
+    'checking' => t('Checking'),
+    'business_checking' => t('Business Checking'),
+    'savings' => t('Savings'),
+  );
+}

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
@@ -18,6 +18,7 @@ function commerce_authnet_echeck_settings_form($settings = NULL) {
     'email_customer' => FALSE,
     'txn_mode' => AUTHNET_TXN_MODE_LIVE_TEST,
     'log' => array('request' => '0', 'response' => '0'),
+    'cardonfile' => FALSE
   );
 
   $form['login'] = array(

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
@@ -106,7 +106,7 @@ function commerce_authnet_echeck_submit_form($payment_method, $pane_values = arr
   $fields = drupal_map_assoc(array('bank_name', 'acct_name'));
   $fields['type'] = drupal_map_assoc(array(
     'checking',
-    'business_checking',
+    'businesschecking',
     'savings',
   ));
 
@@ -512,7 +512,7 @@ function commerce_authnet_echeck_payment_validate_account($number) {
 function commerce_authnet_echeck_payment_types() {
   return array(
     'checking' => t('Checking'),
-    'business_checking' => t('Business Checking'),
+    'businesschecking' => t('Business Checking'),
     'savings' => t('Savings'),
   );
 }

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_authnet_echeck/includes/commerce_authnet_echeck.echeck.inc
@@ -343,7 +343,6 @@ function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form,
           $remote_id = (string) $response->customerProfileId . '|' . (string) $response->customerPaymentProfileIdList->numericString;
 
           // Load the card on file values for this donation
-          $cardonfile_fields = _fundraiser_commerce_credit_card_cardonfile_fields($donation);
           $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
 
           $card_data = commerce_cardonfile_new();
@@ -353,7 +352,7 @@ function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form,
           $card_data->remote_id = $remote_id;
           $card_data->card_type = !empty($card_type) ? $card_type : 'card';
           $card_data->card_name = !empty($billing_address['name_line']) ? $billing_address['name_line'] : '';
-          $card_data->card_number = $cardonfile_fields['card_number'];
+          $card_data->card_number = substr($pane_values['bank account']['acct_num'], -3);
           $card_data->card_exp_month = $expires['month'];
           $card_data->card_exp_year = $expires['year'];
           $card_data->status = 1;
@@ -391,6 +390,7 @@ function commerce_authnet_echeck_submit_form_submit($payment_method, $pane_form,
         $remote_id = $add_to_profile . '|' . (string) $response->customerPaymentProfileId;
 
         // Load the card on file values for this donation
+        $donation = fundraiser_donation_get_donation($order->order_id);
         $cardonfile_fields = _fundraiser_commerce_credit_card_cardonfile_fields($donation);
         $expires = commerce_authnet_echeck_fundraiser_commerce_expire(array());
 

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -2312,7 +2312,7 @@ function fundraiser_sustainers_edit_form($did) {
   else {
     $billing_update_form = t('This recurring donation has been cancelled.');
   }
-  $billing_update_form = '<div id="donation-billing-form"><h2>Update Your Credit Card Information</h2>' . $billing_update_form . '</div>';
+  $billing_update_form = '<div id="donation-billing-form"><h2>Update Your Payment Information</h2>' . $billing_update_form . '</div>';
 
   if ($remaining_donation_count > 0 && empty($cancelled)) {
     $cancel_form_array = drupal_get_form('fundraiser_sustainers_cancel_form', $next_donation);
@@ -2802,7 +2802,7 @@ function fundraiser_sustainers_billing_update_form_validate($form, &$form_state)
 
   if (form_get_errors() || count($credit_card_errors) || $errors) {
     // We've set a form_error by now.
-    drupal_set_message(t('Unable to update credit card information.'));
+    drupal_set_message(t('Unable to update payment information.'));
   }
 }
 


### PR DESCRIPTION
This code adds a payment gateway for authnet echeck.net. One-time and initial recurring transactions take place using AIM, subsequent payments take place using CIM. This code does not include any support for refunds.