### PR TITLE
Store card_id in fundraiser donation

### DIFF
--- a/fundraiser/fundraiser.install
+++ b/fundraiser/fundraiser.install
@@ -184,13 +184,6 @@ function fundraiser_schema() {
       'nid_uid' => array('nid', 'uid'),
     ),
   );
-  if (module_exists('commerce_cardonfile')) {
-    $schema['fundraiser_donation']['fields']['card_id'] = array(
-      'description' => 'The cardonfile card ID used to process this donation',
-      'type' => 'int',
-    );
-    $schema['fundraiser_donation']['indexes']['card_id'] = array('card_id');
-  }
   $schema['fundraiser_refund'] = array(
     'description' => 'Stores information about refunds made on donations',
     'fields' => array(
@@ -556,29 +549,10 @@ function fundraiser_update_7009() {
  * Add card_id field to fundraiser_donation.
  */
 function fundraiser_update_7010() {
-  if (module_exists('commerce_cardonfile')) {
-    $field = array(
-      'description' => 'The cardonfile card ID used to process this donation',
-      'type' => 'int',
-    );
-    db_add_field('fundraiser_donation', 'card_id', $field);
-    db_add_index('fundraiser_donation', 'card_id', array('card_id'));
-  }
-}
-
-/**
- * Implements hook_modules_installed().
- *
- * Used to add card_id field to fundraiser_donation table if commerce_cardonfile
- * module is being enabled.
- */
-function fundraiser_modules_installed($modules) {
-  if (in_array('commerce_cardonfile', $modules)) {
-    $field = array(
-      'description' => 'The cardonfile card ID used to process this donation',
-      'type' => 'int',
-    );
-    db_add_field('fundraiser_donation', 'card_id', $field);
-    db_add_index('fundraiser_donation', 'card_id', array('card_id'));
-  }
+  $field = array(
+    'description' => 'The cardonfile card ID used to process this donation',
+    'type' => 'int',
+  );
+  db_add_field('fundraiser_donation', 'card_id', $field);
+  db_add_index('fundraiser_donation', 'card_id', array('card_id'));
 }

--- a/fundraiser/fundraiser.install
+++ b/fundraiser/fundraiser.install
@@ -167,6 +167,10 @@ function fundraiser_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'card_id' => array(
+        'description' => 'The cardonfile card ID used to process this donation',
+        'type' => 'int',
+      ),
       // @todo Add transaction information here with the gateway.
     ),
     'primary key' => array('did'),

--- a/fundraiser/fundraiser.install
+++ b/fundraiser/fundraiser.install
@@ -184,6 +184,13 @@ function fundraiser_schema() {
       'nid_uid' => array('nid', 'uid'),
     ),
   );
+  if (module_exists('commerce_cardonfile')) {
+    $schema['fundraiser_donation']['fields']['card_id'] = array(
+      'description' => 'The cardonfile card ID used to process this donation',
+      'type' => 'int',
+    );
+    $schema['fundraiser_donation']['indexes']['card_id'] = array('card_id');
+  }
   $schema['fundraiser_refund'] = array(
     'description' => 'Stores information about refunds made on donations',
     'fields' => array(
@@ -542,5 +549,36 @@ function fundraiser_update_7009() {
         );
       }
     }
+  }
+}
+
+/**
+ * Add card_id field to fundraiser_donation.
+ */
+function fundraiser_update_7010() {
+  if (module_exists('commerce_cardonfile')) {
+    $field = array(
+      'description' => 'The cardonfile card ID used to process this donation',
+      'type' => 'int',
+    );
+    db_add_field('fundraiser_donation', 'card_id', $field);
+    db_add_index('fundraiser_donation', 'card_id', array('card_id'));
+  }
+}
+
+/**
+ * Implements hook_modules_installed().
+ *
+ * Used to add card_id field to fundraiser_donation table if commerce_cardonfile
+ * module is being enabled.
+ */
+function fundraiser_modules_installed($modules) {
+  if (in_array('commerce_cardonfile', $modules)) {
+    $field = array(
+      'description' => 'The cardonfile card ID used to process this donation',
+      'type' => 'int',
+    );
+    db_add_field('fundraiser_donation', 'card_id', $field);
+    db_add_index('fundraiser_donation', 'card_id', array('card_id'));
   }
 }

--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1954,6 +1954,7 @@ function fundraiser_donation_update($donation, $vocal_mode = TRUE) {
     $donation_record['form_url'] = $donation->form_url;
   }
   $donation_record['changed'] = REQUEST_TIME;
+  drupal_alter('fundraiser_donation_update_record', $donation, $donation_record);
   _fundraiser_update_donation($donation_record);
   // Refresh the cache. No need to change the donation object passed in, but stored values should be zapped.
   fundraiser_donation_get_donation($donation->did, TRUE);

--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1890,7 +1890,6 @@ function fundraiser_donation_create($donation) {
   elseif (is_array($donation->gateway) && isset($donation->gateway['id']) && !empty($donation->gateway['id'])) {
     $donation_record['gateway'] = $donation->gateway['id'];
   }
-  drupal_alter('fundraiser_donation_create_record', $donation, $donation_record);
   _fundraiser_create_donation($donation_record);
   // Add a comment.
   global $user;
@@ -1953,8 +1952,10 @@ function fundraiser_donation_update($donation, $vocal_mode = TRUE) {
   if (isset($donation->form_url) && !empty($donation->form_url)) {
     $donation_record['form_url'] = $donation->form_url;
   }
+  if (isset($donation->data['cardonfile']) && !empty($donation->data['cardonfile']) && $donation->status == 'payment_received') {
+    $donation_record['cardonfile'] = $donation->data['cardonfile'];
+  }
   $donation_record['changed'] = REQUEST_TIME;
-  drupal_alter('fundraiser_donation_update_record', $donation, $donation_record);
   _fundraiser_update_donation($donation_record);
   // Refresh the cache. No need to change the donation object passed in, but stored values should be zapped.
   fundraiser_donation_get_donation($donation->did, TRUE);

--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1890,6 +1890,7 @@ function fundraiser_donation_create($donation) {
   elseif (is_array($donation->gateway) && isset($donation->gateway['id']) && !empty($donation->gateway['id'])) {
     $donation_record['gateway'] = $donation->gateway['id'];
   }
+  drupal_alter('fundraiser_donation_create_record', $donation, $donation_record);
   _fundraiser_create_donation($donation_record);
   // Add a comment.
   global $user;

--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -1953,7 +1953,7 @@ function fundraiser_donation_update($donation, $vocal_mode = TRUE) {
     $donation_record['form_url'] = $donation->form_url;
   }
   if (isset($donation->data['cardonfile']) && !empty($donation->data['cardonfile']) && $donation->status == 'payment_received') {
-    $donation_record['cardonfile'] = $donation->data['cardonfile'];
+    $donation_record['card_id'] = $donation->data['cardonfile'];
   }
   $donation_record['changed'] = REQUEST_TIME;
   _fundraiser_update_donation($donation_record);

--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.install
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.install
@@ -81,7 +81,7 @@ function fundraiser_commerce_schema() {
     ),
    'indexes' => array(
       'lid' => array('lid'),
-    ),  
+    ),
   );
   return $schema;
 }

--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -2943,3 +2943,15 @@ function fundraiser_commerce_gateway_image_validate($element, &$form_state, $for
     form_error($element, t('Unselected image field is required'));
   }
 }
+
+/**
+ * Implements hook_fundraiser_donation_create_record_alter().
+ */
+function fundraiser_commerce_fundraiser_donation_create_record_alter($donation, &$donation_record) {
+  if (module_exists('commerce_cardonfile')) {
+    $card = _fundraiser_commerce_donation_cardonfile_card($donation);
+    if (!empty($card)) {
+      $donation_record['card_id'] = $card->card_id;
+    }
+  }
+}

--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -2948,6 +2948,13 @@ function fundraiser_commerce_gateway_image_validate($element, &$form_state, $for
  * Implements hook_fundraiser_donation_create_record_alter().
  */
 function fundraiser_commerce_fundraiser_donation_create_record_alter($donation, &$donation_record) {
+  fundraiser_commerce_fundraiser_donation_update_record_alter($donation, $donation_record);
+}
+
+/**
+ * Implements hook_fundraiser_donation_update_record_alter().
+ */
+function fundraiser_commerce_fundraiser_donation_update_record_alter($donation, &$donation_record) {
   if (module_exists('commerce_cardonfile')) {
     $card = _fundraiser_commerce_donation_cardonfile_card($donation);
     if (!empty($card)) {

--- a/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
+++ b/fundraiser/modules/fundraiser_commerce/fundraiser_commerce.module
@@ -2943,22 +2943,3 @@ function fundraiser_commerce_gateway_image_validate($element, &$form_state, $for
     form_error($element, t('Unselected image field is required'));
   }
 }
-
-/**
- * Implements hook_fundraiser_donation_create_record_alter().
- */
-function fundraiser_commerce_fundraiser_donation_create_record_alter($donation, &$donation_record) {
-  fundraiser_commerce_fundraiser_donation_update_record_alter($donation, $donation_record);
-}
-
-/**
- * Implements hook_fundraiser_donation_update_record_alter().
- */
-function fundraiser_commerce_fundraiser_donation_update_record_alter($donation, &$donation_record) {
-  if (module_exists('commerce_cardonfile')) {
-    $card = _fundraiser_commerce_donation_cardonfile_card($donation);
-    if (!empty($card)) {
-      $donation_record['card_id'] = $card->card_id;
-    }
-  }
-}


### PR DESCRIPTION
This update stores the card_id that was stored after a successful donation in the fundraiser_donation table. This will make it possible to query which stored card is attached to a sustainer series.

TODO
* There currently isn't an upgrade path. Ideally the update hook would load all existing donations, extract the card_id from $donation->data and store it in the new location. This will require a batched operation because it will require loading every donation.
