### PR TITLE
7.x 4.11.2 hotfix dw

### DIFF
--- a/springboard_dw/includes/springboard_dw.api.inc
+++ b/springboard_dw/includes/springboard_dw.api.inc
@@ -108,16 +108,15 @@ function springboard_dw_api_call($endpoint_route, $params, $method = 'POST') {
 
     $watchdog_string = "<pre>Warehouse API call: \n" . print_r($api_call, TRUE) . "</pre>";
 
-    // Log the full API call details to watchdog.
-    watchdog("data_warehouse", $watchdog_string);
+    // Log the full API call details to watchdog if logging is enabled.
+    springboard_dw_watchdog_log($watchdog_string);
 
     return $api_response;
   }
   catch (guzzle_client_exception $e) {
-
+    // Log the full API call failure details to watchdog if logging is enabled.
     $watchdog_string = '<pre>' . print_r($e, TRUE) . '</pre>';
-
-    watchdog("data_warehouse", $watchdog_string);
+    springboard_dw_watchdog_log($watchdog_string);
   }
 }
 

--- a/springboard_dw/includes/springboard_dw.queue.inc
+++ b/springboard_dw/includes/springboard_dw.queue.inc
@@ -48,9 +48,7 @@ function springboard_dw_process_queue() {
 
       // If watchdog logging is enabled for item processing and API request
       // failures log this queue process failure here.
-      if (variable_get('springboard_dw_watchdog_enabled')) {
-        watchdog("data_warehouse", $error_log_string);
-      }
+      springboard_dw_watchdog_log($error_log_string);
 
       // Add this failed item to the failed queue items array.
       $failed_queue_items[] = $item;

--- a/springboard_dw/modules/springboard_dw_queue_legacy/springboard_dw_queue_legacy.drush.inc
+++ b/springboard_dw/modules/springboard_dw_queue_legacy/springboard_dw_queue_legacy.drush.inc
@@ -159,7 +159,7 @@ function springboard_dw_queue_legacy_setup_batch($type = '') {
     if (variable_get('springboard_dw_advocacy_authentication_token') == NULL
           || variable_get('springboard_dw_advocacy_api_endpoint') == NULL
       ) {
-      springboard_dw_watchdog_log('API endpoint and/or authentication token
+      watchdog('data_warehouse','API endpoint and/or authentication token
       have not been set.', NULL, WATCHDOG_ERROR, l(t('Fix this on the config page'),
         'admin/config/services/springboard-dw'));
       return drush_set_error(dt('API endpoint and/or authentication token have not been set.'));
@@ -195,7 +195,8 @@ function springboard_dw_queue_legacy_setup_batch($type = '') {
   $record_count = count($records);
   drush_log(dt('@count records found to process.', array('@count' => $record_count)), 'ok');
   if ($record_count < 1 && !$idlist) {
-    springboard_dw_watchdog_log('Attempted to process %type records when there are :record_count remaining.', array('%type' => $type, ':record_count' => $record_count), WATCHDOG_WARNING);
+    watchdog('data_warehouse', 'Attempted to process %type records when there
+     are :record_count remaining.', array('%type' => $type, ':record_count' => $record_count), WATCHDOG_WARNING);
   }
 
   // Break up all of our data so each process does not time out.

--- a/springboard_dw/modules/springboard_dw_queue_legacy/springboard_dw_queue_legacy.drush.inc
+++ b/springboard_dw/modules/springboard_dw_queue_legacy/springboard_dw_queue_legacy.drush.inc
@@ -159,7 +159,7 @@ function springboard_dw_queue_legacy_setup_batch($type = '') {
     if (variable_get('springboard_dw_advocacy_authentication_token') == NULL
           || variable_get('springboard_dw_advocacy_api_endpoint') == NULL
       ) {
-      watchdog('data_warehouse', 'API endpoint and/or authentication token
+      springboard_dw_watchdog_log('API endpoint and/or authentication token
       have not been set.', NULL, WATCHDOG_ERROR, l(t('Fix this on the config page'),
         'admin/config/services/springboard-dw'));
       return drush_set_error(dt('API endpoint and/or authentication token have not been set.'));
@@ -195,7 +195,7 @@ function springboard_dw_queue_legacy_setup_batch($type = '') {
   $record_count = count($records);
   drush_log(dt('@count records found to process.', array('@count' => $record_count)), 'ok');
   if ($record_count < 1 && !$idlist) {
-    watchdog("data_warehouse", 'Attempted to process %type records when there are :record_count remaining.', array('%type' => $type, ':record_count' => $record_count), WATCHDOG_WARNING);
+    springboard_dw_watchdog_log('Attempted to process %type records when there are :record_count remaining.', array('%type' => $type, ':record_count' => $record_count), WATCHDOG_WARNING);
   }
 
   // Break up all of our data so each process does not time out.

--- a/springboard_dw/springboard_dw.drush.inc
+++ b/springboard_dw/springboard_dw.drush.inc
@@ -43,7 +43,7 @@ function drush_springboard_dw_export_queue_process() {
   // If the data warehouse config is not set, don't try to process the queue.
   if (!variable_get('springboard_dw_api_endpoint', FALSE) || !variable_get('springboard_dw_api_endpoint', FALSE)) {
     drush_print('Could not process the data warehouse queue because config has not been set.');
-    watchdog("data_warehouse", 'Could not process the data warehouse queue because config has not been set.');
+    springboard_dw_watchdog_log('Could not process the data warehouse queue because config has not been set.');
   }
   else {
     // Provide CLI feedback.
@@ -54,6 +54,6 @@ function drush_springboard_dw_export_queue_process() {
 
     // Log to the command line with an OK status.
     drush_log('Running springboard-dw-export-queue-process', 'ok');
-    watchdog("data_warehouse", 'Running springboard-dw-export-queue-process');
+    springboard_dw_watchdog_log('Running springboard-dw-export-queue-process');
   }
 }

--- a/springboard_dw/springboard_dw.module
+++ b/springboard_dw/springboard_dw.module
@@ -84,8 +84,20 @@ function springboard_dw_menu() {
 function springboard_dw_log_queue_item($data) {
   // Check if watchdog logging is enabled.
   if (variable_get('springboard_dw_watchdog_enabled')) {
-
     $watchdog_string = '<pre>' . print_r($data, TRUE) . '</pre>';
+    watchdog("data_warehouse", $watchdog_string);
+  }
+}
+
+/**
+ * Log to watchdog if data warehouse watchdog logging setting is enabled.
+ *
+ * @param array $watchdog_string
+ *   A string to log to watchdog.
+ */
+function springboard_dw_watchdog_log($watchdog_string) {
+  // Check if watchdog logging is enabled.
+  if (variable_get('springboard_dw_watchdog_enabled')) {
     watchdog("data_warehouse", $watchdog_string);
   }
 }


### PR DESCRIPTION
This hotfix creates a utility wrapper for logging that all data warehouse module logging gets funneled through so there is a centralized check for if watchdog logging is enabled.