### PR TITLE
urlencode gift string after retrieving it

### DIFF
--- a/secure_prepopulate/dynamic_gift_strings/dynamic_gift_strings.module
+++ b/secure_prepopulate/dynamic_gift_strings/dynamic_gift_strings.module
@@ -256,7 +256,8 @@ function dynamic_gift_strings_node_load($nodes, $types) {
         $parts = drupal_parse_url($redirect_url);
         if (!isset($parts['query']['gs'])) {
           $num = count($parts['query']);
-          $qstring = $num <= 1 ? '?gs=' . $_GET['gs'] : '&gs=' . $_GET['gs'];
+          $gs = urlencode($_GET['gs']);
+          $qstring = $num <= 1 ? '?gs=' . $gs : '&gs=' . $gs;
           $node->webform['redirect_url'] = $node->webform['redirect_url'] . $qstring;
         }
       }


### PR DESCRIPTION
Ooops. Encoded url params are already decoded when retrieved from $_GET. We need to re-encode them.