### PR TITLE
fix duplicate detection issue

### DIFF
--- a/springboard_advocacy/includes/views/handlers/springboard_advocacy_views_handler_field_target_actions.inc
+++ b/springboard_advocacy/includes/views/handlers/springboard_advocacy_views_handler_field_target_actions.inc
@@ -95,6 +95,7 @@ class springboard_advocacy_views_handler_field_target_actions extends views_hand
           'title' => !empty($values->title) ? $values->title : '',
           'state' => !empty($values->state) ? $values->state : '',
           'district' => !empty($values->district_name) ? $values->district_name : '',
+          'roles' => !empty($values->roles) ? $values->roles : '',
 
           // Need to send an empty string if the last query segment is empty
           // so that the query string

--- a/springboard_advocacy/includes/views/handlers/springboard_advocacy_views_handler_field_target_actions.inc
+++ b/springboard_advocacy/includes/views/handlers/springboard_advocacy_views_handler_field_target_actions.inc
@@ -95,7 +95,7 @@ class springboard_advocacy_views_handler_field_target_actions extends views_hand
           'title' => !empty($values->title) ? $values->title : '',
           'state' => !empty($values->state) ? $values->state : '',
           'district' => !empty($values->district_name) ? $values->district_name : '',
-          'roles' => !empty($values->roles) ? $values->roles : '',
+          'role' => !empty($values->role) ? $values->role : '',
 
           // Need to send an empty string if the last query segment is empty
           // so that the query string


### PR DESCRIPTION
1. Create a target group with parameters "federal representatives | republican"
2. Search for targets with parameters Federal senators | Republican
3. Try to add an indivial senator to the recipients block.

Result: incorrect dupe target notice.

Cause: the 'Add' link is missing the 'role' paramter, so the duplication warning is triggered by the party parameter only.