### PR TITLE
Prevent duplicate upsell objects form exporting

### DIFF
--- a/fundraiser/modules/fundraiser_upsell/modules/fundraiser_upsell_salesforce/fundraiser_upsell_salesforce.module
+++ b/fundraiser/modules/fundraiser_upsell/modules/fundraiser_upsell_salesforce/fundraiser_upsell_salesforce.module
@@ -628,9 +628,31 @@ function fundraiser_upsell_salesforce_salesforce_sync_pass_item($item, $result) 
   }
 
   // Add to the queue.
-  if (is_object($sobject)) {
+  if (is_object($sobject) && !fundraiser_upsell_salesforce_upsell_is_exported($sobject)) {
     fundraiser_upsell_salesforce_queue_upsell($sobject);
   }
+}
+
+/**
+ * Determines if an upsell object has already been exported.
+ *
+ * @param $sobject
+ *   The upsell sobject being exported.
+ *
+ * @return int|bool
+ *   The id of the sync map record or FALSE if not found
+ */
+function fundraiser_upsell_salesforce_upsell_is_exported($sobject) {
+  $item = array(
+    'module' => 'fundraiser_upsell_salesforce',
+    'delta' => 'upsell',
+    'drupal_id' => $sobject->fields['Upsell_Order_Id__c'],
+    'object_type' => 'Donation_Upsell__c',
+  );
+
+  $rmid = _salesforce_sync_get_rmid($item);
+
+  return $rmid;
 }
 
 /**

--- a/springboard/modules/springboard_views/springboard_views.module
+++ b/springboard/modules/springboard_views/springboard_views.module
@@ -424,3 +424,61 @@ function springboard_views_springboard_dashboard_panes() {
   );
   return $panes;
 }
+
+/**
+ * Implements hook_views_pre_view().
+ *
+ * Remove the exposed date popup filter from the file export display to
+ * eliminate a conflict between the popup and views_data_export:
+ */
+function springboard_views_views_pre_view(&$view, &$display_id, &$args) {
+  if ($view->name != 'sbv_donations' || $display_id != 'views_data_export_1') {
+    return;
+  }
+
+  // Unset the date filter form both the default and export displays in case
+  // the default date filter is overwritten within the data export's display:
+  unset($view->display['default']->handler->options['filters']['date_filter']);
+  unset($view->display['views_data_export_1']->handler->options['filters']['date_filter']);
+}
+
+/**
+ * Implements hook_views_query_alter().
+ *
+ * Apply date_popup-based filtering to the donations report's data export display, as filtering
+ * by date can result in date formatting errors depending on the site's current, short date format.
+ */
+function springboard_views_views_query_alter(&$view, &$query) {
+  if ($view->name != 'sbv_donations' || $view->current_display != 'views_data_export_1') {
+    return;
+  }
+  $min_date = ''; $max_date = '';
+  if (isset($view->exposed_input['date_filter']['min']['date'])) {
+    $min_date = date('Y-m-d', strtotime($view->exposed_input['date_filter']['min']['date']));
+  }
+  if (isset($view->exposed_input['date_filter']['max']['date'])) {
+    $max_date = date('Y-m-d', strtotime($view->exposed_input['date_filter']['max']['date']));
+  }
+
+  if (!isset($min_date) || !isset($max_date) || empty($min_date) || empty($max_date)) {
+    return;
+  }
+
+  // Add the date filter to the WHERE clause:
+  $query->where[] = array(
+    'conditions' => array(
+      array(
+        'field' =>
+          "DATE_FORMAT(ADDTIME(FROM_UNIXTIME(commerce_order_fundraiser_donation.created), SEC_TO_TIME(-14400)), '%Y-%m-%d') >= :commerce_order_date_filter " .
+          "AND DATE_FORMAT(ADDTIME(FROM_UNIXTIME(commerce_order_fundraiser_donation.created), SEC_TO_TIME(-14400)), '%Y-%m-%d') <= :commerce_order_date_filter1",
+        'value' => array(
+          ':commerce_order_date_filter' => $min_date,
+          ':commerce_order_date_filter1' => $max_date,
+        ),
+        'operator' => 'formula',
+      ),
+    ),
+    'args' => array(),
+    'type' => 'AND',
+  );
+}


### PR DESCRIPTION
Adding a check to see if an upsell object has already been exported. This should prevent duplicates in Salesforce.