### PR TITLE
re #1130 - remove errant space

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.module
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle/commerce_litle.module
@@ -463,7 +463,7 @@ function _commerce_litle_fraud_markup($session_id = NULL) {
   $page_id = isset($node->nid) ? $node->nid : '1';
   $markup = '<div style="background:url(https://' . $subdomain . '/fp/clear.png?org_id=' . $org_id . '&amp;session_id=' . $session_id . '&amp;m=1)"></div>';
   $markup .= '<img src="https://' . $subdomain . '/fp/clear.png?org_id=' . $org_id . '&amp;session_id=' . $session_id . '&amp;m=2" />';
-  $markup .= '<script src="https://' . $subdomain . '/fp/check.js?org_id=' . $org_id . '&amp; session_id=' . $session_id . '&amp;pageid=##' . $page_id . '##"></script>';
+  $markup .= '<script src="https://' . $subdomain . '/fp/check.js?org_id=' . $org_id . '&amp;session_id=' . $session_id . '&amp;pageid=##' . $page_id . '##"></script>';
   $markup .= '<object type="application/x-shockwave-flash" data="https://' . $subdomain . '/fp/fp.swf?org_id=' . $org_id . '&amp;session_id=' . $session_id . '" width="1" height="1">';
   $markup .= '<param name="movie" value="https://' . $subdomain . '/fp/fp.swf?org_id=' . $org_id . '&amp;session_id=' . $session_id . '" /><param name="wmode" value="transparent" /> <div></div></object>';
   return $markup;


### PR DESCRIPTION
In commerce_litle.module on line 466 there is a space between "&" and "session_id." I believe this space is errant: it is causing a 'Failed to load resource: the server responded with a status of 400 (Bad request)' error in the console on a client site.