### PR TITLE
7.x 4.x fundraider designations and portal

### DIFF
--- a/fundraiser/modules/fundraiser_designations/fundraiser_designations.module
+++ b/fundraiser/modules/fundraiser_designations/fundraiser_designations.module
@@ -369,7 +369,7 @@ function fundraiser_designations_form_commerce_product_ui_product_delete_form_al
   $product = entity_load_single('commerce_product', $pid);
   if (!empty($product->type) && $product->type == 'fundraiser_designation') {
     $form['actions']['cancel']['#href'] = 'springboard/settings/config/designations';
-    $in_use = db_query("SELECT field_ffg_fd_reference_target_id FROM {field_data_field_ffg_fd_reference} WHERE fund_id = :pid", array(':pid' => $pid))->fetchField();
+    $in_use = db_query("SELECT field_ffg_fd_reference_target_id FROM {field_data_field_ffg_fd_reference} WHERE field_ffg_fd_reference_target_id = :pid", array(':pid' => $pid))->fetchField();
     if (!empty($in_use)) {
       $form['actions']['submit']['#access'] = FALSE;
       $form['actions']['cancel']['#title'] = 'Go back';


### PR DESCRIPTION
There are additional commits sonce this was last merged. three fixes:

1. Incorrect field name in select query was causing pdo on product delete confirm page.

2. The state of the recurring donation option was not being maintained after a page refresh, and was returning to the default value when dual ask amounts was enabled with radio options and checkbox. This caused the items in the cart to be out of sync with the recurring option. A form repopulator function was added to complement the cart repopulator function - saving the current value in a cookie which persists until submission.

3. when dual ask is enabled and items have been added to the cart, the dual ask element is disabled to prevent it from being out of sync with items in the cart. Setting the element to disabled caused the value to be ignored during form submission, resulting in the use of the default value and preventing recurring donations from being created. Instead, the element should have been read-only with the click event set to false to prevent changes.