### PR TITLE
convert sbp referrer fields to textarea

### DIFF
--- a/springboard/springboard.admin.inc
+++ b/springboard/springboard.admin.inc
@@ -1923,7 +1923,7 @@ function _springboard_default_user_profile($mode = 'commerce') {
     'field_name' => 'sbp_referrer',
     'type' => 'text',
     'widget' => array(
-      'type' => 'text_textfield',
+      'type' => 'text_textarea',
     ),
     'display' => array(
       'default' => array(
@@ -1937,7 +1937,7 @@ function _springboard_default_user_profile($mode = 'commerce') {
     'field_name' => 'sbp_initial_referrer',
     'type' => 'text',
     'widget' => array(
-      'type' => 'text_textfield',
+      'type' => 'text_textarea',
     ),
     'display' => array(
       'default' => array(

--- a/springboard/springboard.install
+++ b/springboard/springboard.install
@@ -109,3 +109,47 @@ function springboard_update_7003() {
   $market_source_to_user_map['sbp_device_browser'] = 'device_browser';
   variable_set('market_source_to_user_map', $market_source_to_user_map);
 }
+
+/**
+ * Change sbp_referrer and sbp_initial_referrer to textareas.
+ */
+function springboard_update_7004() {
+
+  $fields = array(
+    'sbp_referrer',
+    'sbp_initial_referrer',
+  );
+
+  foreach ($fields as $field_name) {
+    // Change the field_config table entry.
+    db_update('field_config')
+      ->fields(array('type' => 'text_long'))
+      ->condition('field_name', $field_name)
+      ->execute();
+
+    // Change the field storage tables.
+    $data_table = 'field_data_' . $field_name;
+    $revision_table = 'field_revision_' . $field_name;
+    $value_field = $field_name . '_value';
+    $textarea_spec = array(
+      'type' => 'text',
+      'size' => 'big',
+      'not null' => FALSE,
+    );
+    db_change_field($data_table, $value_field, $value_field, $textarea_spec);
+    db_change_field($revision_table, $value_field, $value_field, $textarea_spec);
+
+    // Change the field_config_instance settings so that the
+    // textarea shows up in the admin ui.
+    $result = db_query("Select entity_type, bundle FROM {field_config_instance} WHERE field_name = :name", array(':name' => $field_name));
+    foreach ($result as $instance) {
+      $instance_info = field_info_instance($instance->entity_type, $field_name, $instance->bundle);
+      $instance_info['widget']['type'] = 'text_textarea';
+      field_update_instance($instance_info);
+    }
+  }
+
+  // Clear caches.
+  field_cache_clear();
+}
+


### PR DESCRIPTION
This patch converts the sbp referrer fields to long text. It's like the patch in P2P that converts the MS referrer fields to long text, except that the P2P patch only changes the field storage, not the field instances, which in the Drupal UI continue to be textfields on the profile page. This patch converts the intances too, so that they display as textareas and do not truncate the referrer data like the p2p/ms fields doif the user is re-saved by an admin. If we don't care about that, then the instance conversions could be removed, although that would mean making the field storage config not in sync with the field instance config.
