### PR TITLE
check for session before unsetting it.

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/fundraiser_sustainers_upgrade.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/fundraiser_sustainers_upgrade.module
@@ -1066,7 +1066,9 @@ function fundraiser_sustainers_upgrade_tokenize_confirmation($status, $confirmat
  * Clear the session payload after the confirmation has been built.
  */
 function fundraiser_sustainers_process_webform_confirmation(&$vars) {
-  fundraiser_sustainers_upgrade_clear_session_payload();
+  if (!empty($vars['node']->type) && $vars['node']->type == 'sustainers_upgrade_form') {
+    fundraiser_sustainers_upgrade_clear_session_payload();
+  }
 }
 
 /**

--- a/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/fundraiser_sustainers_upgrade.module
+++ b/fundraiser/modules/fundraiser_sustainers/modules/fundraiser_sustainers_upgrade/fundraiser_sustainers_upgrade.module
@@ -814,7 +814,9 @@ function fundraiser_sustainers_upgrade_get_session_payload() {
  * Clear the session.
  */
 function fundraiser_sustainers_upgrade_clear_session_payload() {
-  unset($_SESSION['springboard_hmac']);
+  if (!empty($_SESSION) && isset($_SESSION['springboard_hmac'])) {
+    unset($_SESSION['springboard_hmac']);
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes a php notice which occurs on webform confirmatin pages when sustainer upgrade is enabled.  Adds checks for:
1. That we are on a confirmation page belonging to the sustainer upgrade node type;
2. That the session var exists.