### PR TITLE
7.x 4.12 beta 1139 user role assign

### DIFF
--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -79,8 +79,11 @@ function springboard_admin_form_alter(&$form, &$form_state, $form_id) {
   switch ($form_id) {
     case 'user_account_form':
     case 'user_profile_form':
-      $roles = array_map('check_plain', user_roles(TRUE));
-      $form['account']['roles']['#access'] = $roles && (user_access('assign user roles') || user_access('administer permissions'));
+    case 'user_register_form':
+      if (!empty($form['account']['roles'])) {
+        $roles = array_map('check_plain', user_roles(TRUE));
+        $form['account']['roles']['#access'] = $roles && (user_access('assign user roles') || user_access('administer permissions'));
+      }
       break;
 
     case 'clone_node_confirm':

--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -82,6 +82,12 @@ function springboard_admin_form_alter(&$form, &$form_state, $form_id) {
     case 'user_register_form':
       if (!empty($form['account']['roles'])) {
         $roles = array_map('check_plain', user_roles(TRUE));
+        unset($roles[DRUPAL_AUTHENTICATED_RID]);
+        $admin = array_search("Administrator", $roles);
+        if (!empty($admin) && (user_access('assign user roles') && !user_access('administer permissions'))) {
+          unset($roles[$admin]);
+        }
+        $form['account']['roles']['#options'] = $roles;
         $form['account']['roles']['#access'] = $roles && (user_access('assign user roles') || user_access('administer permissions'));
       }
       break;

--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -78,7 +78,7 @@ function springboard_admin_form_alter(&$form, &$form_state, $form_id) {
 
   switch ($form_id) {
     // Allow users with the custom "assign user roles"
-    // permission to assign user roles to every role except administrator.
+    // permission to assign user roles to every role except disallowed roles.
     case 'user_account_form':
     case 'user_profile_form':
     case 'user_register_form':
@@ -88,21 +88,27 @@ function springboard_admin_form_alter(&$form, &$form_state, $form_id) {
         $roles = array_map('check_plain', user_roles(TRUE));
         // Unset authenticated role like user.module does.
         unset($roles[DRUPAL_AUTHENTICATED_RID]);
-        // Find the administrator role so we can disable it.
+        // Find the disallowed roles so we can disable them.
         $admin = array_search("Administrator", $roles);
-        // Do the same disabling of admin role checkbox that
+        $default = $admin ? $admin : '';
+        $disallowed = array_filter(variable_get('springboard_disallowed_roles', array($default)));
+        // Do the same disabling of disallowed role checkbox that
         // user.module does to the authenticated role checkbox.
         if (!empty($admin) && (user_access('assign user roles') && !user_access('administer permissions'))) {
-          $admin_checkbox = array(
-            '#type' => 'checkbox',
-            '#title' => $roles[$admin],
-            '#default_value' => in_array($admin, $form['account']['roles']['#default_value']),
-            '#disabled' => TRUE,
-          );
-          // Remove admin from the regular set of checkboxes.
-          unset($roles[$admin]);
-          // Add it back separately.
-          $form['account']['roles'][$admin] = $admin_checkbox;
+          foreach ($disallowed as $role_id) {
+            $admin_checkbox = array(
+              '#type' => 'checkbox',
+              '#title' => $roles[$role_id],
+              '#default_value' => in_array($role_id, $form['account']['roles']['#default_value']),
+              '#disabled' => TRUE,
+              '#weight' => 0,
+              '#description' => t('You do not have permission to assign this role.'),
+            );
+            // Remove disallowed from the regular set of checkboxes.
+            unset($roles[$role_id]);
+            // Add it back separately.
+            $form['account']['roles'][$role_id] = $admin_checkbox;
+          }
         }
         // Override user.module with our new roles and permission check.
         $form['account']['roles']['#options'] = $roles;
@@ -246,7 +252,18 @@ function springboard_admin_form_springboard_admin_settings_alter(&$form, &$form_
       '#options' => $roles,
       '#default_value' => variable_get('springboard_user_experience', array_keys($roles)),
     );
-
+    if (user_access('administer permissions')) {
+      $allowed_roles = array_map('check_plain', user_roles(TRUE));
+      $admin = array_search("Administrator", $allowed_roles);
+      $default = $admin ? $admin : '';
+      $form['admin']['springboard_disallowed_roles'] = array(
+        '#type' => 'checkboxes',
+        '#title' => t('Disallowed role assignments'),
+        '#description' => t('Choose which roles are disallowed when users with the "assign user roles" permission assign roles to users.'),
+        '#options' => $allowed_roles,
+        '#default_value' => variable_get('springboard_disallowed_roles', array($default)),
+      );
+    }
     // Field for selecting form types.
     $form['admin']['springboard_admin_allowed_form_types'] = array(
       '#type' => 'checkboxes',

--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -254,12 +254,13 @@ function springboard_admin_form_springboard_admin_settings_alter(&$form, &$form_
     );
     if (user_access('administer permissions')) {
       $allowed_roles = array_map('check_plain', user_roles(TRUE));
+      unset($allowed_roles[DRUPAL_AUTHENTICATED_RID]);
       $admin = array_search("Administrator", $allowed_roles);
       $default = $admin ? $admin : '';
       $form['admin']['springboard_disallowed_roles'] = array(
         '#type' => 'checkboxes',
         '#title' => t('Disallowed role assignments'),
-        '#description' => t('Choose which roles are disallowed when users with the "assign user roles" permission assign roles to users.'),
+        '#description' => t('Choose which roles are disallowed when administrators with the "assign user roles" permission assign roles to users. Administrators with the "administer permissions" permission are exempt from this limitation.'),
         '#options' => $allowed_roles,
         '#default_value' => variable_get('springboard_disallowed_roles', array($default)),
       );

--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -77,16 +77,34 @@ function springboard_admin_form_alter(&$form, &$form_state, $form_id) {
   }
 
   switch ($form_id) {
+    // Allow users with the custom "assign user roles"
+    // permission to assign user roles to every role except administrator.
     case 'user_account_form':
     case 'user_profile_form':
     case 'user_register_form':
+
       if (!empty($form['account']['roles']) && user_access('assign user roles')) {
+        // Get the roles.
         $roles = array_map('check_plain', user_roles(TRUE));
+        // Unset authenticated role like user.module does.
         unset($roles[DRUPAL_AUTHENTICATED_RID]);
+        // Find the administrator role so we can disable it.
         $admin = array_search("Administrator", $roles);
+        // Do the same disabling of admin role checkbox that
+        // user.module does to the authenticated role checkbox.
         if (!empty($admin) && (user_access('assign user roles') && !user_access('administer permissions'))) {
+          $admin_checkbox = array(
+            '#type' => 'checkbox',
+            '#title' => $roles[$admin],
+            '#default_value' => in_array($admin, $form['account']['roles']['#default_value']),
+            '#disabled' => TRUE,
+          );
+          // Remove admin from the regular set of checkboxes.
           unset($roles[$admin]);
+          // Add it back separately.
+          $form['account']['roles'][$admin] = $admin_checkbox;
         }
+        // Override user.module with our new roles and permission check.
         $form['account']['roles']['#options'] = $roles;
         $form['account']['roles']['#access'] = $roles && (user_access('assign user roles') || user_access('administer permissions'));
       }

--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -78,7 +78,7 @@ function springboard_admin_form_alter(&$form, &$form_state, $form_id) {
 
   switch ($form_id) {
     // Allow users with the custom "assign user roles"
-    // permission to assign user roles to every role except disallowed roles.
+    // permission to assign users to every role except disallowed roles.
     case 'user_account_form':
     case 'user_profile_form':
     case 'user_register_form':
@@ -94,7 +94,7 @@ function springboard_admin_form_alter(&$form, &$form_state, $form_id) {
         $disallowed = array_filter(variable_get('springboard_disallowed_roles', array($default)));
         // Do the same disabling of disallowed role checkbox that
         // user.module does to the authenticated role checkbox.
-        if (!empty($admin) && (user_access('assign user roles') && !user_access('administer permissions'))) {
+        if (user_access('assign user roles') && !user_access('administer permissions')) {
           foreach ($disallowed as $role_id) {
             $admin_checkbox = array(
               '#type' => 'checkbox',
@@ -109,10 +109,10 @@ function springboard_admin_form_alter(&$form, &$form_state, $form_id) {
             // Add it back separately.
             $form['account']['roles'][$role_id] = $admin_checkbox;
           }
+          // Override user.module with our new roles and permission check.
+          $form['account']['roles']['#options'] = $roles;
+          $form['account']['roles']['#access'] = $roles && (user_access('assign user roles') || user_access('administer permissions'));
         }
-        // Override user.module with our new roles and permission check.
-        $form['account']['roles']['#options'] = $roles;
-        $form['account']['roles']['#access'] = $roles && (user_access('assign user roles') || user_access('administer permissions'));
       }
       break;
 

--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -80,7 +80,7 @@ function springboard_admin_form_alter(&$form, &$form_state, $form_id) {
     case 'user_account_form':
     case 'user_profile_form':
     case 'user_register_form':
-      if (!empty($form['account']['roles'])) {
+      if (!empty($form['account']['roles']) && user_access('assign user roles')) {
         $roles = array_map('check_plain', user_roles(TRUE));
         unset($roles[DRUPAL_AUTHENTICATED_RID]);
         $admin = array_search("Administrator", $roles);


### PR DESCRIPTION
Original "assign user roles" patch was missing a form ID, and did not remove the administrator role from the possible role assignments.

Also adds a config form to Springboard Admin settings to select which user roles should be excluded from the assign user roles permission.

Uses the same approach user.module implements to disable "authenticated user" checkbox to disable disallowed role checkboxes.

related: https://github.com/JacksonRiver/springboard/pull/21