### PR TITLE
Add Salesforce integration support for quick donate opt-outs

### DIFF
--- a/fundraiser/modules/fundraiser_quick_donate/fundraiser_quick_donate.module
+++ b/fundraiser/modules/fundraiser_quick_donate/fundraiser_quick_donate.module
@@ -436,6 +436,16 @@ function _fundraiser_quick_donate_set_new_qd_cof($form, $form_state) {
   $payment_fields = $values['payment_fields'];
   $payment_method = $values['payment_method'];
 
+  // See if the user currently has a default card.
+  $default_card = fundraiser_quick_donate_get_default_card($values['uid']);
+  if ($default_card && $default_card == $form_state['card']->card_id) {
+    // If quickdonate is not true the user is opting this card out.
+    if (!$payment_fields['credit']['quickdonate']) {
+      // Invoke quick donate opt-out hook.
+      module_invoke_all('fundraiser_quick_donate_optout', $form_state['card']->card_id, $values['uid']);
+    }
+  }
+
   // First reset all existing cards' status to 0.
   db_query('UPDATE {fundraiser_quick_donate_cardonfile} SET status = 0 WHERE uid = :uid', array(
     ':uid' => $values['uid'],
@@ -502,6 +512,16 @@ function _fundraiser_quick_donate_set_new_qd_cof($form, $form_state) {
       ':card_id' => $form_state['card']->card_id,
     ));
   }
+}
+
+/**
+ * Returns a user's quick donate card or FALSE if they have none.
+ * 
+ * @param $uid
+ *   The id of the user whose quick donate card you want to retreive.
+ */
+function fundraiser_quick_donate_get_default_card($uid) {
+  return db_query('SELECT card_id FROM {fundraiser_quick_donate_cardonfile} WHERE status = 1 and uid = :uid', array(':uid' => $uid))->fetchField();
 }
 
 /**

--- a/fundraiser/modules/fundraiser_quick_donate/includes/fundraiser_quick_donate.fundraiser.inc
+++ b/fundraiser/modules/fundraiser_quick_donate/includes/fundraiser_quick_donate.fundraiser.inc
@@ -385,6 +385,13 @@ function _fundraiser_quick_donate_checkout_form_submit($form, &$form_state) {
     }
   }
 
+  // Does the user already have a default quick donate card
+  $is_card_replacement = FALSE;
+  $existing_quick_donate_card_id = fundraiser_quick_donate_get_default_card($account->uid);
+  if ($card_id != $existing_quick_donate_card_id) {
+    $is_card_replacement = TRUE;
+  }
+
   db_merge('fundraiser_quick_donate_cardonfile')
     ->key(array('uid' => $account->uid))
     ->fields(array(
@@ -400,7 +407,12 @@ function _fundraiser_quick_donate_checkout_form_submit($form, &$form_state) {
     ))
     ->execute();
 
-  module_invoke_all('springboard_quick_donate_optin_create', $account, $donation, $card_id);
+  if ($is_card_replacement) {
+    module_invoke_all('fundraiser_quick_donate_optin_update', $account, $donation, $existing_quick_donate_card_id, $card_id);
+  }
+  else {
+    module_invoke_all('fundraiser_quick_donate_optin_create', $account, $donation, $card_id);
+  }
 }
 
 /**

--- a/salesforce/salesforce_quick_donate/salesforce_quick_donate.module
+++ b/salesforce/salesforce_quick_donate/salesforce_quick_donate.module
@@ -1,10 +1,55 @@
 <?php
 
 /**
- * Implements hook_springboard_quick_donate_optin_create().
+ * Implements hook_fundraiser_quick_donate_optin_create().
  */
-function salesforce_quick_donate_springboard_quick_donate_optin_create($account, $donation, $card_id) {
-  // Load the full card on file entity.
+function salesforce_quick_donate_fundraiser_quick_donate_optin_create($account, $donation, $card_id) {
+  salesforce_quick_donate_optin($account, $donation, $card_id);
+}
+
+/**
+ * Implements hook_fundraiser_quick_donate_optin_update().
+ */
+function salesforce_quick_donate_fundraiser_quick_donate_optin_update($account, $donation, $old_card_id, $new_card_id) {
+  // When an optin is updated, e.g., the current card is replaced.
+  // Add a new quick donate subscription object and opt out of the old one.
+  salesforce_quick_donate_optin($account, $donation, $new_card_id);
+  salesforce_quick_donate_optout($old_card_id);
+}
+
+/**
+ * Implements hook_salesforce_genmap_map_fields_alter().
+ */
+function salesforce_quick_donate_salesforce_genmap_map_fields_alter(&$fields, $context) {
+  if ($context['module'] == 'salesforce_donation') {
+    // Add the card on file id to the opportunity if it was a quick donate transaction.
+    if (isset($context['object']->data['is_quick_donate'])) {
+      $fields['Quick_Donate_Token_Id__c'] = $context['object']->data['cardonfile'];  
+    }
+  }
+}
+
+/**
+ * Implements hook_fundraiser_quick_donate_optout().
+ */
+function salesforce_fundraiser_quick_donate_optout($card_id, $uid) {
+  salesforce_quick_donate_optout($card_id);
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function salesforce_quick_donate_entity_delete($entity, $type) {
+  if ($type == 'commerce_cardonfile') {
+    // Send the subscription back to Salesforce with the opt-out date set.
+    salesforce_quick_donate_optout($entity->card_id);
+  }
+}
+
+/**
+ * Generates and queues a new quick donate subscription object.
+ */
+function salesforce_quick_donate_optin($account, $donation, $card_id) {
   $card_on_file = commerce_cardonfile_load($card_id);
 
   // Create a quick donate subscription object and queue it up.
@@ -42,13 +87,38 @@ function salesforce_quick_donate_springboard_quick_donate_optin_create($account,
 }
 
 /**
- * Implements hook_salesforce_genmap_map_fields_alter().
+ * Sends an update to an existing quick donate subscription
+ * setting the opt-out date.
+ *
+ * @param $card_id
+ *   The id of the card being opted out of.
  */
-function salesforce_quick_donate_salesforce_genmap_map_fields_alter(&$fields, $context) {
-  if ($context['module'] == 'salesforce_donation') {
-    // Add the card on file id to the opportunity if it was a quick donate transaction.
-    if (isset($context['object']->data['is_quick_donate'])) {
-      $fields['Quick_Donate_Token_Id__c'] = $context['object']->data['cardonfile'];  
-    }
+function salesforce_quick_donate_optout($card_id) {
+  $sobject = new stdClass();
+  $sobject->type = 'Quick_Donate_Subscription__c';
+  $sobject->fields = array(
+    'Opt_Out_Date__c' => time(),
+    'Default_Payment_Method__c' => FALSE,
+  );
+
+  $item = array(
+    'drupal_id' => $card_id,
+    'module' => 'salesforce_quick_donate',
+    'delta' => 'commerce_cardonfile',
+    'object_type' => 'Quick_Donate_Subscription__c',
+    'operation' => 'CREATE',
+    'sobject' => $sobject,
+  );
+
+  $queue = salesforce_queue_load();
+  // Only queue these up if they've actually been exported.
+  if (salesforce_sync_load_map($item)) {
+    _salesforce_genmap_alter_operation($item);
+    $result = $queue->createItem($item);  
+  }
+  else {
+    // If the initial opt-in never exported. Delete it from the
+    // queue because there is nothing to update.
+    $queue->deleteItem((object)$item);
   }
 }


### PR DESCRIPTION
The quick donate module needed new hooks to announce a card was being opted out. The salesforce module now operates on these hooks to push the opt-outs to Salesforce.