### PR TITLE
Add module_exists() check for commerce_cardonfile in fundraiser_updat…

### DIFF
--- a/fundraiser/fundraiser.install
+++ b/fundraiser/fundraiser.install
@@ -565,6 +565,10 @@ function fundraiser_update_7010() {
  * Batch update records to add card_id field.
  */
 function fundraiser_update_7011(&$sandbox) {
+  // No action necessary if cardonfile isn't enabled 
+  if (!module_exists('commerce_cardonfile')) {
+    return;
+  }
   $ret = array();
   $cards = &drupal_static(__FUNCTION__);
 


### PR DESCRIPTION
Add module_exists() check for commerce_cardonfile to prevent fatal errors in fundraiser_update_7011(). Some Springboard installs may not have the commerce_cardonfile module enabled.