### PR TITLE
re #1458 - replace module_invoke with drupal_alter

### DIFF
--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -3089,7 +3089,7 @@ function _fundraiser_get_donation_gateway($did) {
   $found_gateway = db_query('SELECT d.gateway FROM {fundraiser_donation} d ' .
     'WHERE d.did = :did', array(':did' => $did))->fetchField();
   // Now ask if any other module wants to override this result.
-  module_invoke('fundraiser_get_donation_gateway_alter', $did, $found_gateway);
+  drupal_alter('fundraiser_get_donation_gateway', $found_gateway);
   // Now translate that into something we can use by getting the rest of the dateway info.
   if (isset($found_gateway)) {
     return _fundraiser_gateway_info($found_gateway);


### PR DESCRIPTION
As noted in #1458, I think this was meant to be a drupal_alter on creation. Module_invoke doesn't take params by reference. I've also removed the $did param, as altering it at this point in the function would have no affect. 
