### PR TITLE
Data warehouse drush command should output a count of items processed

### DIFF
--- a/springboard_dw/includes/springboard_dw.queue.inc
+++ b/springboard_dw/includes/springboard_dw.queue.inc
@@ -7,6 +7,9 @@
 
 /**
  * Queue processing hook.
+ *
+ * @return int
+ *   Count of items processed, whether or not they were successful.
  */
 function springboard_dw_process_queue() {
 
@@ -17,11 +20,16 @@ function springboard_dw_process_queue() {
   // Get an instance of the Drupal data warehouse queue.
   $queue = DrupalQueue::get('springboard_dw_export');
 
+  // Keep a count of the number of items processed, whether or not they fail.
+  $counter = 0;
+
   // Create an array for placeholder to track any failed queue items.
   $failed_queue_items = array();
 
   // Lock and claim an item for queue processing.
   while (time() < $end && ($item = $queue->claimItem())) {
+    // Increment counter when item is claimed.
+    $counter++;
 
     // If the api responds back correctly, remove the queue item.
     if (call_user_func($callback, $item->data)) {
@@ -67,6 +75,9 @@ function springboard_dw_process_queue() {
   foreach ($failed_queue_items as $queue_item) :
     $queue->releaseItem($queue_item);
   endforeach;
+
+  // Return the counter to the calling function.
+  return $counter;
 }
 
 /**

--- a/springboard_dw/springboard_dw.drush.inc
+++ b/springboard_dw/springboard_dw.drush.inc
@@ -50,7 +50,10 @@ function drush_springboard_dw_export_queue_process() {
     drush_print('Processing the Springboard data warehouse export queue');
 
     // Process the items in the queue.
-    springboard_dw_process_queue();
+    $counter = springboard_dw_process_queue();
+    if (!is_null($counter)) {
+      drush_log('Processed !counter items in Springboard data warehouse export queue.', 'ok');
+    }
 
     // Log to the command line with an OK status.
     drush_log('Running springboard-dw-export-queue-process', 'ok');

--- a/springboard_dw/springboard_dw.drush.inc
+++ b/springboard_dw/springboard_dw.drush.inc
@@ -47,7 +47,7 @@ function drush_springboard_dw_export_queue_process() {
   }
   else {
     // Provide CLI feedback.
-    drush_print('Processing the Springboard data warehouse export queue');
+    drush_log('Processing the Springboard data warehouse export queue.', 'ok');
 
     // Process the items in the queue.
     $counter = springboard_dw_process_queue();
@@ -56,7 +56,6 @@ function drush_springboard_dw_export_queue_process() {
     }
 
     // Log to the command line with an OK status.
-    drush_log('Running springboard-dw-export-queue-process', 'ok');
-    springboard_dw_watchdog_log('Running springboard-dw-export-queue-process');
+    drush_log('Finished processing the Springboard data warehouse export queue.', 'ok');
   }
 }


### PR DESCRIPTION
Adds a counter of the raw number of items processed by the drush export queue command.

This will improve our Sumo Logic dashboard, as well as allow us to see how well the export queue API is performing so that we can dial-in the right `--limit` values for legacy data jobs.

I also threw in some tweaks to the `drush_log()` calls in the drush command callback.