### PR TITLE
Fix regression in `webform_user_create_missing_users_batch_process()`

### DIFF
--- a/webform_user/includes/webform_user.drush.inc
+++ b/webform_user/includes/webform_user.drush.inc
@@ -138,7 +138,8 @@ function webform_user_create_missing_users_batch_process($chunk, $node_id, $oper
       $account = user_save('', $user_fields);
     }
 
-    _webform_user_save_profile_map($account, $submission);
+    $form_state = array();
+    _webform_user_save_profile_map($account, $submission, $form_state);
 
     $submission = webform_get_submission($node_id, $sid);
     $submission->uid = $account->uid;

--- a/webform_user/includes/webform_user.drush.inc
+++ b/webform_user/includes/webform_user.drush.inc
@@ -138,8 +138,9 @@ function webform_user_create_missing_users_batch_process($chunk, $node_id, $oper
       $account = user_save('', $user_fields);
     }
 
+    $form = array();
     $form_state = array();
-    _webform_user_save_profile_map($account, $submission, $form_state);
+    _webform_user_save_profile_map($account, $submission, $form, $form_state);
 
     $submission = webform_get_submission($node_id, $sid);
     $submission->uid = $account->uid;


### PR DESCRIPTION
`_webform_user_save_profile_map()` now requires `$form` and `$form_state` to be passed by reference as 3rd and 4th parameters.

Regression introduced by https://github.com/JacksonRiver/springboard_modules/commit/fa87b52d1a61186b46360ec175f1460c625a4450 for https://app.assembla.com/spaces/springboard/tickets/936.

@robertromore @pcave - I'm passing empty arrays for `$form` and `$form_state` here. I'm not sure whether any future alter hook implementations will expect either array to have any keys/values in it, so if there's a better way to handle this, I'm fine to drop this PR.