### PR TITLE
re #1466 - check next donation update callback

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -2319,7 +2319,7 @@ function fundraiser_sustainers_edit_form($did) {
     // Display the billing update form only if the update callback for the
     // gatway has been defined.
     $billing_update_form = '';
-    if (isset($donation->gateway['update callback'])) {
+    if (isset($next_donation->gateway['update callback'])) {
       $billing_update_form_array = drupal_get_form('fundraiser_update_billing_form', $data);
       $billing_update_form_array['#attached']['js'][3]['data']['fundraiser']['js_validation_settings']['card_cvv']->required = FALSE;
       $billing_update_form_array['#attached']['js'][3]['data']['fundraiser']['js_validation_settings']['card_number']->required = FALSE;


### PR DESCRIPTION
Per ticket #1466, sustainers currently checks for the update callback on the master donation's gateway, rather than the next donation. If the series's gateway was changed mid-series, sustainers can fail to display the billing update form because the initiating gateway lacked an update callback, even though the updated gateway has one. This PR alters sustainers to check the next_donation's update callback. 