### PR TITLE
Drush command for sustainer processing

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.drush.inc
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.drush.inc
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @file
+ * Drush commands for the fundraiser sustainers module.
+ */
+
+/**
+ * Implements hook_drush_help().
+ */
+function fundraiser_sustainers_drush_help($command) {
+  switch ($command) {
+    case 'drush:fundraiser-sustainers-process':
+      return dt('Processes any sustainer payments due to be charged at this point in time.');
+  }
+}
+
+/**
+ * Implements hook_drush_command().
+ */
+function fundraiser_sustainers_drush_command() {
+  $items = array();
+  $items['fundraiser-sustainers-process'] = array(
+    'description' => dt('Processes any sustainer payments due to be charged at this point in time.'),
+    'options' => array(
+      'limit' => 'The maximum number of transactions to process.',
+    ),
+    'examples' => array(
+      'Standard example' => 'fundraiser-sustainers-process',
+    ),
+    'aliases' => array('fsp'),
+  );
+
+  return $items;
+}
+
+/**
+ * Drush command to process recurring donations.
+ *
+ * @param $max
+ *   The maximum number of transactions to process.
+ */
+function drush_fundraiser_sustainers_process() {
+  $limit = drush_get_option('limit', 200);
+
+  drush_log('Checking for sustainer key match.', 'ok');
+  $processor_key_match = fundraiser_sustainers_processor_key_match();
+
+  // If the site-wide sustainer key does not match, bail out of processing.
+  if (!$processor_key_match) {
+    watchdog('fundraiser_sustainers_drush', 'The fundraiser sustainer key has not been configured correctly. Recurring donations will not be processed.', NULL, WATCHDOG_CRITICAL);
+    return;
+  }
+
+  // Give other modules a chance to bail out of sustainer processing.
+  $process_recurring = TRUE;
+  drupal_alter('fundraiser_sustainers_process_recurring', $process_recurring);
+  // If process_recurring is not true, bail out of processing.
+  if (!$process_recurring) {
+    return;
+  }
+
+  // Do one last double check before proceeding.
+  if ($process_recurring && $processor_key_match) {
+    drush_log(dt('All sustainer preprocessing checks complete. Starting to process !limit sustainers.', array('!limit' => $limit)), 'ok');
+    
+    fundraiser_sustainers_process_recurring_donations($limit);
+  }
+}

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -1191,20 +1191,19 @@ function fundraiser_sustainers_fundraiser_donation_delete($donation) {
 /**
  * Helper function, kick off recurring donations for payment. Called on cron usually.
  */
-function fundraiser_sustainers_process_recurring_donations() {
+function fundraiser_sustainers_process_recurring_donations($limit = 200) {
   // Provide a hook to allow for modules to respond.
   module_invoke_all('fundraiser_donation_recurring');
   $log = array(
     'successes' => 0,
     'fails' => 0,
   );
-  $donations = _fundraiser_sustainers_cron_get_recurring();
+  $donations = _fundraiser_sustainers_cron_get_recurring($limit);
   $sustainer_key = fundraiser_sustainers_get_sustainer_key_value();
 
   // Loop over the found orders
   foreach ($donations as $recurring) {
     try {
-
       fundraiser_sustainers_process_single_recurring_donation($log, $recurring, $sustainer_key);
     }
     catch (Exception $e) {

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -4359,8 +4359,8 @@ function fundraiser_sustainers_preprocess_html(&$vars) {
  *   Part of the sustainer record for additional logging.
  */
 function fundraiser_sustainers_processing_exception(Exception $e, $sustainer) {
-  $message = 'Exception thrown while processing a sustainer. Sustainer ID: %did. %type: !message in %function (line %line of %file).';
-  $variables = array('%did' => $sustainer->did);
+  $message = 'Exception thrown while processing a sustainer - did=%did, gateway=%gateway, uid=%uid, %type=!message in %function (line %line of %file).';
+  $variables = array('%did' => $sustainer->did, '%gateway' => $sustainer->gateway, '%uid' => $sustainer->uid);
   watchdog_exception('fundraiser_sustainers', $e, $message, $variables);
 }
 


### PR DESCRIPTION
Sustainers can now be processed via a drush command! The --uri passed in must match the configured sustainer key or processing will not happen. This pull request also adds the ability to pass a maximum number of sustainers to process.

`drush fsp --limit=50 --uri=https://7x.local `