### PR TITLE
lock recurring doantion amounts on specific designation categories

### DIFF
--- a/fundraiser/modules/fundraiser_designations/fundraiser_designations.install
+++ b/fundraiser/modules/fundraiser_designations/fundraiser_designations.install
@@ -1,6 +1,13 @@
 <?php
-
 /**
  * @file
  * Install, update and uninstall functions.
  */
+
+/**
+ * Add the lock checkbox to the designations vocabulary.
+ */
+function fundraiser_designations_update_7002() {
+  module_load_include('inc', 'fundraiser_designations', 'includes/fundraiser_designations.taxonomy');
+  _fundraiser_designations_install_lock_fields();
+}

--- a/fundraiser/modules/fundraiser_designations/fundraiser_designations.module
+++ b/fundraiser/modules/fundraiser_designations/fundraiser_designations.module
@@ -583,21 +583,26 @@ function fundraiser_designations_form_fundraiser_sustainers_donation_amount_form
     $line_items =& $form['commerce_line_items'][$form['commerce_line_items']['#language']]['line_items'];
 
     foreach ($line_items as $key => $item) {
-      $item_wrapper = entity_metadata_wrapper('commerce_line_item', $item['line_item']['#value']);
-      $product_id = $item_wrapper->commerce_product->value()->product_id;
-      $product = commerce_product_load($product_id);
-      $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
-      $terms = $product_wrapper->field_fd_designation_categories->value();
       $lock_it = FALSE;
-      foreach ($terms as $term) {
-        $term_wrapper = entity_metadata_wrapper('taxonomy_term', $term);
-        $locked = $term_wrapper->field_fd_lock_donation_amount->value();
-        if (!empty($locked[0]) && $locked[0] == 1) {
-          $lock_it = TRUE;
-          break;
+      if (!empty($item['line_item']['#value'])) {
+        $item_wrapper = entity_metadata_wrapper('commerce_line_item', $item['line_item']['#value']);
+        if (!empty($item_wrapper->commerce_product->value()->product_id)) {
+          $product_id = $item_wrapper->commerce_product->value()->product_id;
+          $product = commerce_product_load($product_id);
+          if (!empty($product)) {
+            $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
+            $terms = $product_wrapper->field_fd_designation_categories->value();
+            foreach ($terms as $term) {
+              $term_wrapper = entity_metadata_wrapper('taxonomy_term', $term);
+              $locked = $term_wrapper->field_fd_lock_donation_amount->value();
+              if (!empty($locked[0]) && $locked[0] == 1) {
+                $lock_it = TRUE;
+                break;
+              }
+            }
+          }
         }
       }
-
       $line_items[$key]['remove']['#disabled'] = TRUE;
       $line_items[$key]['remove']['#description'] = 'N/A';
       if ($lock_it) {

--- a/fundraiser/modules/fundraiser_designations/fundraiser_designations.module
+++ b/fundraiser/modules/fundraiser_designations/fundraiser_designations.module
@@ -581,9 +581,28 @@ function fundraiser_designations_form_fundraiser_sustainers_donation_amount_form
     $form['fee_amount']['#access'] = FALSE;
     $form['fee_amount']['#required'] = FALSE;
     $line_items =& $form['commerce_line_items'][$form['commerce_line_items']['#language']]['line_items'];
+
     foreach ($line_items as $key => $item) {
+      $item_wrapper = entity_metadata_wrapper('commerce_line_item', $item['line_item']['#value']);
+      $product_id = $item_wrapper->commerce_product->value()->product_id;
+      $product = commerce_product_load($product_id);
+      $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
+      $terms = $product_wrapper->field_fd_designation_categories->value();
+      $lock_it = FALSE;
+      foreach ($terms as $term) {
+        $term_wrapper = entity_metadata_wrapper('taxonomy_term', $term);
+        $locked = $term_wrapper->field_fd_lock_donation_amount->value();
+        if (!empty($locked[0]) && $locked[0] == 1) {
+          $lock_it = TRUE;
+          break;
+        }
+      }
+
       $line_items[$key]['remove']['#disabled'] = TRUE;
       $line_items[$key]['remove']['#description'] = 'N/A';
+      if ($lock_it) {
+        $line_items[$key]['commerce_unit_price']['#disabled'] = TRUE;
+      }
     }
     array_unshift($form['#validate'], 'fundraiser_designation_donation_amount_form_validate');
   }

--- a/fundraiser/modules/fundraiser_designations/includes/fundraiser_designations.taxonomy.inc
+++ b/fundraiser/modules/fundraiser_designations/includes/fundraiser_designations.taxonomy.inc
@@ -50,6 +50,7 @@ function _fundraiser_designations_install_vocab_fd_designation_categories($produ
       }
     }
     _fundraiser_designations_install_taxonomy_fields($product_type);
+    _fundraiser_designations_install_lock_fields();
   }
 }
 
@@ -160,4 +161,110 @@ function _fundraiser_designations_install_taxonomy_field_definitions($product_ty
   );
 
   return $fields;
+}
+
+/**
+ * Add a checkbox to the designations category.
+ */
+function fundraiser_designations_taxonomy_category_field_bases() {
+  $field_bases = array();
+
+  $field_bases['field_fd_lock_donation_amount'] = array(
+    'active' => 1,
+    'cardinality' => 2,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'field_fd_lock_donation_amount',
+    'foreign keys' => array(),
+    'indexes' => array(
+      'value' => array(
+        0 => 'value',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'list',
+    'settings' => array(
+      'allowed_values' => array(
+        1 => 'Lock recurring donation amounts of products with this term.',
+      ),
+      'allowed_values_function' => '',
+    ),
+    'translatable' => 0,
+    'type' => 'list_text',
+  );
+
+  return $field_bases;
+}
+
+/**
+ * Add a checkbox to the designations category.
+ */
+function fundraiser_designations_taxonomy_category_field_instances() {
+  $field_instances = array();
+
+  $field_instances['field_fd_lock_donation_amount'] = array(
+    'bundle' => 'fd_designation_categories',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => 'Don\'t allow donors to update the amount of their recurring donations to funds in this category.',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'module' => 'list',
+        'settings' => array(),
+        'type' => 'list_default',
+        'weight' => 1,
+      ),
+    ),
+    'entity_type' => 'taxonomy_term',
+    'field_name' => 'field_fd_lock_donation_amount',
+    'label' => 'Lock Recurring Donation Amount',
+    'required' => 0,
+    'settings' => array(
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 1,
+      'module' => 'options',
+      'settings' => array(),
+      'type' => 'options_buttons',
+      'weight' => 1,
+    ),
+  );
+
+  // Translatables
+  // Included for use with string extractors like potx.
+  t('Don\'t allow donors to update the amount of their recurring donations to funds in this category.');
+  t('Lock Recurring Donation Amount');
+
+  return $field_instances;
+}
+
+/**
+ * Add a checkbox to the designations category.
+ */
+function _fundraiser_designations_install_lock_fields() {
+  $already_exists = FALSE;
+  foreach (taxonomy_get_vocabularies() as $vocab) {
+    if ($vocab->machine_name == 'fd_designation_categories') {
+      $already_exists = TRUE;
+      break;
+    }
+  }
+
+  if ($already_exists) {
+    $fields = fundraiser_designations_taxonomy_category_field_bases();
+    $instances = fundraiser_designations_taxonomy_category_field_instances();
+    foreach ($fields as $key => $values) {
+      $instance = $instances[$key];
+      $base = field_info_field($key);
+      $term = field_info_instance('taxonomy_term', $key, 'fd_designation_categories');
+      if (empty($base)) {
+        field_create_field($fields[$key]);
+      }
+      if (empty($term)) {
+        field_create_instance($instance);
+      }
+    }
+  }
 }


### PR DESCRIPTION
Make the donation amount field on line items uneditable if the donation product is in a specific category.