### PR TITLE
7.x 4.x p2p goals invalid argument warning

### DIFF
--- a/springboard_p2p/modules/springboard_p2p_fields/springboard_p2p_fields.module
+++ b/springboard_p2p/modules/springboard_p2p_fields/springboard_p2p_fields.module
@@ -113,9 +113,11 @@ function springboard_p2p_fields_get_goal_from_entity($entity) {
   $goal_set_id = $entity->field_p2p_campaign_goals[$entity->language][0]['goal_set_id'];
   $goals_field = new SpringboardP2pCampaignGoalsField();
   $goals = $goals_field->load($goal_set_id);
-  foreach ($goals as $goal) {
-    if ($goal['enabled']) {
-      return $goal;
+  if (isset($goals) && is_array($goals)) {
+    foreach ($goals as $goal) {
+      if ($goal['enabled']) {
+        return $goal;
+      }
     }
   }
 

--- a/springboard_p2p/modules/springboard_p2p_fields/springboard_p2p_fields.module
+++ b/springboard_p2p/modules/springboard_p2p_fields/springboard_p2p_fields.module
@@ -110,16 +110,25 @@ function springboard_p2p_fields_property_field_campaign_goals_get($entity, array
  * @todo This only handles a single enabled goal.
  */
 function springboard_p2p_fields_get_goal_from_entity($entity) {
-  $goal_set_id = $entity->field_p2p_campaign_goals[$entity->language][0]['goal_set_id'];
-  $goals_field = new SpringboardP2pCampaignGoalsField();
-  $goals = $goals_field->load($goal_set_id);
-  if (isset($goals) && is_array($goals)) {
-    foreach ($goals as $goal) {
-      if ($goal['enabled']) {
-        return $goal;
+  if (isset($entity->language) && isset($entity->field_p2p_campaign_goals[$entity->language][0]['goal_set_id'])) {
+    $goal_set_id = $entity->field_p2p_campaign_goals[$entity->language][0]['goal_set_id'];
+    $goals_field = new SpringboardP2pCampaignGoalsField();
+    $goals = $goals_field->load($goal_set_id);
+    if (isset($goals) && is_array($goals)) {
+      foreach ($goals as $goal) {
+        if ($goal['enabled']) {
+          return $goal;
+        }
       }
     }
   }
+
+  // If the function arrives here, it was not able to return $goal. Log this
+  // event in watchdog and return a somewhat safe default.
+  watchdog('springboard_p2p_fields', 'Could not determine goal from !type ID !id', array(
+    '!type' => isset($entity->type) ? $entity->type : t('entity'),
+    '!id' => isset($entity->nid) ? $entity->nid : '',
+  ), WATCHDOG_WARNING);
 
   // Somewhat safe default.
   return array(


### PR DESCRIPTION
Avoid invalid argument warnings like the following:

```
Notice: Trying to get property of non-object in springboard_p2p_fields_get_goal_from_entity() (line 113 of ... springboard_p2p/modules/springboard_p2p_fields/springboard_p2p_fields.module).
```
```
Warning: Invalid argument supplied for foreach() in springboard_p2p_fields_get_goal_from_entity() (line 116 of ... springboard_p2p/modules/springboard_p2p_fields/springboard_p2p_fields.module).
```