### PR TITLE
update scrutinizer config

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -71,7 +71,7 @@ build:
             - 'find . -type f \( -name "*.php" -or -name "*.module" -or -name "*.install" -or -name "*.inc" -or -name "*.profile" -or -name "*.test" -or -name "*.theme" \) -print0 | xargs -0 -n1 -P8 php -l'
             # Negate the return value of ack, because not finding these
             # strings should be a pass.
-            - '! ack-grep -i "<<<<<<<|^=======$|>>>>>>>|dpm\(|dsm\(|var_dump\(|var_export\(|[^set]debug\(|dpq|dvm|dpr\(|kpr|dvr|kprint_r|dprint_r|devel_render|ddebug_backtrace|debug_backtrace|debug_print_backtrace|debug_to_file" --ignore-file=ext:txt,html,yml,js'
+            - '! ack-grep -i "<<<<<<<|^=======$|>>>>>>>|dpm\(|dsm\(|var_dump\(|var_export\(|[^set]debug\(|dpq|dvm|dpr\(|kpr|dvr|kprint_r|dprint_r|devel_render|ddebug_backtrace|debug_backtrace|debug_print_backtrace|debug_to_file" --ignore-file=ext:txt,html,yml,js --ignore-file=braintree.inc'
             - 'cd'
             - 'mv build repo'
             - 'git clone --depth 1 --branch 7.x-4.x https://github.com/JacksonRiver/Springboard-Build.git build-tools'

--- a/salesforce/salesforce_donation_history/salesforce_donation_history.module
+++ b/salesforce/salesforce_donation_history/salesforce_donation_history.module
@@ -210,7 +210,6 @@ function salesforce_donation_history_get_opportunity($user_sfid, $donation_sfid)
   $opportunities = salesforce_donation_history_get_opportunities($user_sfid);
   if (count($opportunities) > 0) {
     foreach ($opportunities as $opportunity) {
-      // dpm($opportunity->Id);
       foreach ($opportunity->Id as $id) {
         if ($id == $donation_sfid) {
           $results[] = $opportunity;


### PR DESCRIPTION
Braintree uses debug_backtrace in logging so we need to exclude the braintree.inc fiel from the ack-grep scan for erroneous debug statements.

Also remove a commented out dpm from salesforce_history.