### PR TITLE
7.x 4.x 927 prepopulate autofill flag

### DIFF
--- a/salesforce/salesforce_donation/salesforce_donation.install
+++ b/salesforce/salesforce_donation/salesforce_donation.install
@@ -64,6 +64,7 @@ function salesforce_donation_install() {
       'device_name' => 'Device_Name__c',
       'device_os' => 'Device_OS__c',
       'device_browser' => 'Device_Browser__c',
+      'secure_prepop_autofilled' => 'Autofilled__c',
     ),
     'salesforce_node_map' => array(
       'title' => 'Donation_Form_Name__c',

--- a/salesforce/salesforce_genmap/salesforce_genmap.install
+++ b/salesforce/salesforce_genmap/salesforce_genmap.install
@@ -217,7 +217,7 @@ function salesforce_genmap_update_7003(&$sandbox) {
     // Set the map key based on the module name.
     $map_key = ($record['module'] == 'salesforce_donation') ? 'salesforce_webform_map' : 'webform_map';
 
-    $map->field_map[$map_key]['secure_prepop_autofill'] = 'Autofill__c';
+    $map->field_map[$map_key]['secure_prepop_autofilled'] = 'Autofilled__c';
 
     salesforce_genmap_save_map($map, $record['map_handler']);
 

--- a/salesforce/salesforce_genmap/salesforce_genmap.install
+++ b/salesforce/salesforce_genmap/salesforce_genmap.install
@@ -180,3 +180,55 @@ function salesforce_genmap_update_7002(&$sandbox) {
     return t('Device info field mappings have been added to salesforce_genmap records.');
   }
 }
+
+
+
+/**
+ * Create Salesforce mappings for secure preopoulate autofill.
+ */
+function salesforce_genmap_update_7003(&$sandbox) {
+  $path = libraries_get_path('salesforce');
+  require_once $path . '/soapclient/SforcePartnerClient.php';
+
+  // Update Salesforce mappings for webforms provided by these modules:
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['current_mid'] = 0;
+    $sandbox['max'] = db_query('SELECT COUNT(`mid`) FROM {salesforce_genmap_map} WHERE `module` IN(:module1, :module2, :module3, :module4)',
+      array(
+        ':module1' => 'salesforce_donation',
+        ':module2' => 'salesforce_message_action',
+        ':module3' => 'salesforce_petition',
+        ':module4' => 'salesforce_social_action',
+      ))->fetchField();
+  }
+
+  $result = db_select('salesforce_genmap_map', 'map')
+    ->fields('map', array('mid', 'nid', 'map_handler', 'module'))
+    ->condition('map.module', array('salesforce_donation', 'salesforce_message_action', 'salesforce_petition', 'salesforce_social_action'), 'IN')
+    ->condition('map.mid', $sandbox['current_mid'], '>')
+    ->range(0, 5)
+    ->orderBy('mid', 'ASC')
+    ->execute();
+
+  while ($record = $result->fetchAssoc()) {
+    $map = salesforce_genmap_load_map($record['nid'], $record['map_handler']);
+
+    // Set the map key based on the module name.
+    $map_key = ($record['module'] == 'salesforce_donation') ? 'salesforce_webform_map' : 'webform_map';
+
+    $map->field_map[$map_key]['secure_prepop_autofill'] = 'Autofill__c';
+
+    salesforce_genmap_save_map($map, $record['map_handler']);
+
+    $sandbox['progress']++;
+    $sandbox['current_mid'] = $record['mid'];
+  }
+
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+
+  if ($sandbox['#finished'] >= 1) {
+    return t('Device info field mappings have been added to salesforce_genmap records.');
+  }
+}
+

--- a/salesforce/salesforce_message_action/salesforce_message_action.install
+++ b/salesforce/salesforce_message_action/salesforce_message_action.install
@@ -64,7 +64,8 @@ function salesforce_message_action_create_actions_taken_fieldmap() {
       'device_name' => 'Device_Name__c',
       'device_os' => 'Device_OS__c',
       'device_browser' => 'Device_Browser__c',
-      'sba_quicksign_flag' =>'Quick_Sign__c',
+      'sba_quicksign_flag' => 'Quick_Sign__c',
+      'secure_prepop_autofilled' => 'Autofilled__c',
     ),
     'salesforce_node_map' => array(
       'title' => 'Name',

--- a/salesforce/salesforce_petition/salesforce_petition.install
+++ b/salesforce/salesforce_petition/salesforce_petition.install
@@ -57,7 +57,8 @@ function salesforce_petition_create_petition_action_fieldmap() {
       'device_name' => 'Device_Name__c',
       'device_os' => 'Device_OS__c',
       'device_browser' => 'Device_Browser__c',
-      'sba_quicksign_flag' =>'Quick_Sign__c',
+      'sba_quicksign_flag' => 'Quick_Sign__c',
+      'secure_prepop_autofilled' => 'Autofilled__c',
     ),
     'salesforce_node_map' => array(
       'title' => 'Name',

--- a/salesforce/salesforce_social_action/salesforce_social_action.install
+++ b/salesforce/salesforce_social_action/salesforce_social_action.install
@@ -83,7 +83,8 @@ function salesforce_social_action_create_actions_taken_fieldmap() {
       'device_name' => 'Device_Name__c',
       'device_os' => 'Device_OS__c',
       'device_browser' => 'Device_Browser__c',
-      'sba_quicksign_flag' =>'Quick_Sign__c',
+      'sba_quicksign_flag' => 'Quick_Sign__c',
+      'secure_prepop_autofilled' => 'Autofilled__c',
     ),
     'salesforce_node_map' => array(
       'title' => 'Name',

--- a/secure_prepopulate/secure_prepopulate.components.inc
+++ b/secure_prepopulate/secure_prepopulate.components.inc
@@ -24,14 +24,17 @@ function secure_prepopulate_insert_components($node) {
     'value' => 0,
     'weight' => 13,
     'email' => 1,
+    '#extra' => array(
+      'description' => '',
+      'hidden_type' => 'hidden',
+    ),
   );
-
 
   // Add the component to the Webform.
   foreach ($fields as $field) {
     // Don't insert fields if cloning.
     if (!isset($node->map) || (isset($node->map) && !in_array($field['form_key'], $node->map))) {
-      $cid = webform_component_insert($field);
+      webform_component_insert($field);
     }
   }
 }

--- a/secure_prepopulate/secure_prepopulate.components.inc
+++ b/secure_prepopulate/secure_prepopulate.components.inc
@@ -15,7 +15,7 @@
 function secure_prepopulate_insert_components($node) {
   module_load_include('inc', 'webform', 'includes/webform.components');
 
-  $fields[] = array(
+  $field = array(
     'nid' => $node->nid,
     'form_key' => 'secure_prepop_autofilled',
     'pid' => 0,
@@ -31,13 +31,8 @@ function secure_prepopulate_insert_components($node) {
   );
 
   // Add the component to the Webform.
-  foreach ($fields as $field) {
-    // Don't insert fields if cloning.
-    if (!isset($node->map) || (isset($node->map) && !in_array($field['form_key'], $node->map))) {
-      webform_component_insert($field);
-    }
+  // Don't insert field if cloning.
+  if (!isset($node->map) || (isset($node->map) && !in_array($field['form_key'], $node->map))) {
+    webform_component_insert($field);
   }
 }
-
-
-

--- a/secure_prepopulate/secure_prepopulate.components.inc
+++ b/secure_prepopulate/secure_prepopulate.components.inc
@@ -17,7 +17,7 @@ function secure_prepopulate_insert_components($node) {
 
   $fields[] = array(
     'nid' => $node->nid,
-    'form_key' => 'secure_prepop_autofill',
+    'form_key' => 'secure_prepop_autofilled',
     'pid' => 0,
     'name' => t('Autofilled'),
     'type' => 'hidden',

--- a/secure_prepopulate/secure_prepopulate.components.inc
+++ b/secure_prepopulate/secure_prepopulate.components.inc
@@ -19,7 +19,7 @@ function secure_prepopulate_insert_components($node) {
     'nid' => $node->nid,
     'form_key' => 'secure_prepop_autofill',
     'pid' => 0,
-    'name' => t('User Edit Flag'),
+    'name' => t('Autofilled'),
     'type' => 'hidden',
     'value' => 0,
     'weight' => 13,

--- a/secure_prepopulate/secure_prepopulate.components.inc
+++ b/secure_prepopulate/secure_prepopulate.components.inc
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * Helper functions for the secure prepopulate component.
+ */
+
+/**
+ * Insert new components on node/add.
+ *
+ * Called from secure_prepopulate_node_insert();
+ *
+ * @param $node
+ */
+function secure_prepopulate_insert_components($node) {
+  module_load_include('inc', 'webform', 'includes/webform.components');
+
+  $fields[] = array(
+    'nid' => $node->nid,
+    'form_key' => 'secure_prepop_autofill',
+    'pid' => 0,
+    'name' => t('User Edit Flag'),
+    'type' => 'hidden',
+    'value' => 0,
+    'weight' => 13,
+    'email' => 1,
+  );
+
+
+  // Add the component to the Webform.
+  foreach ($fields as $field) {
+    // Don't insert fields if cloning.
+    if (!isset($node->map) || (isset($node->map) && !in_array($field['form_key'], $node->map))) {
+      $cid = webform_component_insert($field);
+    }
+  }
+}
+
+
+

--- a/secure_prepopulate/secure_prepopulate.install
+++ b/secure_prepopulate/secure_prepopulate.install
@@ -110,7 +110,7 @@ function secure_prepopulate_update_7002(&$sandbox) {
     if (!$cid) {
       $field = array(
         'nid' => $node->nid,
-        'form_key' => 'secure_prepop_autofill',
+        'form_key' => 'secure_prepop_autofilled',
         'pid' => 0,
         'name' => t('Autofilled'),
         'type' => 'hidden',

--- a/secure_prepopulate/secure_prepopulate.install
+++ b/secure_prepopulate/secure_prepopulate.install
@@ -88,7 +88,7 @@ function secure_prepopulate_update_7002(&$sandbox) {
     $sandbox['current_node'] = -1;
   }
 
-  $limit = 10;
+  $limit = 25;
 
   $nodes = db_select('webform', 'n')
     ->fields('n', array('nid'))
@@ -127,9 +127,6 @@ function secure_prepopulate_update_7002(&$sandbox) {
   }
 
   $sandbox['#finished'] = ($sandbox['progress'] >= $sandbox['max']) ? TRUE : ($sandbox['progress'] / $sandbox['max']);
-  $sandbox_status = $sandbox;
-  // Don't want them in the output.
-  unset($sandbox_status['messages']);
 
   if ($sandbox['#finished']) {
     return t('Autofill field has been added to existing webforms.');

--- a/secure_prepopulate/secure_prepopulate.install
+++ b/secure_prepopulate/secure_prepopulate.install
@@ -114,9 +114,13 @@ function secure_prepopulate_update_7002(&$sandbox) {
         'pid' => 0,
         'name' => t('Autofilled'),
         'type' => 'hidden',
-        'value' => '',
-        'weight' => 30,
+        'value' => 0,
+        'weight' => 13,
         'email' => 1,
+        '#extra' => array(
+          'description' => '',
+          'hidden_type' => 'hidden',
+        ),
       );
       webform_component_insert($field);
     }

--- a/secure_prepopulate/secure_prepopulate.install
+++ b/secure_prepopulate/secure_prepopulate.install
@@ -75,3 +75,59 @@ function secure_prepopulate_update_7001() {
   db_add_index('secure_prepopulate_expired', 'hash', array('hash'));
   db_add_index('secure_prepopulate_expired', 'expired', array('expire_date'));
 }
+
+/**
+ * Add the secure preopoulate autofill field to existing webforms.
+ */
+function secure_prepopulate_update_7002(&$sandbox) {
+
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['max'] = db_query('SELECT COUNT(nid) FROM {webform}')->fetchField();
+    $sandbox['messages'] = array();
+    $sandbox['current_node'] = -1;
+  }
+
+  $limit = 10;
+
+  $nodes = db_select('webform', 'n')
+    ->fields('n', array('nid'))
+    ->orderBy('n.nid', 'ASC')
+    ->where('n.nid > :nid', array(':nid' => $sandbox['current_node']))
+    ->extend('PagerDefault')
+    ->limit($limit)
+    ->execute();
+
+  foreach ($nodes as $node) {
+    $sandbox['progress']++;
+    $sandbox['current_node'] = $node->nid;
+
+    $cid = db_query('select wc.cid from {webform_component} wc
+      WHERE wc.nid = :nid AND wc.form_key = :key',
+      array(':nid' => $node->nid, ':key' => 'sba_action_is_multistep')
+    )->fetchAssoc();
+
+    if (!$cid) {
+      $field = array(
+        'nid' => $node->nid,
+        'form_key' => 'secure_prepop_autofill',
+        'pid' => 0,
+        'name' => t('Autofilled'),
+        'type' => 'hidden',
+        'value' => '',
+        'weight' => 30,
+        'email' => 1,
+      );
+      webform_component_insert($field);
+    }
+  }
+
+  $sandbox['#finished'] = ($sandbox['progress'] >= $sandbox['max']) ? TRUE : ($sandbox['progress'] / $sandbox['max']);
+  $sandbox_status = $sandbox;
+  // Don't want them in the output.
+  unset($sandbox_status['messages']);
+
+  if ($sandbox['#finished']) {
+    return t('Autofill field has been added to existing webforms.');
+  }
+}

--- a/secure_prepopulate/secure_prepopulate.module
+++ b/secure_prepopulate/secure_prepopulate.module
@@ -326,10 +326,8 @@ function secure_prepopulate_form_webform_client_form_alter(&$form, $form_state) 
       }
     }
   }
-  $quicksign_field = &_secure_prepopulate_find_field($form, $component_hierarchy['secure_prepop_autofill']);
-  $quicksign_field['#value'] = "1";
-  $quicksign_field['#default_value'] = "1";
-
+  $autofill_field = &_secure_prepopulate_find_field($form, $component_hierarchy['secure_prepop_autofilled']);
+  $autofill_field['#value'] = "1";
 }
 
 /**

--- a/secure_prepopulate/secure_prepopulate.module
+++ b/secure_prepopulate/secure_prepopulate.module
@@ -326,6 +326,10 @@ function secure_prepopulate_form_webform_client_form_alter(&$form, $form_state) 
       }
     }
   }
+  $quicksign_field = &_secure_prepopulate_find_field($form, $component_hierarchy['secure_prepop_autofill']);
+  $quicksign_field['#value'] = "1";
+  $quicksign_field['#default_value'] = "1";
+
 }
 
 /**
@@ -613,11 +617,11 @@ function pkcs5_unpad($text) {
  *
  * Add the autofill flag to forms.
  */
-function secure_propulate_node_insert($node) {
+function secure_prepopulate_node_insert($node) {
   $webform_node_types = variable_get('webform_node_types', array('webform'));
   if (in_array($node->type, $webform_node_types)) {
     // Adds some custom fields to new webforms.
-    module_load_include('inc', 'secure_prepopulate', 'includes/secure_prepopulate.components');
+    module_load_include('inc', 'secure_prepopulate', 'secure_prepopulate.components');
     secure_prepopulate_insert_components($node);
   }
 }

--- a/secure_prepopulate/secure_prepopulate.module
+++ b/secure_prepopulate/secure_prepopulate.module
@@ -328,7 +328,9 @@ function secure_prepopulate_form_webform_client_form_alter(&$form, $form_state) 
   }
 
   $autofill_field = &_secure_prepopulate_find_field($form, $component_hierarchy['secure_prepop_autofilled']);
-  $autofill_field['#value'] = "1";
+  if ($autofill_field) {
+    $autofill_field['#value'] = "1";
+  }
 }
 
 /**

--- a/secure_prepopulate/secure_prepopulate.module
+++ b/secure_prepopulate/secure_prepopulate.module
@@ -326,6 +326,7 @@ function secure_prepopulate_form_webform_client_form_alter(&$form, $form_state) 
       }
     }
   }
+
   $autofill_field = &_secure_prepopulate_find_field($form, $component_hierarchy['secure_prepop_autofilled']);
   $autofill_field['#value'] = "1";
 }

--- a/secure_prepopulate/secure_prepopulate.module
+++ b/secure_prepopulate/secure_prepopulate.module
@@ -606,3 +606,18 @@ function pkcs5_unpad($text) {
   }
   return drupal_substr($text, 0, -1 * $pad);
 }
+
+
+/**
+ * Implements hook_node_insert().
+ *
+ * Add the autofill flag to forms.
+ */
+function secure_propulate_node_insert($node) {
+  $webform_node_types = variable_get('webform_node_types', array('webform'));
+  if (in_array($node->type, $webform_node_types)) {
+    // Adds some custom fields to new webforms.
+    module_load_include('inc', 'secure_prepopulate', 'includes/secure_prepopulate.components');
+    secure_prepopulate_insert_components($node);
+  }
+}


### PR DESCRIPTION
Adds the autofilled webform component flag to webforms and salesforce mappings.

Some code duplication in salesforce_genmap.install update hooks 7002 & 7003, but I'm reluctant to modify a pre-existing hook. They could use a common helper function however, and perhaps there will be more similar updates in the future.