### PR TITLE
Fixing a typo in the minimum amount message for designations

### DIFF
--- a/fundraiser/modules/fundraiser_designations/js/fundraiser_designations.js
+++ b/fundraiser/modules/fundraiser_designations/js/fundraiser_designations.js
@@ -389,7 +389,7 @@
       else {
         var MinAmt = parseFloat(Drupal.settings.fundraiserWebform.minimum_donation_amount);
         if (amtFloat < MinAmt) {
-          message += ' Below the minumum amount.'
+          message += ' Below the minimum amount.'
         }
       }
     }


### PR DESCRIPTION
Changing "minumum" to "minimum", affects JS targeting of minimum amount messages in page wrapper JS