### PR TITLE
Add check_plain() to output of P2P donor_name when output for display.

### DIFF
--- a/springboard_p2p/plugins/content_types/personal_campaign_comments.inc
+++ b/springboard_p2p/plugins/content_types/personal_campaign_comments.inc
@@ -67,7 +67,7 @@ function springboard_p2p_personal_campaign_comments_render($subtype, $conf, $pan
 
     if ($comment['show_name'] && !empty($comment['donor_name'])) {
       $output[] = '<h3 class="p2p-comment-name">';
-      $output[] = $comment['donor_name'];
+      $output[] = check_plain($comment['donor_name']);
       $output[] = '</h3>';
     }
     else {

--- a/springboard_p2p/plugins/content_types/personal_campaign_roll.inc
+++ b/springboard_p2p/plugins/content_types/personal_campaign_roll.inc
@@ -83,7 +83,7 @@ function springboard_p2p_personal_campaign_roll_render($subtype, $conf, $panel_a
 
     if ($comment['show_name'] && !empty($comment['donor_name'])) {
       $output[] = '<td>';
-      $output[] = $comment['donor_name'];
+      $output[] = check_plain($comment['donor_name']);
       $output[] = '</td>';
     }
     else {


### PR DESCRIPTION
Need to add check_plain() to the the two panels content types that render user submitted data on p2p personal campaign pages to avoid xss.

This wraps the donor_name variable in check_plain() before display to sanitize the donor's submitted first name and last name as stored in the springboard_p2p_personal_campaign_action table.