### PR TITLE
Implement submission delete hook to clean up leftover record

### DIFF
--- a/webform_confirmations/webform_confirmations.module
+++ b/webform_confirmations/webform_confirmations.module
@@ -125,6 +125,15 @@ function webform_confirmations_webform_submission_insert($node, $submission) {
 }
 
 /**
+ * Implements hook_webform_submission_delete().
+ */
+function webform_confirmations_webform_submission_delete($node, $submission) {
+  db_delete('webform_confirmations_submissions')
+    ->condition('sid', $submission->sid)
+    ->execute();
+}
+
+/**
  * Log submission ID and current session id.
  */
 function webform_confirmations_save_submission_session($sid) {


### PR DESCRIPTION
The related record in webform_confirmations_submissions is not cleaned up when a submission is removed.