### PR TITLE
use cookie instead of location hash to prevent dupe cart items

### DIFF
--- a/fundraiser/modules/fundraiser_designations/js/fundraiser_designations.js
+++ b/fundraiser/modules/fundraiser_designations/js/fundraiser_designations.js
@@ -56,33 +56,39 @@
       }
     }
     // Landing page query params are present in Drupal.settings.
-    if(typeof(settings.fundraiser_designations) != "undefined" && location.hash != '#fdprocessed') {
+    if(typeof(settings.fundraiser_designations) != "undefined") {
+
+      var query_cookie = $.cookie('designations_query_' + Drupal.settings.fdNid);
       var sfd = settings.fundraiser_designations;
-      var cartEmpty = $('input[name$="[fund_catcher]"]').val().replace(/&quot;/g, '"').length;
-      self.repopCart(sfd);
-      $('select#funds-select-' + sfd.fundGroup + ' option[value=' + sfd.fundId +']').prop('selected', true)
-      if (typeof(sfd.recurs) != 'undefined' && cartEmpty === 0) {
-        var rcr = $('input[name*="[recurs_monthly]"]');
-        var freq = sfd.recurs;
-        switch (freq) {
-          case 'one-time':
-          case 'yearly':
-            rcr.each(function(){
-              if (this.value == 'NO_RECURR') {
-                $(this).attr('checked', true);
-              }
-            });
-            break;
-          case 'monthly':
-            rcr.each(function(){
-              if (this.value == 'recurs') {
-                $(this).attr('checked', true);
-              }
-            });
-            break;
+      var sfdString = JSON.stringify(sfd);
+
+      if(query_cookie !== sfdString) {
+        var cartEmpty = $('input[name$="[fund_catcher]"]').val().replace(/&quot;/g, '"').length;
+        self.repopCart(sfd);
+        $('select#funds-select-' + sfd.fundGroup + ' option[value=' + sfd.fundId + ']').prop('selected', true)
+        if (typeof(sfd.recurs) != 'undefined' && cartEmpty === 0) {
+          var rcr = $('input[name*="[recurs_monthly]"]');
+          var freq = sfd.recurs;
+          switch (freq) {
+            case 'one-time':
+            case 'yearly':
+              rcr.each(function () {
+                if (this.value == 'NO_RECURR') {
+                  $(this).attr('checked', true);
+                }
+              });
+              break;
+            case 'monthly':
+              rcr.each(function () {
+                if (this.value == 'recurs') {
+                  $(this).attr('checked', true);
+                }
+              });
+              break;
+          }
         }
+        $.cookie('designations_query_' + Drupal.settings.fdNid, JSON.stringify(sfd));
       }
-      location.hash = 'fdprocessed';
     }
   };
 


### PR DESCRIPTION
After the aggregation into the cart of multiple landing pages was enabled, there was problem: reloading the page would cause another item to be added to the cart; also navigating to another and then using the back button would do the same. Placing #fdprocessed into the anchor tag was the solution to that problem. A cookie that used the same ffdprocessed flag wouldn’t work because it is persistent -  yes, it would prevent the accidental addition of items on reload and back navigation, but it would also prevent the aggregation of multiple landing pages.

a different cookie approach might work: one where we place the actual query parameters into the cookie instead of the fdprocessed flag. That way we could compare any loaded parameters to the stored parameters, and only add to the cart if the loaded parameters are not in the stored parameters.