### PR TITLE
update scrutinizer.yml to allow backtrace

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -71,7 +71,7 @@ build:
             - 'find . -type f \( -name "*.php" -or -name "*.module" -or -name "*.install" -or -name "*.inc" -or -name "*.profile" -or -name "*.test" -or -name "*.theme" \) -print0 | xargs -0 -n1 -P8 php -l'
             # Negate the return value of ack, because not finding these
             # strings should be a pass.
-            - '! ack-grep -i "<<<<<<<|^=======$|>>>>>>>|dpm\(|dsm\(|var_dump\(|var_export\(|[^set]debug\(|dpq|dvm|dpr\(|kpr|dvr|kprint_r|dprint_r|devel_render|ddebug_backtrace|debug_backtrace|debug_print_backtrace|debug_to_file" --ignore-file=ext:txt,html,yml,js'
+            - '! ack-grep -i "<<<<<<<|^=======$|>>>>>>>|dpm\(|dsm\(|var_dump\(|[^set]debug\(|dpq|dvm|dpr\(|kpr|dvr|kprint_r|dprint_r|devel_render|ddebug_backtrace|debug_print_backtrace|debug_to_file" --ignore-file=ext:txt,html,yml,js'
             - 'cd'
             - 'mv build repo'
             - 'git clone --depth 1 --branch 7.x-4.x https://github.com/JacksonRiver/Springboard-Build.git build-tools'


### PR DESCRIPTION
We use debug backtrace and var_export in code now.