### PR TITLE
fix pager notice - update page info even if no result

### DIFF
--- a/springboard_advocacy/includes/views/plugins/springboard_advocacy_views_plugin_query.inc
+++ b/springboard_advocacy/includes/views/plugins/springboard_advocacy_views_plugin_query.inc
@@ -159,19 +159,20 @@ class springboard_advocacy_views_plugin_query extends views_plugin_query {
         }
       }
       if (!empty($items)) {
-
         // Build the pager.
         if ($this->pager->use_pager()) {
           $this->pager->total_items = $response->data->count;
           if (!empty($this->pager->options['offset'])) {
             $this->pager->total_items -= $this->pager->options['offset'];
           }
-          $this->pager->update_page_info();
         }
-
         // Add target IDs to build info. We retrieve elsewhere for use in
         // Target Add links.
         $view->build_info['target_ids'] = $response->data->ids;
+      }
+
+      if ($this->pager->use_pager()) {
+        $this->pager->update_page_info();
       }
 
       $view->result = array();


### PR DESCRIPTION
On the advocacy custom groups landing page, if there are two views blocks on a page, you need to update page info on both of them, even if one has no result, otherwise you get a php notice.