### PR TITLE
7.x 4.13 rc7 1213 awf p2p sync

### DIFF
--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -1736,20 +1736,20 @@ function springboard_p2p_form_alter(&$form, &$form_state, $form_id) {
       break;
   }
 
-  if (strpos($form_id, 'webform_client_form_') !== FALSE && !empty($form['#node'])) {
+  if (!empty($form_state['values']['springboard_p2p_personal_campaign_action']['personal_campaign_nid'])) {
+    $personal_campaign_id = $form_state['values']['springboard_p2p_personal_campaign_action']['personal_campaign_nid'];
+  }
+  else {
+    $personal_campaign_id = springboard_p2p_get_personal_campaign_id_from_request();
+  }
+
+  if ($personal_campaign_id && strpos($form_id, 'webform_client_form_') !== FALSE && !empty($form['#node'])) {
     $type = $form['#node']->type;
 
     $is_fundraiser_type = fundraiser_is_donation_type($type);
     $is_webform_user_type = _webform_user_is_webform_user_node_type($type);
 
-    if (!empty($form_state['values']['springboard_p2p_personal_campaign_action']['personal_campaign_nid'])) {
-      $personal_campaign_id = $form_state['values']['springboard_p2p_personal_campaign_action']['personal_campaign_nid'];
-    }
-    else {
-      $personal_campaign_id = springboard_p2p_get_personal_campaign_id_from_request();
-    }
-
-    if (($is_fundraiser_type || $is_webform_user_type) && $personal_campaign_id) {
+    if ($is_fundraiser_type || $is_webform_user_type) {
 
       $personal_campaign = node_load($personal_campaign_id);
 

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -2316,28 +2316,6 @@ function springboard_p2p_format_campaign_form_header($campaign) {
  * Adds customizations to the p2p webform.
  */
 function springboard_p2p_page_alter(&$page, $form) {
-  if (isset($_GET['p2p_pcid']) && is_numeric($_GET['p2p_pcid']) && arg(0) == 'node' && is_numeric(arg(1)) && is_null(arg(2))) {
-    $personal_campaign_id = $_GET['p2p_pcid'];
-
-    $node = node_load(arg(1));
-    $type = $node->type;
-    $is_fundraiser_type = fundraiser_is_donation_type($type);
-    $is_webform_user_type = _webform_user_is_webform_user_node_type($type);
-    if ($is_fundraiser_type || $is_webform_user_type) {
-      $personal_campaign = node_load($personal_campaign_id);
-      if ($personal_campaign->type == 'p2p_personal_campaign') {
-
-        $campaign_id = $personal_campaign->field_p2p_campaign[$personal_campaign->language][0]['target_id'];
-        $campaign = node_load($campaign_id);
-        if (!empty($campaign) && $campaign->type == 'p2p_campaign') {
-
-          // Place the banner in the springboard_frontend theme header region.
-          // @todo Review and remove this if needed.
-          // $page['page_top']['springboard_p2p_banner'] = springboard_p2p_format_campaign_form_header($campaign);
-        }
-      }
-    }
-  }
 
   // Not admin page.
   if (!path_is_admin(current_path())) {

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -1493,6 +1493,23 @@ function springboard_p2p_get_campaign_id_from_request() {
 }
 
 /**
+ * Gets a personal campaign ID from the URL.
+ *
+ * @return int|null
+ *   The personal campaign ID, or NULL if one can't be found.
+ */
+function springboard_p2p_get_personal_campaign_id_from_request() {
+  if (isset($_GET['p2p_pcid']) && is_numeric($_GET['p2p_pcid'])) {
+    $node = node_load($_GET['p2p_pcid']);
+    if (isset($node->type) && $node->type == 'p2p_personal_campaign') {
+      return $node->nid;
+    }
+  }
+
+  return NULL;
+}
+
+/**
  * Submit handler.
  *
  * Saves the campaign approval status and changes the redirect.
@@ -1719,13 +1736,20 @@ function springboard_p2p_form_alter(&$form, &$form_state, $form_id) {
       break;
   }
 
-  if (isset($_GET['p2p_pcid']) && is_numeric($_GET['p2p_pcid']) && strpos($form_id, 'webform_client_form_') !== FALSE && !empty($form['#node'])) {
+  if (strpos($form_id, 'webform_client_form_') !== FALSE && !empty($form['#node'])) {
     $type = $form['#node']->type;
-    $personal_campaign_id = $_GET['p2p_pcid'];
 
     $is_fundraiser_type = fundraiser_is_donation_type($type);
     $is_webform_user_type = _webform_user_is_webform_user_node_type($type);
-    if ($is_fundraiser_type || $is_webform_user_type) {
+
+    if (!empty($form_state['values']['springboard_p2p_personal_campaign_action']['personal_campaign_nid'])) {
+      $personal_campaign_id = $form_state['values']['springboard_p2p_personal_campaign_action']['personal_campaign_nid'];
+    }
+    else {
+      $personal_campaign_id = springboard_p2p_get_personal_campaign_id_from_request();
+    }
+
+    if (($is_fundraiser_type || $is_webform_user_type) && $personal_campaign_id) {
 
       $personal_campaign = node_load($personal_campaign_id);
 
@@ -1812,7 +1836,7 @@ function springboard_p2p_form_alter(&$form, &$form_state, $form_id) {
     }
 
     // Test for donation form and if a p2p form.
-    if (($is_fundraiser_type) || (!empty($_GET['p2p_pcid']))) {
+    if ($is_fundraiser_type || $personal_campaign_id) {
 
       // Get rid of the grippie.
       $form["springboard_p2p_personal_campaign_action"]['comment']['#resizable'] = FALSE;


### PR DESCRIPTION
Fixes an issue with the webform countries field ajax request removing the form altered values set by springboard_p2p_form_alter() and adds a helper function to look up personal campaign ids. 

Also removes a non-functional code block that has been marked for removal for three years, but which was nonetheless calling node_load twice on personal campaign pages.