### PR TITLE
do not try to resave a deleted card post update

### DIFF
--- a/fundraiser/modules/fundraiser_commerce_cardonfile/includes/fundraiser_commerce_cardonfile.fundraiser.inc
+++ b/fundraiser/modules/fundraiser_commerce_cardonfile/includes/fundraiser_commerce_cardonfile.fundraiser.inc
@@ -33,13 +33,15 @@ function fundraiser_commerce_cardonfile_fundraiser_donation_post_update($donatio
   }
 
   $card = commerce_cardonfile_load($donation->data['cardonfile']);
-  $card_wrapper = entity_metadata_wrapper('commerce_cardonfile', $card);
+  if (!empty($card)) {
+    $card_wrapper = entity_metadata_wrapper('commerce_cardonfile', $card);
 
-  $order = commerce_order_load($donation->did);
-  $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
+    $order = commerce_order_load($donation->did);
+    $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
 
-  $card_wrapper->commerce_cardonfile_profile = $order_wrapper->commerce_customer_billing->value();
-  $card_wrapper->save();
+    $card_wrapper->commerce_cardonfile_profile = $order_wrapper->commerce_customer_billing->value();
+    $card_wrapper->save();
+  }
 
   $updated_donation = TRUE;
 }


### PR DESCRIPTION
Fixes an issue where a fatal error occurs if a post update hook tries to resave a card that has been deleted.