### PR TITLE
test for existence of offsite config prior to lookup

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -499,7 +499,12 @@ function fundraiser_sustainers_salesforce_genmap_map_fields_alter(&$fields, $con
   if ($context['module'] == 'salesforce_donation') {
     $donation = $context['object'];
     $info = _fundraiser_get_donation_gateway($donation->did);
-    $offsite_recurring = _fundraiser_sustainers_offsite_recurring($info['offsite_recurring'], $donation->donation['payment_method']);
+    if (!empty($info['offsite_recurring'])) {
+      $offsite_recurring = _fundraiser_sustainers_offsite_recurring($info['offsite_recurring'], $donation->donation['payment_method']);
+    }
+    else {
+      $offsite_recurring = FALSE;
+    }
     $map = $context['map'];
 
     // Add recurring item marker if recurring or not.


### PR DESCRIPTION
Some gateway info arrays don't have an offsite recurring index. This patch prevents php notices when that is the case.