### PR TITLE
fix incorrect field name in secure prepop update hook

### DIFF
--- a/secure_prepopulate/secure_prepopulate.install
+++ b/secure_prepopulate/secure_prepopulate.install
@@ -104,7 +104,7 @@ function secure_prepopulate_update_7002(&$sandbox) {
 
     $cid = db_query('select wc.cid from {webform_component} wc
       WHERE wc.nid = :nid AND wc.form_key = :key',
-      array(':nid' => $node->nid, ':key' => 'sba_action_is_multistep')
+      array(':nid' => $node->nid, ':key' => 'secure_prepop_autofilled')
     )->fetchAssoc();
 
     if (!$cid) {


### PR DESCRIPTION
I forgot to change the field name when I copied the code block for this update hook. The result was that the autofill field was not being added to actions, instead of the proper result of not adding the autofill field when it already exists.