### PR TITLE
add a check for null values/deleted components to fundraiser_webform_…

### DIFF
--- a/fundraiser/modules/fundraiser_webform/fundraiser_webform.module
+++ b/fundraiser/modules/fundraiser_webform/fundraiser_webform.module
@@ -1375,6 +1375,7 @@ function fundraiser_webform_get_submission($sid) {
   $query->fields('sd', array('no', 'data'))
     ->fields('sc', array('form_key'))
     ->condition('sd.sid', $sid)
+    ->isNotNull('sc.form_key')
     ->orderBy('sd.sid', 'ASC')
     ->orderBy('sd.cid', 'ASC')
     ->orderBy('sd.no', 'ASC');


### PR DESCRIPTION
fundraiser_webform_get_submission() doesn't check if form_key is null due to deleted components when selecting from the webform_component and webform_submitted data tables. This results in unformatted and incomplete data being added to  $donation->submission_data array, which can cause problems down the line when successor functions are expecting data arrays keyed by the form_key. 

