### PR TITLE
1608 let p2p campaigns show refunds adjustments

### DIFF
--- a/springboard_p2p/modules/springboard_p2p_fields/springboard_p2p_fields.install
+++ b/springboard_p2p/modules/springboard_p2p_fields/springboard_p2p_fields.install
@@ -107,7 +107,7 @@ function springboard_p2p_fields_personal_campaign_progress_schema() {
   return array(
     'columns' => array(
       'amount' => array(
-        'type' => 'int',
+        'type' => 'float',
         'unsigned' => TRUE,
         'not null' => FALSE,
         'description' => 'The donation amount attributed to this personal campaign.',

--- a/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.install
+++ b/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.install
@@ -68,11 +68,11 @@ function springboard_p2p_personal_campaign_update_7003() {
 }
 
 /**
- * Change data type for column field_p2p_campaign_progress_amount from unsigned int to decimal.
+ * Change data type for column field_p2p_campaign_progress_amount from int to float.
  */
 function springboard_p2p_personal_campaign_update_7004() {
   if (db_field_exists('field_data_field_p2p_campaign_progress', 'field_p2p_campaign_progress_amount')) {
-    db_query("ALTER TABLE {field_data_field_p2p_campaign_progress} MODIFY field_p2p_campaign_progress_amount DECIMAL (10,2);");
+    db_query("ALTER TABLE {field_data_field_p2p_campaign_progress} MODIFY field_p2p_campaign_progress_amount float unsigned;");
   }
   else {
     drupal_set_message('Type for column field_p2p_campaign_progress_amount could not be updated because it does not exist.');

--- a/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.install
+++ b/springboard_p2p/modules/springboard_p2p_personal_campaign/springboard_p2p_personal_campaign.install
@@ -66,3 +66,15 @@ function springboard_p2p_personal_campaign_update_7003() {
   // Apply the new field instance configuration.
   features_revert(array('springboard_p2p_personal_campaign' => array('field')));
 }
+
+/**
+ * Change data type for column field_p2p_campaign_progress_amount from unsigned int to decimal.
+ */
+function springboard_p2p_personal_campaign_update_7004() {
+  if (db_field_exists('field_data_field_p2p_campaign_progress', 'field_p2p_campaign_progress_amount')) {
+    db_query("ALTER TABLE {field_data_field_p2p_campaign_progress} MODIFY field_p2p_campaign_progress_amount DECIMAL (10,2);");
+  }
+  else {
+    drupal_set_message('Type for column field_p2p_campaign_progress_amount could not be updated because it does not exist.');
+  }
+}

--- a/springboard_p2p/springboard_p2p.install
+++ b/springboard_p2p/springboard_p2p.install
@@ -697,17 +697,3 @@ function springboard_p2p_update_7010(&$sandbox) {
     return t('springboard_p2p_personal_campaign_action table donor_names updated.');
   }
 }
-
-/**
- * Change the field_data_field_p2p_campaign_progress table's field_p2p_campaign_progress_amount column from
- * unsigned int to decimal in order to accurately track non-whole-number refunds and donations; previously,
- * the "ceiling" of a decimal donation was being used.
- */
-function springboard_p2p_update_7011() {
-  if (db_field_exists('field_data_field_p2p_campaign_progress', 'field_p2p_campaign_progress_amount')) {
-    db_query("ALTER TABLE {field_data_field_p2p_campaign_progress} MODIFY field_p2p_campaign_progress_amount DECIMAL (10,2);");
-  }
-  else {
-    drupal_set_message('Type for column field_p2p_campaign_progress_amount could not be updated because it does not exist.');
-  }
-}

--- a/springboard_p2p/springboard_p2p.install
+++ b/springboard_p2p/springboard_p2p.install
@@ -697,3 +697,17 @@ function springboard_p2p_update_7010(&$sandbox) {
     return t('springboard_p2p_personal_campaign_action table donor_names updated.');
   }
 }
+
+/**
+ * Change the field_data_field_p2p_campaign_progress table's field_p2p_campaign_progress_amount column from
+ * unsigned int to decimal in order to accurately track non-whole-number refunds and donations; previously,
+ * the "ceiling" of a decimal donation was being used.
+ */
+function springboard_p2p_update_7011() {
+  if (db_field_exists('field_data_field_p2p_campaign_progress', 'field_p2p_campaign_progress_amount')) {
+    db_query("ALTER TABLE {field_data_field_p2p_campaign_progress} MODIFY field_p2p_campaign_progress_amount DECIMAL (10,2);");
+  }
+  else {
+    drupal_set_message('Type for column field_p2p_campaign_progress_amount could not be updated because it does not exist.');
+  }
+}

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -1732,26 +1732,26 @@ function springboard_p2p_fundraiser_refund_success($refund) {
     if (isset($personal_campaign_data['personal_campaign_nid']) && is_numeric($personal_campaign_data['personal_campaign_nid'])) {
       $pc_nid = $personal_campaign_data['personal_campaign_nid'];
 
-      // Subtract the refund from the total amount donated for this personal campaign:
-      $amount_modifier = $refund->amount * -1;
-      springboard_p2p_update_personal_campaign_amount_progress($pc_nid, $amount_modifier);
-
-      // Determine if this is a full refund:
-      $is_full_refund = FALSE;
       if (isset($refund->donation->amount) && isset($refund->donation->refunds) && is_array($refund->donation->refunds)) {
-        $total_amount_refunded = $refund->amount;
+        // Determine if this is a full refund:
+        $is_full_refund = FALSE;
+        $previously_refunded = 0.00;
         foreach ($refund->donation->refunds as $previous_refund) {
           if (isset($previous_refund->amount)) {
-            $total_amount_refunded += $previous_refund->amount;
+            $previously_refunded += $previous_refund->amount;
           }
         }
-        if ($refund->donation->amount <= $total_amount_refunded) { // Total should not exceed the original donation amount, but checking just in case!
+        if ($refund->donation->amount <= ($refund->amount + $previously_refunded)) { // Total should not exceed the original donation amount, but checking just in case!
           $is_full_refund = TRUE;
         }
 
-        // Decrement the submissions count for this personal campaign if the full amount was refunded
-        // AND delete the action record associated with this donation.
+        // For full refunds:
+        // - Remove the original donation amount from personal campaign progress amount.
+        // - Decrement the submissions count for this personal campaign.
+        // - Delete the action record associated with this donation.
         if ($is_full_refund) {
+          $amount_modifier = ($refund->donation->amount - $previously_refunded) * -1.00;
+          springboard_p2p_update_personal_campaign_amount_progress($pc_nid, $amount_modifier);
           springboard_p2p_update_personal_campaign_submissions_progress($pc_nid, FALSE);
           db_query("DELETE FROM {springboard_p2p_personal_campaign_action} WHERE " .
             "personal_campaign_nid = :pc_nid AND sid = :sid LIMIT 1",
@@ -1761,12 +1761,16 @@ function springboard_p2p_fundraiser_refund_success($refund) {
             )
           );
         }
-        // Otherwise, update the amount for the action record association with this refund's submission:
+
+        // For partial refunds:
+        // - Subtract the refund amount from the personal campaign progress amount.
+        // - Update the amount for the action record association with this refund's submission.
         elseif (!$is_full_refund) {
+          springboard_p2p_update_personal_campaign_amount_progress($pc_nid, $refund->amount * -1.00);
           db_query("UPDATE {springboard_p2p_personal_campaign_action} " .
             "SET amount = :new_amount WHERE personal_campaign_nid = :pc_nid AND sid = :sid LIMIT 1",
             array(
-              ':new_amount' => ($refund->donation->amount - $total_amount_refunded) * 100,
+              ':new_amount' => ($refund->donation->amount - ($refund->amount + $previously_refunded)) * 100,
               ':pc_nid' => $pc_nid,
               ':sid' => $refund->donation->sid,
             )

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -1721,6 +1721,38 @@ function springboard_p2p_fundraiser_donation_post_create($donation) {
 }
 
 /**
+ * Implements hook_fundraiser_donation_refund_success().
+ *
+ * Updates p2p campaign data to reflect a donation being refunded.
+ */
+function springboard_p2p_fundraiser_refund_success($refund) {
+  if (isset($refund->donation->sid) && isset($refund->amount) && $refund->amount > 0) {
+    // Get the p2p_personal_campaign node ID:
+    $personal_campaign_data = springboard_p2p_get_personal_campaign_action_by_sid($refund->donation->sid);
+    if (isset($personal_campaign_data['personal_campaign_nid']) && is_numeric($personal_campaign_data['personal_campaign_nid'])) {
+      $pc_nid = $personal_campaign_data['personal_campaign_nid'];
+
+      // Subtract the refund from the total amount donated for this personal campaign:
+      $amount_modifier = $refund->amount * -1;
+      springboard_p2p_update_personal_campaign_amount_progress($pc_nid, $amount_modifier);
+
+      // If this is a full refund then also decrement the submissions count:
+      if (isset($refund->donation->amount) && isset($refund->donation->refunds) && is_array($refund->donation->refunds)) {
+        $total_amount_refunded = $refund->amount;
+        foreach ($refund->donation->refunds as $previous_refund) {
+          if (isset($previous_refund->amount)) {
+            $total_amount_refunded += $previous_refund->amount;
+          }
+        }
+        if ($refund->donation->amount == $total_amount_refunded) {
+          springboard_p2p_update_personal_campaign_submissions_progress($pc_nid, FALSE);
+        }
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_form_alter().
  *
  * Adds extra data to a p2p enabled form if a personal campaign ID is passed in.
@@ -2220,8 +2252,21 @@ function springboard_p2p_fundraiser_donation_success($donation) {
  */
 function springboard_p2p_update_personal_campaign_amount_progress($nid, $amount) {
   $personal_campaign = node_load($nid);
-  $personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['amount'] += $amount;
-  node_save($personal_campaign);
+  $current_progress = 0;
+  if (isset($personal_campaign->language)
+    && isset($personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['amount'])) {
+    $current_progress = $personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['amount'];
+  }
+
+  // Prevent a negative value, as the column is unsigned:
+  $current_progress += $amount;
+  if ($current_progress >= 0) {
+    $personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['amount'] = $current_progress;
+    node_save($personal_campaign);
+  }
+  else {
+    watchdog('springboard_p2p', 'Error adjusting campaign progress due to negative value: ' . $current_progress);
+  }
 }
 
 /**
@@ -2230,10 +2275,21 @@ function springboard_p2p_update_personal_campaign_amount_progress($nid, $amount)
  * @param int $nid
  *   The node ID of the personal campaign.
  */
-function springboard_p2p_update_personal_campaign_submissions_progress($nid) {
+function springboard_p2p_update_personal_campaign_submissions_progress($nid, $increment = TRUE) {
   $personal_campaign = node_load($nid);
-  ++$personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['submissions'];
-  node_save($personal_campaign);
+  $current_submissions = 0;
+  if (isset($personal_campaign->language)
+    && isset($personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['submissions'])) {
+    $current_submissions = $personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['submissions'];
+  }
+  $current_submissions += ($increment ? 1 : -1);
+  if ($current_submissions >= 0) {
+    $personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['submissions'] = $current_submissions;
+    node_save($personal_campaign);
+  }
+  else {
+    watchdog('springboard_p2p', 'Error adjusting campaign progress due to negative value: ' . $current_submissions);
+  }
 }
 
 /**

--- a/springboard_p2p/springboard_p2p.module
+++ b/springboard_p2p/springboard_p2p.module
@@ -1736,7 +1736,8 @@ function springboard_p2p_fundraiser_refund_success($refund) {
       $amount_modifier = $refund->amount * -1;
       springboard_p2p_update_personal_campaign_amount_progress($pc_nid, $amount_modifier);
 
-      // If this is a full refund then also decrement the submissions count:
+      // Determine if this is a full refund:
+      $is_full_refund = FALSE;
       if (isset($refund->donation->amount) && isset($refund->donation->refunds) && is_array($refund->donation->refunds)) {
         $total_amount_refunded = $refund->amount;
         foreach ($refund->donation->refunds as $previous_refund) {
@@ -1744,8 +1745,32 @@ function springboard_p2p_fundraiser_refund_success($refund) {
             $total_amount_refunded += $previous_refund->amount;
           }
         }
-        if ($refund->donation->amount == $total_amount_refunded) {
+        if ($refund->donation->amount <= $total_amount_refunded) { // Total should not exceed the original donation amount, but checking just in case!
+          $is_full_refund = TRUE;
+        }
+
+        // Decrement the submissions count for this personal campaign if the full amount was refunded
+        // AND delete the action record associated with this donation.
+        if ($is_full_refund) {
           springboard_p2p_update_personal_campaign_submissions_progress($pc_nid, FALSE);
+          db_query("DELETE FROM {springboard_p2p_personal_campaign_action} WHERE " .
+            "personal_campaign_nid = :pc_nid AND sid = :sid LIMIT 1",
+            array(
+              'pc_nid' => $pc_nid,
+              'sid' => $refund->donation->sid,
+            )
+          );
+        }
+        // Otherwise, update the amount for the action record association with this refund's submission:
+        elseif (!$is_full_refund) {
+          db_query("UPDATE {springboard_p2p_personal_campaign_action} " .
+            "SET amount = :new_amount WHERE personal_campaign_nid = :pc_nid AND sid = :sid LIMIT 1",
+            array(
+              ':new_amount' => ($refund->donation->amount - $total_amount_refunded) * 100,
+              ':pc_nid' => $pc_nid,
+              ':sid' => $refund->donation->sid,
+            )
+          );
         }
       }
     }
@@ -2258,7 +2283,6 @@ function springboard_p2p_update_personal_campaign_amount_progress($nid, $amount)
     $current_progress = $personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['amount'];
   }
 
-  // Prevent a negative value, as the column is unsigned:
   $current_progress += $amount;
   if ($current_progress >= 0) {
     $personal_campaign->field_p2p_campaign_progress[$personal_campaign->language][0]['amount'] = $current_progress;


### PR DESCRIPTION
This pull request also fixes a bug where precision was getting lost for non-whole number donations because field_data_field_p2p_campaign_progress.field_p2p_campaign_progress_amount was an integer rather than a floating point value.