### PR TITLE
prevent session storage after quicksign

### DIFF
--- a/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
+++ b/springboard_advocacy/modules/sba_quicksign/sba_quicksign.module
@@ -820,3 +820,18 @@ function sba_quicksign_clone_node_alter(&$node, $context) {
     $node->quicksign_button_text = $original_settings['quicksign_button_text'];
   }
 }
+
+
+/**
+ * Implements hook_webform_user_session_storage_cancel().
+ *
+ * Don't allow session storage when forms are submitted via quicksign.
+ */
+function sba_quicksign_webform_user_session_storage_cancel($form_state) {
+  if (isset($form_state['triggering_element'])) {
+    if (in_array('sba_quicksign', $form_state['triggering_element']['#parents'])) {
+      return FALSE;
+    }
+  }
+  return TRUE;
+}

--- a/webform_user/webform_user.module
+++ b/webform_user/webform_user.module
@@ -571,7 +571,7 @@ function webform_user_webform_submit($form, &$form_state) {
       }
       webform_submission_update($node, $submission);
       // Save webform user fields in user session for the existing user.
-      if (_webform_user_is_webform_user_session_store()) {
+      if (_webform_user_is_webform_user_session_store($form_state)) {
         _webform_user_session_set($node->nid, $map);
       }
     }
@@ -603,7 +603,7 @@ function webform_user_webform_submit($form, &$form_state) {
       }
       webform_submission_update($node, $submission);
       // Save webform user fields in user session.
-      if (_webform_user_is_webform_user_session_store()) {
+      if (_webform_user_is_webform_user_session_store($form_state)) {
         _webform_user_session_set($node->nid, $map);
       }
     }
@@ -1297,8 +1297,22 @@ function _webform_user_is_webform_user_node_type($type) {
 
 /**
  * Check if webform_user should save submission values to session.
+ *
+ * @form_state
+ *   The submitted form state.
+ *
+ * @return bool
+ *   Whether to allow session storage.
  */
-function _webform_user_is_webform_user_session_store() {
+function _webform_user_is_webform_user_session_store($form_state) {
+  // Allow other modules to prevent webform user session storage.
+  $session_cancel = module_invoke_all('webform_user_session_storage_cancel', $form_state);
+  foreach ($session_cancel as $cancel) {
+    if (!$cancel) {
+      return FALSE;
+    }
+  }
+
   return variable_get('webform_user_session_store', FALSE);
 }
 


### PR DESCRIPTION
Creates a hook to allow other modules to disable webform_user session storage during a submission.