### PR TITLE
1699 add delete function to sb api key management

### DIFF
--- a/springboard_api/includes/springboard_api.admin.inc
+++ b/springboard_api/includes/springboard_api.admin.inc
@@ -40,3 +40,36 @@ function springboard_api_admin_settings($form, $form_state) {
   }
   return system_settings_form($form);
 }
+
+
+/**
+ * Confirm form for api key delete.
+ *
+ * @param string $id
+ *   The app id.
+ */
+function springboard_api_admin_remove_app_form($form, $form_state, $id) {
+  $form = array();
+  $api_keys = variable_get('springboard_api_basic_keys', array());
+  $form['#app_id'] = $id;
+  $title = $api_keys["{$id}"]['name'];
+  $form['#submit'][] = 'springboard_api_remove_app_form_submit';
+  return confirm_form(
+    $form,
+    t('Are you sure you want to delete %title?', array('%title' => $title)),
+    'admin/config/services/springboard_api',
+    t('This action cannot be undone.'),
+    t('Delete'),
+    t('Cancel'),
+    'springboard_api_admin_manage_app');
+}
+
+/**
+ * Remove an API key.
+ */
+function springboard_api_remove_app_form_submit($form, &$form_state) {
+  $api_keys = variable_get('springboard_api_basic_keys', array());
+  unset($api_keys[$form['#app_id']]);
+  variable_set('springboard_api_basic_keys', $api_keys);
+  $form_state['redirect'] = 'admin/config/services/springboard_api';
+}

--- a/springboard_api/plugins/api_management_services/basic/springboard_api.basic_service.inc
+++ b/springboard_api/plugins/api_management_services/basic/springboard_api.basic_service.inc
@@ -85,7 +85,7 @@ function springboard_api_basic_service_settings(&$form, $form_state) {
   $rows = array();
   $defaults = array();
   foreach ($api_keys as $key => $value) {
-    $links = _springboard_api_basic_service_links($key['id']);
+    $links = _springboard_api_basic_service_links($key);
     $defaults[$key] = $value['enabled'] ? $key : 0;
     $rows[$key] = array(
       $value['name'],
@@ -138,9 +138,7 @@ function _springboard_api_tracker_count() {
 }
 
 function _springboard_api_basic_service_links($id) {
-
-  $links = l(t('Edit'), '');
-  $links .= ' | ' . l(t('Delete'), '');
+  $links = l(t('Delete'), 'admin/config/services/springboard_api/' . $id .'/delete');
   return $links;
 }
 

--- a/springboard_api/springboard_api.module
+++ b/springboard_api/springboard_api.module
@@ -54,7 +54,18 @@ function springboard_api_menu() {
     'type' => MENU_NORMAL_ITEM,
     'file' => 'includes/springboard_api.admin.inc',
   );
+
+  $items['admin/config/services/springboard_api/%/delete'] = array(
+    'title' => 'Springboard API Key Delete',
+    'description' => 'Remove Springboard API App.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('springboard_api_admin_remove_app_form', 4),
+    'access arguments' => array('administer springboard api'),
+    'type' => MENU_CALLBACK,
+    'file' => 'includes/springboard_api.admin.inc',
+  );
   return $items;
+
 }
 
 /**


### PR DESCRIPTION
Unifinished admin UI for sb api was genreating php notices. This patch removes the API key edit link, which is unneeded, and fixes delete link so that it actually works.