### PR TITLE
1428 Include commerce file to prevent upsell error

### DIFF
--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_cybersource.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_cybersource.inc
@@ -234,6 +234,7 @@ function commerce_cybersource_fundraiser_commerce_update($donation, $card_data =
       );
     $request->recurringSubscriptionInfo = (object) array('frequency' => 'on-demand');
     $request->paySubscriptionCreateService = (object) array('run' => 'true');
+    module_load_include('inc', 'commerce_payment', 'includes/commerce_payment.credit_card');
     $card_type = commerce_payment_validate_credit_card_type($pane_values['credit_card']['number'], array_keys(commerce_payment_credit_card_types()));
     $request->card->cardType = commerce_cybersource_cc_type_code($card_type);
 

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_litle.inc
@@ -426,6 +426,7 @@ function commerce_litle_fundraiser_commerce_update($donation, $card_data = NULL)
       if (!empty($token)) {
 
         // Get the card type.
+        module_load_include('inc', 'commerce_payment', 'includes/commerce_payment.credit_card');
         $card_type = commerce_payment_validate_credit_card_type($pane_values['credit_card']['number'], array_keys(commerce_payment_credit_card_types()));
         $all_types = commerce_payment_credit_card_types();
         $card_type = !empty($all_types[$card_type]) ? $all_types[$card_type] : 'card';

--- a/fundraiser/modules/fundraiser_commerce/gateways/commerce_payment_example.inc
+++ b/fundraiser/modules/fundraiser_commerce/gateways/commerce_payment_example.inc
@@ -288,6 +288,7 @@ function commerce_payment_example_fundraiser_commerce_update($donation, $card_da
     $remote_id = (string) $payment_method['method_id'] . '|' . time();
 
     // Get the card type.
+    module_load_include('inc', 'commerce_payment', 'includes/commerce_payment.credit_card');
     $card_type = commerce_payment_validate_credit_card_type($pane_values['credit_card']['number'], array_keys(commerce_payment_credit_card_types()));
     $all_types = commerce_payment_credit_card_types();
     $card_type = !empty($all_types[$card_type]) ? $all_types[$card_type] : 'card';


### PR DESCRIPTION
commerce_payment_validate_credit_card_type() doesn't exist during upsell doantions that are charged immediatel on some gateways. Updates affected gateways to match what the functioning gateways do: include commerce_payment.credit_card.inc prior to calling the validate function.