### PR TITLE
7.x 4.x 1710 designation clone overrides

### DIFF
--- a/fundraiser/modules/fundraiser_designations/components/designations.inc
+++ b/fundraiser/modules/fundraiser_designations/components/designations.inc
@@ -237,36 +237,45 @@ function _fundraiser_designations_build_child_elements($id, &$element, $amounts,
     $amounts = fundraiser_designations_get_group_display_amounts($group, $node);
   }
 
-  // Determine whether the designation group overrides the form's default ask amounts, then determine
-  // the default ask option for both one-time and recurring based on either the form's settings or
+  // Determine whether the designation group overrides the form's default ask
+  // amounts, then determine the default ask option for both one-time and
+  // recurring based on either the form's settings or
   // the designation group's settings, as appropriate.
   $default_default_amount = false;
   $recurring_default_amount = false;
-  // Check the designation group for overrides
-  if(isset($group->fd_overrides['price_set']) && $group->fd_overrides['status'] == '1') {
+  // Check the designation group for overrides.
+  if (isset($group->fd_overrides['price_set']) && $group->fd_overrides['status'] == '1') {
     $price_set = unserialize($group->fd_overrides['price_set']);
-    // if there are overrides, determine the default option for one-time ask amounts.
-    foreach($price_set['default'] as $price) {
-      if($price['default_amount'] === 1) {
-        $default_default_amount = $price['amount'];
+    // If there are overrides, determine the default option for
+    // one-time ask amounts.
+    if (isset($price_set['default'])) {
+      foreach ($price_set['default'] as $price) {
+        if ($price['default_amount'] === 1) {
+          $default_default_amount = $price['amount'];
+        }
       }
     }
-    // if there are overrides, determine the default option for recurring ask amounts.
-    foreach($price_set['recurring'] as $price) {
-      //find the one that is set to default.
-      if($price['default_amount'] === 1) {
-        $recurring_default_amount = $price['amount'];
+
+    // If there are overrides, determine the default option for
+    // recurring ask amounts.
+    if (isset($price_set['recurring'])) {
+      foreach ($price_set['recurring'] as $price) {
+        // Find the one that is set to default.
+        if ($price['default_amount'] === 1) {
+          $recurring_default_amount = $price['amount'];
+        }
       }
     }
   }
-  // if there are not overrides and the parent node has default options set, use those values
-  else if(isset($node->default_amount) || isset($node->recurring_default_amount)) {
-    // parent node one-time default option.
-    if(isset($node->default_amount)){
+  // If there are not overrides and the parent node has default options set,
+  // use those values.
+  elseif (isset($node->default_amount) || isset($node->recurring_default_amount)) {
+    // Parent node one-time default option.
+    if (isset($node->default_amount)){
       $default_default_amount = intval($node->default_amount);
     }
-    // parent node recurring default option.
-    if(isset($node->recurring_default_amount)) {
+    // Parent node recurring default option.
+    if (isset($node->recurring_default_amount)) {
       $recurring_default_amount = intval($node->recurring_default_amount);
     }
   }
@@ -554,10 +563,8 @@ function fundraiser_designations_get_group_display_amounts($group, $node) {
   // Used if price override is enabled, but no overries defined. (i.e., when
   // switching to dual ask on alredy overriden forms).
   $node_form_amounts = fundraiser_designations_get_form_display_amounts($node);
-
   // Get the group override ask amounts.
   $override_price_set = unserialize($group->fd_overrides['price_set']);
-
   // Build the price set array.
   $price_sets = [];
   $donation_amounts = [];
@@ -588,7 +595,7 @@ function fundraiser_designations_get_group_display_amounts($group, $node) {
 
     }
   }
-  else {
+  elseif(isset($node_form_amounts['recurring'])) {
     // If no recurring override get the donation form default.
     $donation_amounts['recurring'] = $node_form_amounts['recurring'];
   }

--- a/fundraiser/modules/fundraiser_designations/fundraiser_designations.module
+++ b/fundraiser/modules/fundraiser_designations/fundraiser_designations.module
@@ -1362,6 +1362,9 @@ function fundraiser_designations_clone_fund_groups($node) {
       fundraiser_fund_group_draggable_save($arg, $group->fundraiser_fund_group_id, $group->data['weight']);
 
       $data = db_query("SELECT * FROM {fundraiser_fund_group_overrides} WHERE gid = :gid", array(':gid' => $group_id))->fetchAssoc();
+      if (isset($data['price_set'])) {
+        $data['price_set'] = unserialize($data['price_set']);
+      }
       if (!empty($data)) {
         $data['gid'] = $group->fundraiser_fund_group_id;
         drupal_write_record('fundraiser_fund_group_overrides', $data);

--- a/fundraiser/modules/fundraiser_designations/modules/fundraiser_fund_group/fundraiser_fund_group.admin.inc
+++ b/fundraiser/modules/fundraiser_designations/modules/fundraiser_fund_group/fundraiser_fund_group.admin.inc
@@ -239,7 +239,7 @@ function fundraiser_fund_group_edit_form_submit(&$form, &$form_state) {
     $arg = json_encode(array($nid));
     // Create new order record.
     $weight = db_query("SELECT MAX(weight) FROM {draggableviews_structure} WHERE view_name = :name and args = :arg",
-      array(':name' => 'fundraiser_fund_groups_node', ':arg' => $arg))->fetchField();
+      array(':name' => 'fundraiser_fund_group', ':arg' => $arg))->fetchField();
 
     $fundraiser_fund_group->data['weight']  = $weight + 1;
     $fundraiser_fund_group->save();

--- a/fundraiser/modules/fundraiser_designations/modules/fundraiser_fund_group/fundraiser_fund_group.module
+++ b/fundraiser/modules/fundraiser_designations/modules/fundraiser_fund_group/fundraiser_fund_group.module
@@ -278,7 +278,7 @@ function fundraiser_fund_group_drag_submit(&$form, &$form_state) {
  */
 function fundraiser_fund_group_draggable_save($arg, $fundraiser_fund_group_id, $weight) {
   $record = array(
-    'view_name' => 'fundraiser_fund_groups_node',
+    'view_name' => 'fundraiser_fund_group',
     'view_display' => 'block_1',
     'args' => $arg,
     'entity_id' => $fundraiser_fund_group_id,


### PR DESCRIPTION
Fixes:

1. Double serialization of fund group ask amounts was causing ask amounts to be lost when cloning.
2. Missing issets resulted in php notices when creating ask amount overrides on fund groups.
3. Incorrect view name was causing issues with draggable weights being ignored on the front end form.