### PR TITLE
Fix min amount formatting for amounts >= 1000

### DIFF
--- a/fundraiser/fundraiser.module
+++ b/fundraiser/fundraiser.module
@@ -735,7 +735,7 @@ function _fundraiser_donation_settings_form(&$form, &$form_state) {
     '#title' => t('Minimum donation amount'),
     '#description' => t('The minimum acceptable donation amount.'),
     '#default_value' => isset($node->minimum_donation_amount) ?
-      number_format($node->minimum_donation_amount, 2) : variable_get('fundraiser_default_minimum', 10.00),
+      number_format($node->minimum_donation_amount, 2, '.', "") : variable_get('fundraiser_default_minimum', 10.00),
   );
 
   $form['#validate'][] = '_fundraiser_form_amounts_validate';

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -867,7 +867,7 @@ function fundraiser_sustainers_form_node_form_alter(&$form, &$form_state, $form_
       '#title' => t('Minimum donation amount'),
       '#description' => t('The minimum acceptable donation amount.'),
       '#default_value' => isset($node->recurring_minimum_donation_amount) ?
-        number_format($node->recurring_minimum_donation_amount, 2) : variable_get('fundraiser_default_minimum', 10.00),
+        number_format($node->recurring_minimum_donation_amount, 2, '.', "") : variable_get('fundraiser_default_minimum', 10.00),
     );
     foreach ($form['#validate'] as $index => $callback) {
       if ($callback == '_fundraiser_form_amounts_validate') {


### PR DESCRIPTION
Don't use a comma separator when formatting retrieved minimum donation amount configurations on the node edit form.