### PR TITLE
re #686 - alter names for executive branch offices

### DIFF
--- a/springboard_advocacy/modules/sba_leg_lookup/includes/sba_leg_lookup.block.inc
+++ b/springboard_advocacy/modules/sba_leg_lookup/includes/sba_leg_lookup.block.inc
@@ -365,8 +365,8 @@ function sba_leg_lookup_legislator_roles() {
     'SS' => t('State Senator'),
     'SR' => t('State Representative'),
     'GOVNR' => t('Governor'),
-    'PRES01' => t('President'),
-    'PRES03' => t('Vice President'),
+    'PRES01' => t('Executive Office of the President'),
+    'PRES03' => t('Office of the Vice President'),
   );
 }
 


### PR DESCRIPTION
This PR changes the President and Vice President values of the US to "Executive Office of the President" and "Office of the Vice President."