### PR TITLE
make springboard dashboard permissions finer-grained

### DIFF
--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -377,7 +377,7 @@ function springboard_admin_menu() {
   $items['admin/springboard/marketing-analytics'] = array(
     'title' => 'Marketing & Analytics',
     'type' => MENU_NORMAL_ITEM,
-    'access arguments' => array('access springboard dashboard'),
+    'access callback' => 'springboard_admin_access_marketing_overview',
     'page callback' => 'springboard_admin_aggregate_links_page',
     'page arguments' => array('admin/springboard/marketing-analytics'),
    );
@@ -391,7 +391,7 @@ function springboard_admin_menu() {
    $items['admin/springboard/reports/integration-reports'] = array(
     'title' => 'Integration Reports',
     'type' => MENU_NORMAL_ITEM,
-    'access arguments' => array('access springboard dashboard'),
+    'access callback' => 'springboard_admin_access_integration_overview',
     'page callback' => 'springboard_admin_aggregate_links_page',
     'page arguments' => array('admin/springboard/reports/integration-reports', array('admin/springboard/reports')),
    );
@@ -445,6 +445,31 @@ function springboard_admin_menu_title_callback($original_title, $new_title) {
 
   return $original_title;
 }
+
+function springboard_admin_access_marketing_overview() {
+  if (user_access('bypass node access')
+    || user_access('administer market source')
+    || user_access('administer webform_ab')
+    || user_access('manage webform goals')
+    || user_access('administer springboard social')
+    || user_access('administer springboard')
+    || user_access('administer springboard tags')
+  ) {
+    return TRUE;
+  }
+  return FALSE;
+}
+
+function springboard_admin_access_integration_overview() {
+  if (user_access('bypass node access')
+    || user_access('administer springboard')
+    || user_access('view salesforce batch logs')
+  ) {
+    return TRUE;
+  }
+  return FALSE;
+}
+
 
 /**
  * Page callback used to redirect from /admin to /springboard when the
@@ -777,16 +802,19 @@ function springboard_admin_aggregate_links_page($path, $parents = array()) {
   $links = array();
   if (isset($item['_children'])) {
     foreach ($item['_children'] as $child) {
-      $options = array();
-      if (isset($child['external'])) {
-        $options['external'] = $child['external'];
+      $item = menu_get_item($child['link_path']);
+      if ($item['access']) {
+        $options = array();
+        if (isset($child['external'])) {
+          $options['external'] = $child['external'];
+        }
+        $links[] = array(
+          'title' => $child['link_title'],
+          'href' => $child['link_path'],
+          'options' => $options,
+          'weight' => $child['weight'],
+        );
       }
-      $links[] = array(
-        'title' => $child['link_title'],
-        'href' => $child['link_path'],
-        'options' => $options,
-        'weight' => $child['weight'],
-      );
     }
   }
   if (!empty($links)) {

--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -446,6 +446,14 @@ function springboard_admin_menu_title_callback($original_title, $new_title) {
   return $original_title;
 }
 
+/**
+ * Check user if a user should have access to the marketing menu item.
+ *
+ * This could be replaced by a named permission rather than relying
+ * on subsets of other named permissions.
+ *
+ * @return bool
+ */
 function springboard_admin_access_marketing_overview() {
   if (user_access('bypass node access')
     || user_access('administer market source')
@@ -460,6 +468,14 @@ function springboard_admin_access_marketing_overview() {
   return FALSE;
 }
 
+/**
+ * Check if a user should have access to the reports menu item.
+ *
+ * This could be replaced by a named permission rather than relying
+ * on subsets of other named permissions.
+ *
+ * @return bool
+ */
 function springboard_admin_access_integration_overview() {
   if (user_access('bypass node access')
     || user_access('administer springboard')
@@ -802,8 +818,8 @@ function springboard_admin_aggregate_links_page($path, $parents = array()) {
   $links = array();
   if (isset($item['_children'])) {
     foreach ($item['_children'] as $child) {
-      $item = menu_get_item($child['link_path']);
-      if ($item['access']) {
+      $child_item = menu_get_item($child['link_path']);
+      if ($child_item['access']) {
         $options = array();
         if (isset($child['external'])) {
           $options['external'] = $child['external'];

--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -455,13 +455,15 @@ function springboard_admin_menu_title_callback($original_title, $new_title) {
  * @return bool
  */
 function springboard_admin_access_marketing_overview() {
-  if (user_access('bypass node access')
-    || user_access('administer market source')
+  if (
+    user_access('administer market source')
     || user_access('administer webform_ab')
     || user_access('manage webform goals')
     || user_access('administer springboard social')
-    || user_access('administer springboard')
     || user_access('administer springboard tags')
+    || user_access('administer springboard')
+    || user_access('administer springboard dashboard')
+    || user_access('bypass node access')
   ) {
     return TRUE;
   }
@@ -479,6 +481,7 @@ function springboard_admin_access_marketing_overview() {
 function springboard_admin_access_integration_overview() {
   if (user_access('bypass node access')
     || user_access('administer springboard')
+    || user_access('administer springboard dashboard')
     || user_access('view salesforce batch logs')
   ) {
     return TRUE;

--- a/springboard/modules/springboard_admin/templates/springboard-admin-asset-page.tpl.php
+++ b/springboard/modules/springboard_admin/templates/springboard-admin-asset-page.tpl.php
@@ -25,8 +25,9 @@
           <li><a href="<?php print base_path(); ?>admin/springboard/forms/all"><?php print t('Forms'); ?></a></li>
         </ul>
       </div><!--// btn-group -->
+    <?php if (user_access('create ' . $type->type . ' content')) : ?>
       <a href="<?php print base_path(); ?>node/add/<?php print preg_replace('/_/', '-', $type->type); ?>" class="button add-button"><?php print t('Create'); ?> <?php print $type->name; ?></a>
-
+    <?php endif; ?>
     </div><!-- // buttons-wrapper -->
 
     <?php print($tables[$type->type]); ?>

--- a/springboard/modules/springboard_admin/templates/springboard-admin-forms-page.tpl.php
+++ b/springboard/modules/springboard_admin/templates/springboard-admin-forms-page.tpl.php
@@ -16,6 +16,7 @@
     <div class="buttons-wrapper">
 
       <!-- bootstrap drop list widget -->
+      <?php if (user_access('create email_wrapper content') || user_access('create page_wrapper content')) : ?>
       <div class="btn-group">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
           <?php print t('Options'); ?>
@@ -27,9 +28,11 @@
           <li><a href="<?php print base_path(); ?>admin/springboard/asset-library"><?php print t('Templates & Wrappers'); ?></a></li>
         </ul>
       </div><!--// btn-group -->
+      <?php endif; ?>
 
-      <a href="<?php print base_path(); ?>node/add/<?php print preg_replace('/_/', '-', $type->type); ?>" class="button add-button"><?php print t('Create'); ?> <?php print $type->name; ?></a>
-
+      <?php if (user_access('create ' . $type->type . ' content')) : ?>
+        <a href="<?php print base_path(); ?>node/add/<?php print preg_replace('/_/', '-', $type->type); ?>" class="button add-button"><?php print t('Create'); ?> <?php print $type->name; ?></a>
+      <?php endif; ?>
     </div><!-- // buttons-wrapper -->
 
     <?php print($tables[$type->type]); ?>

--- a/springboard/modules/springboard_views/springboard_views.module
+++ b/springboard/modules/springboard_views/springboard_views.module
@@ -37,8 +37,9 @@ function springboard_views_views_pre_render(&$view) {
  *
  * The sbv_forms view result has to be filtered by user_access to
  * each content type in the result, removing rows to which the user does not
- * have edit or create access. Removing is easy, but that makes the
- * pager count wrong, requiring the following to correct it.
+ * have edit or create access for the *content type* (not the node) displayed.
+ * Removing is easy, but that makes the pager count wrong, requiring the
+ * following to correct it.
  *
  * @param object $view
  *   The sbv_forms view.

--- a/springboard/modules/springboard_views/springboard_views.module
+++ b/springboard/modules/springboard_views/springboard_views.module
@@ -455,10 +455,14 @@ function springboard_views_springboard_dashboard_panes() {
   drupal_alter('springboard_views_springboard_dashboard_panes', $webform_types);
 
   $donation_pane_access = FALSE;
-  foreach ($fundraiser_types as $type) {
-    if (user_access('create ' . $type . ' content') || user_access('edit any ' . $type . ' content')) {
-      $donation_pane_access = TRUE;
-    }
+  if (user_access("administer springboard")
+    || user_access('administer springboard dashboard')
+    || user_access('administer fundraiser')
+    || user_access('bypass node access')
+    || user_access('edit any donation form')
+    || user_access('create donation form')
+  ) {
+    $donation_pane_access = TRUE;
   }
 
   if ($donation_pane_access) {
@@ -487,6 +491,14 @@ function springboard_views_springboard_dashboard_panes() {
     if (user_access('create ' . $type . ' content') || user_access('edit any ' . $type . ' content')) {
       $webform_pane_access = TRUE;
     }
+  }
+
+  if (user_access("administer springboard")
+    || user_access('administer springboard dashboard')
+    || user_access('bypass node access')
+    || user_access('administer nodes')
+  ) {
+    $webform_pane_access = TRUE;
   }
 
   if ($webform_pane_access) {

--- a/springboard/modules/springboard_views/springboard_views.module
+++ b/springboard/modules/springboard_views/springboard_views.module
@@ -19,15 +19,66 @@ function springboard_views_views_pre_render(&$view) {
     'sbv_retry_queue' => 'Retry',
     'sbv_permanent_failure' => 'Failed',
   );
-  if (!array_key_exists($view->name, $sbv_views)) {
-    return;
+  if (array_key_exists($view->name, $sbv_views)) {
+    $view->attachment_before .= t('!status Items: !count items',
+      array(
+        '!status' => $sbv_views[$view->name],
+        '!count' => $view->total_rows,
+      ));
   }
-  $view->attachment_before .= t('!status Items: !count items',
-    array('!status' => $sbv_views[$view->name], '!count' => $view->total_rows));
+
+  if ($view->name == 'sbv_forms') {
+    springboard_views_filter_sbv_forms($view);
+  }
+}
+
+/**
+ * Apply access filters to the sbv_forms view result.
+ *
+ * The sbv_forms view result has to be filtered by user_access to
+ * each content type in the result, removing rows to which the user does not
+ * have edit or create access. Removing is easy, but that makes the
+ * pager count wrong, requiring the following to correct it.
+ *
+ * @param object $view
+ *   The sbv_forms view.
+ */
+function springboard_views_filter_sbv_forms(&$view) {
+  // Re-execute the view without a page limit to get a full count of
+  // user_access filtered results.
+  $counting_view = views_get_view($view->name);
+  $counting_view->set_display($view->current_display);
+  $counting_view->set_items_per_page('');
+  $counting_view->set_arguments($view->args);
+  $counting_view->execute();
+
+  // Iterate through the un-paged result and filter by access.
+  foreach ($counting_view->result as $index => $count_result) {
+    if (!empty($count_result->node_type)) {
+      if (!user_access('edit any ' . $count_result->node_type . ' content') && !user_access('create ' . $count_result->node_type . ' content')) {
+        unset($counting_view->result[$index]);
+      }
+    }
+  }
+
+  // Remove the user_access filtered results, this time
+  // from the original pre-rendered view.
+  foreach ($view->result as $index => $result) {
+    if (!empty($result->node_type)) {
+      if (!user_access('edit any ' . $result->node_type . ' content') && !user_access('create ' . $result->node_type . ' content')) {
+        unset($view->result[$index]);
+      }
+    }
+  }
+
+  // Reset the pager to match the filtered results.
+  $view->query->pager->total_items = count($counting_view->result);
+  $view->query->pager->update_page_info();
 }
 
 /**
  * Implements hook_date_api_tables().
+ *
  * Tell Date which tables to look for date fields in.
  */
 function springboard_views_date_api_tables() {
@@ -402,26 +453,60 @@ function springboard_views_springboard_dashboard_panes() {
 
   drupal_alter('springboard_views_springboard_dashboard_panes', $webform_types);
 
-  $panes['springboard_recent_donation_forms'] = array(
-   'label' => t('Recent donation forms'),
-   'description' => t('Configuration and submissions summary for recently created or updated springboard donation forms.'),
-   'content' => '<h2>' . t('Recent donation forms ') .  '</h2>' .
-     (module_exists('webform') && user_access('create donation_form content') ? l(t('Create donation form'), $base_url . '/node/add/donation-form', array('attributes' => array('class' => array('button', 'add-button')))) : '' ) .
-     (module_exists('views') ? views_embed_view('sbv_forms', 'block_4', implode('+', $fundraiser_types)) : t('Please enable the Views module to improve your Springboard experience.')) .
-     l(t('View All Donation Forms'), 'admin/springboard/donation-forms/all', array('attributes' => array('class' => array('more-link button more-button')))),
-   'position' => 'column_left',
-   'weight' => 0,
-  );
-  $panes['springboard_recent_forms'] = array(
-    'label' => t('Recent forms'),
-    'description' => t('Configuration and submissions summary for recently created or updated springboard forms.'),
-    'content' => '<h2>' . t('Recent forms ') .   '</h2>' .
-      (module_exists('fundraiser') && user_access('create webform content') ? l(t('Create form'), $base_url . '/node/add/webform', array('attributes' => array('class' => array('button', 'add-button')))) : '')  .
-      (module_exists('views') ? views_embed_view('sbv_forms', 'block_3', implode('+', $webform_types)) : t('Please enable the Views module to improve your Springboard experience.')) .
-      l(t('View All Forms'), 'admin/springboard/forms/all', array('attributes' => array('class' => array('more-link button more-button')))),
-    'position' => 'column_left',
-    'weight' => 2,
-  );
+  $donation_pane_access = FALSE;
+  foreach ($fundraiser_types as $type) {
+    if (user_access('create ' . $type . ' content') || user_access('edit any ' . $type . ' content')) {
+      $donation_pane_access = TRUE;
+    }
+  }
+
+  if ($donation_pane_access) {
+    $panes['springboard_recent_donation_forms'] = array(
+      'label' => t('Recent donation forms'),
+      'description' => t('Configuration and submissions summary for recently created or updated springboard donation forms.'),
+      'content' => '<h2>' . t('Recent donation forms') . '</h2>' .
+        (module_exists('webform') && user_access('create donation_form content') ? l(t('Create donation form'), $base_url . '/node/add/donation-form', array(
+          'attributes' => array(
+            'class' => array(
+              'button',
+              'add-button',
+            ),
+          ),
+        )) : '') .
+        (module_exists('views') ? views_embed_view('sbv_forms', 'block_4', implode('+', $fundraiser_types)) : t('Please enable the Views module to improve your Springboard experience.')) .
+        l(t('View All Donation Forms'), 'admin/springboard/donation-forms/all', array('attributes' => array('class' => array('more-link button more-button')))),
+      'position' => 'column_left',
+      'weight' => 0,
+    );
+  }
+
+
+  $webform_pane_access = FALSE;
+  foreach ($webform_types as $type) {
+    if (user_access('create ' . $type . ' content') || user_access('edit any ' . $type . ' content')) {
+      $webform_pane_access = TRUE;
+    }
+  }
+
+  if ($webform_pane_access) {
+    $panes['springboard_recent_forms'] = array(
+      'label' => t('Recent forms'),
+      'description' => t('Configuration and submissions summary for recently created or updated springboard forms.'),
+      'content' => '<h2>' . t('Recent forms') . '</h2>' .
+        (module_exists('fundraiser') && user_access('create webform content') ? l(t('Create form'), $base_url . '/node/add/webform', array(
+          'attributes' => array(
+            'class' => array(
+              'button',
+              'add-button',
+            ),
+          ),
+        )) : '') .
+        (module_exists('views') ? views_embed_view('sbv_forms', 'block_3', implode('+', $webform_types)) : t('Please enable the Views module to improve your Springboard experience.')) .
+        l(t('View All Forms'), 'admin/springboard/forms/all', array('attributes' => array('class' => array('more-link button more-button')))),
+      'position' => 'column_left',
+      'weight' => 2,
+    );
+  }
   return $panes;
 }
 

--- a/springboard/modules/springboard_views/springboard_views.module
+++ b/springboard/modules/springboard_views/springboard_views.module
@@ -406,7 +406,7 @@ function springboard_views_springboard_dashboard_panes() {
    'label' => t('Recent donation forms'),
    'description' => t('Configuration and submissions summary for recently created or updated springboard donation forms.'),
    'content' => '<h2>' . t('Recent donation forms ') .  '</h2>' .
-     (module_exists('webform') ? l(t('Create donation form'), $base_url . '/node/add/donation-form', array('attributes' => array('class' => array('button', 'add-button')))) : '' ) .
+     (module_exists('webform') && user_access('create donation_form content') ? l(t('Create donation form'), $base_url . '/node/add/donation-form', array('attributes' => array('class' => array('button', 'add-button')))) : '' ) .
      (module_exists('views') ? views_embed_view('sbv_forms', 'block_4', implode('+', $fundraiser_types)) : t('Please enable the Views module to improve your Springboard experience.')) .
      l(t('View All Donation Forms'), 'admin/springboard/donation-forms/all', array('attributes' => array('class' => array('more-link button more-button')))),
    'position' => 'column_left',
@@ -416,7 +416,7 @@ function springboard_views_springboard_dashboard_panes() {
     'label' => t('Recent forms'),
     'description' => t('Configuration and submissions summary for recently created or updated springboard forms.'),
     'content' => '<h2>' . t('Recent forms ') .   '</h2>' .
-      (module_exists('fundraiser') ? l(t('Create form'), $base_url . '/node/add/webform', array('attributes' => array('class' => array('button', 'add-button')))) : '')  .
+      (module_exists('fundraiser') && user_access('create webform content') ? l(t('Create form'), $base_url . '/node/add/webform', array('attributes' => array('class' => array('button', 'add-button')))) : '')  .
       (module_exists('views') ? views_embed_view('sbv_forms', 'block_3', implode('+', $webform_types)) : t('Please enable the Views module to improve your Springboard experience.')) .
       l(t('View All Forms'), 'admin/springboard/forms/all', array('attributes' => array('class' => array('more-link button more-button')))),
     'position' => 'column_left',

--- a/springboard/modules/springboard_views/springboard_views.views_default.inc
+++ b/springboard/modules/springboard_views/springboard_views.views_default.inc
@@ -413,6 +413,11 @@ function springboard_views_views_default_views() {
   $handler->display->display_options['fields']['view_node']['element_class'] = 'table-actions';
   $handler->display->display_options['fields']['view_node']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['view_node']['text'] = 'view';
+  /* Field: Content: Type */
+  $handler->display->display_options['fields']['type']['id'] = 'type';
+  $handler->display->display_options['fields']['type']['table'] = 'node';
+  $handler->display->display_options['fields']['type']['field'] = 'type';
+  $handler->display->display_options['fields']['type']['exclude'] = TRUE;
   $handler->display->display_options['defaults']['arguments'] = FALSE;
   /* Contextual filter: Content: Type */
   $handler->display->display_options['arguments']['type']['id'] = 'type';
@@ -844,6 +849,11 @@ function springboard_views_views_default_views() {
   $handler->display->display_options['fields']['view_node']['element_class'] = 'table-actions';
   $handler->display->display_options['fields']['view_node']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['view_node']['text'] = 'view';
+  /* Field: Content: Type */
+  $handler->display->display_options['fields']['type']['id'] = 'type';
+  $handler->display->display_options['fields']['type']['table'] = 'node';
+  $handler->display->display_options['fields']['type']['field'] = 'type';
+  $handler->display->display_options['fields']['type']['exclude'] = TRUE;
   $handler->display->display_options['defaults']['arguments'] = FALSE;
   /* Contextual filter: Content: Type */
   $handler->display->display_options['arguments']['type']['id'] = 'type';
@@ -1015,6 +1025,11 @@ function springboard_views_views_default_views() {
   $handler->display->display_options['fields']['view_node']['element_class'] = 'table-actions';
   $handler->display->display_options['fields']['view_node']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['view_node']['text'] = 'view';
+  /* Field: Content: Type */
+  $handler->display->display_options['fields']['type']['id'] = 'type';
+  $handler->display->display_options['fields']['type']['table'] = 'node';
+  $handler->display->display_options['fields']['type']['field'] = 'type';
+  $handler->display->display_options['fields']['type']['exclude'] = TRUE;
   $handler->display->display_options['defaults']['arguments'] = FALSE;
   /* Contextual filter: Content: Type */
   $handler->display->display_options['arguments']['type']['id'] = 'type';
@@ -1071,6 +1086,10 @@ function springboard_views_views_default_views() {
   $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
     'node_revision.timestamp' => 'node_revision.timestamp',
   );
+  /* Filter criterion: Content access: Access */
+  $handler->display->display_options['filters']['nid']['id'] = 'nid';
+  $handler->display->display_options['filters']['nid']['table'] = 'node_access';
+  $handler->display->display_options['filters']['nid']['field'] = 'nid';
   $handler->display->display_options['path'] = 'admin/springboard/donation-forms/%';
 
   /* Display: Springboard Recent Forms by Type */
@@ -1174,14 +1193,6 @@ function springboard_views_views_default_views() {
   $handler->display->display_options['defaults']['row_plugin'] = FALSE;
   $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['defaults']['fields'] = FALSE;
-  /* No results behavior: Global: Text area */
-  $handler->display->display_options['empty']['area']['id'] = 'area';
-  $handler->display->display_options['empty']['area']['table'] = 'views';
-  $handler->display->display_options['empty']['area']['field'] = 'area';
-  $handler->display->display_options['empty']['area']['empty'] = TRUE;
-  $handler->display->display_options['empty']['area']['content'] = 'Your search returned 0 results, please try again.';
-  $handler->display->display_options['empty']['area']['format'] = 'filtered_html';
-  $handler->display->display_options['defaults']['fields'] = FALSE;
   /* Field: Content: Internal Name */
   $handler->display->display_options['fields']['field_fundraiser_internal_name']['id'] = 'field_fundraiser_internal_name';
   $handler->display->display_options['fields']['field_fundraiser_internal_name']['table'] = 'field_data_field_fundraiser_internal_name';
@@ -1252,6 +1263,11 @@ function springboard_views_views_default_views() {
   $handler->display->display_options['fields']['field_webform_user_internal_name']['field'] = 'field_webform_user_internal_name';
   $handler->display->display_options['fields']['field_webform_user_internal_name']['label'] = '';
   $handler->display->display_options['fields']['field_webform_user_internal_name']['element_label_colon'] = FALSE;
+  /* Field: Content: Type */
+  $handler->display->display_options['fields']['type']['id'] = 'type';
+  $handler->display->display_options['fields']['type']['table'] = 'node';
+  $handler->display->display_options['fields']['type']['field'] = 'type';
+  $handler->display->display_options['fields']['type']['exclude'] = TRUE;
   $handler->display->display_options['defaults']['arguments'] = FALSE;
   /* Contextual filter: Content: Type */
   $handler->display->display_options['arguments']['type']['id'] = 'type';


### PR DESCRIPTION
Springboard assumes if you have the “access dashboard” permission, you should be able to view all form types. That sounds reasonable, but it also does not check if you have the ability to create form types, and displays the create buttons for each type to everyone. This patch wraps the create buttons in an access check.

The marketing and analytics tab is also controlled by the “access dashboard” permission. The links on the marketing and analytics page are also included without any subsequent permissions check

So, in this case, the menu item for the marketing page needs to use a permission callback instead of checking dashboard perms. The permission callback needs to parse all of the user’s current permissions to see if he can access any one of the multiple marketing and analytics sub-pages.

And then, if the user has access to some or all marketing and analytics functions, the iterator that produces the links on the page must check each link for access.

The "reports" section uses the same page callback as the marketing section, and is also patched by this.