### PR TITLE
1069 Adds salesforce_merge_handler

### DIFF
--- a/salesforce/salesforce_genmap/includes/modules/salesforce_mapping.inc
+++ b/salesforce/salesforce_genmap/includes/modules/salesforce_mapping.inc
@@ -475,6 +475,10 @@ function salesforce_genmap_entity_delete($entity, $entity_type) {
  *   queued, or if the item was not supposed to be queued.
  */
 function salesforce_mapping_send_entity_to_queue($entity, $entity_type, $op) {
+  dpm('salesforce_mapping_send_entity_to_queue');
+  dpm($entity);
+  dpm($entity_type);
+  dpm($op);
   $sfapi = salesforce_get_api();
   if (!$sfapi->isAuthorized()) {
     // If there isn't a valid connection to Salesforce, lets not start queueing

--- a/salesforce/salesforce_genmap/includes/modules/salesforce_mapping.inc
+++ b/salesforce/salesforce_genmap/includes/modules/salesforce_mapping.inc
@@ -475,10 +475,6 @@ function salesforce_genmap_entity_delete($entity, $entity_type) {
  *   queued, or if the item was not supposed to be queued.
  */
 function salesforce_mapping_send_entity_to_queue($entity, $entity_type, $op) {
-  dpm('salesforce_mapping_send_entity_to_queue');
-  dpm($entity);
-  dpm($entity_type);
-  dpm($op);
   $sfapi = salesforce_get_api();
   if (!$sfapi->isAuthorized()) {
     // If there isn't a valid connection to Salesforce, lets not start queueing

--- a/salesforce/salesforce_merge_handler/salesforce_merge_handler.info
+++ b/salesforce/salesforce_merge_handler/salesforce_merge_handler.info
@@ -1,0 +1,6 @@
+name = Salesforce Merge Handler
+description = Handle sync failures that result from merged SF records.
+package = Salesforce
+core = 7.x
+
+dependencies[] = salesforce_queue

--- a/salesforce/salesforce_merge_handler/salesforce_merge_handler.module
+++ b/salesforce/salesforce_merge_handler/salesforce_merge_handler.module
@@ -4,8 +4,8 @@
  * Implements hook_salesforce_sync_fail_item().
  *
  * Examines statusCode returned from failed sync items for ENTITY_IS_DELETED.
- * When found, the corresponding record from salesforce_sync_map is deleted and
- * the queue item is refreshed.
+ * When found, the corresponding Contact and Account records from
+ * salesforce_sync_map are deleted and the queue item is refreshed.
  *
  * When the queue item is synced, it should match on the email field and a new
  * salesforce_sync_map record created that referenced the new SF record.
@@ -15,12 +15,12 @@ function salesforce_merge_handler_salesforce_sync_fail_item($item, $message, $re
     if (isset($result->errors)) {
       foreach ($result->errors as $error) {
         if ($error->statusCode == 'ENTITY_IS_DELETED') {
-          $rmid = db_query('SELECT rmid FROM salesforce_sync_map WHERE drupal_id=:drupal_id AND module=:module AND delta=:delta AND object_type=:object_type LIMIT 1', array(':drupal_id' => $item->drupal_id, ':module' => $item->module, ':delta' => $item->delta, ':object_type' => $item->object_type))->fetchField();
-          if (!empty($rmid)) {
-            entity_delete('salesforce_sync_map', $rmid);
-            // In order for the queue item to refresh properly, we need to change
-            // the operation from UPDATE to UPSERT, and delete the old/invalid
-            // SF Id from the queued item.
+          $rmids = db_query("SELECT rmid FROM salesforce_sync_map WHERE drupal_id=:drupal_id AND module=:module AND delta=:delta AND object_type IN ('Contact', 'Account') LIMIT 2", array(':drupal_id' => $item->drupal_id, ':module' => $item->module, ':delta' => $item->delta))->fetchCol();
+          if (!empty($rmids)) {
+            entity_delete_multiple('salesforce_sync_map', $rmids);
+            // In order for the queue item to refresh properly, we need to
+            // change the operation from UPDATE to UPSERT, and delete the
+            // old/invalid SF Id from the queued item.
             $item->operation = 'UPSERT';
             unset($item->sobject->Id);
             salesforce_queue_salesforce_queue_item_refresh_item_action($item);

--- a/salesforce/salesforce_merge_handler/salesforce_merge_handler.module
+++ b/salesforce/salesforce_merge_handler/salesforce_merge_handler.module
@@ -19,9 +19,9 @@ function salesforce_merge_handler_salesforce_sync_fail_item($item, $message, $re
           if (!empty($rmids)) {
             entity_delete_multiple('salesforce_sync_map', $rmids);
             // In order for the queue item to refresh properly, we need to
-            // change the operation from UPDATE to UPSERT, and delete the
+            // change the operation from UPDATE to CREATE, and delete the
             // old/invalid SF Id from the queued item.
-            $item->operation = 'UPSERT';
+            $item->operation = 'CREATE';
             unset($item->sobject->Id);
             salesforce_queue_salesforce_queue_item_refresh_item_action($item);
             watchdog('salesforce_merge_handler', 'ENTITY_IS_DELETED error detected on Salesforce queue item #:item_id. The relationship to the deleted SF record has been broken and the queue item refreshed. It should sync in the next run.', array(':item_id' => $item->item_id), WATCHDOG_NOTICE, l('View the queued item', 'springboard/reports/integration-reports/queue', array('query' => array('item_id' => $item->item_id))));

--- a/salesforce/salesforce_merge_handler/salesforce_merge_handler.module
+++ b/salesforce/salesforce_merge_handler/salesforce_merge_handler.module
@@ -11,19 +11,21 @@
  * salesforce_sync_map record created that referenced the new SF record.
  */
 function salesforce_merge_handler_salesforce_sync_fail_item($item, $message, $result) {
-  if (isset($result->errors)) {
-    foreach ($result->errors as $error) {
-      if ($error->statusCode == 'ENTITY_IS_DELETED') {
-        $rmid = db_query('SELECT rmid FROM salesforce_sync_map WHERE drupal_id=:drupal_id AND module=:module AND delta=:delta AND object_type=:object_type LIMIT 1', array(':drupal_id' => $item->drupal_id, ':module' => $item->module, ':delta' => $item->delta, ':object_type' => $item->object_type))->fetchField();
-        if (!empty($rmid)) {
-          entity_delete('salesforce_sync_map', $rmid);
-          // In order for the queue item to refresh properly, we need to change
-          // the operation from UPDATE to UPSERT, and delete the old/invalid
-          // SF Id from the queued item.
-          $item->operation = 'UPSERT';
-          unset($item->sobject->Id);
-          salesforce_queue_salesforce_queue_item_refresh_item_action($item);
-          watchdog('salesforce_merge_handler', 'ENTITY_IS_DELETED error detected on Salesforce queue item #:item_id. The relationship to the deleted SF record has been broken and the queue item refreshed. It should sync in the next run.', array(':item_id' => $item->item_id), WATCHDOG_NOTICE, l('View the queued item', 'springboard/reports/integration-reports/queue', array('query' => array('item_id' => $item->item_id))));
+  if ($item->object_type == 'Contact') {
+    if (isset($result->errors)) {
+      foreach ($result->errors as $error) {
+        if ($error->statusCode == 'ENTITY_IS_DELETED') {
+          $rmid = db_query('SELECT rmid FROM salesforce_sync_map WHERE drupal_id=:drupal_id AND module=:module AND delta=:delta AND object_type=:object_type LIMIT 1', array(':drupal_id' => $item->drupal_id, ':module' => $item->module, ':delta' => $item->delta, ':object_type' => $item->object_type))->fetchField();
+          if (!empty($rmid)) {
+            entity_delete('salesforce_sync_map', $rmid);
+            // In order for the queue item to refresh properly, we need to change
+            // the operation from UPDATE to UPSERT, and delete the old/invalid
+            // SF Id from the queued item.
+            $item->operation = 'UPSERT';
+            unset($item->sobject->Id);
+            salesforce_queue_salesforce_queue_item_refresh_item_action($item);
+            watchdog('salesforce_merge_handler', 'ENTITY_IS_DELETED error detected on Salesforce queue item #:item_id. The relationship to the deleted SF record has been broken and the queue item refreshed. It should sync in the next run.', array(':item_id' => $item->item_id), WATCHDOG_NOTICE, l('View the queued item', 'springboard/reports/integration-reports/queue', array('query' => array('item_id' => $item->item_id))));
+          }
         }
       }
     }

--- a/salesforce/salesforce_merge_handler/salesforce_merge_handler.module
+++ b/salesforce/salesforce_merge_handler/salesforce_merge_handler.module
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Implements hook_salesforce_sync_fail_item().
+ *
+ * Examines statusCode returned from failed sync items for ENTITY_IS_DELETED.
+ * When found, the corresponding record from salesforce_sync_map is deleted and
+ * the queue item is refreshed.
+ *
+ * When the queue item is synced, it should match on the email field and a new
+ * salesforce_sync_map record created that referenced the new SF record.
+ */
+function salesforce_merge_handler_salesforce_sync_fail_item($item, $message, $result) {
+  if (isset($result->errors)) {
+    foreach ($result->errors as $error) {
+      if ($error->statusCode == 'ENTITY_IS_DELETED') {
+        $rmid = db_query('SELECT rmid FROM salesforce_sync_map WHERE drupal_id=:drupal_id AND module=:module AND delta=:delta AND object_type=:object_type LIMIT 1', array(':drupal_id' => $item->drupal_id, ':module' => $item->module, ':delta' => $item->delta, ':object_type' => $item->object_type))->fetchField();
+        if (!empty($rmid)) {
+          entity_delete('salesforce_sync_map', $rmid);
+          // In order for the queue item to refresh properly, we need to change
+          // the operation from UPDATE to UPSERT, and delete the old/invalid
+          // SF Id from the queued item.
+          $item->operation = 'UPSERT';
+          unset($item->sobject->Id);
+          salesforce_queue_salesforce_queue_item_refresh_item_action($item);
+          watchdog('salesforce_merge_handler', 'ENTITY_IS_DELETED error detected on Salesforce queue item #:item_id. The relationship to the deleted SF record has been broken and the queue item refreshed. It should sync in the next run.', array(':item_id' => $item->item_id), WATCHDOG_NOTICE, l('View the queued item', 'springboard/reports/integration-reports/queue', array('query' => array('item_id' => $item->item_id))));
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
When Contacts are merged in SF, one of them gets deleted, and we may end up with a Drupal user associated to a Contact that no longer exists. The next time the Drupal user is synced, SF returns a ENTITY_IS_DELETED error. 

This module looks for those errors and, when found, deletes the salesforce_sync_map record associated with it, and refreshes the sync item (as an UPSERT instead of UPDATE). The next time the salesforce sync process runs, the email should match the "other" Contact and we end up with a Drupal User associated with the right Contact.