### PR TITLE
Use correct plugin js for twitter for AddThis.

### DIFF
--- a/springboard_social/plugins/social_networks/twitter/twitter.inc
+++ b/springboard_social/plugins/social_networks/twitter/twitter.inc
@@ -22,7 +22,7 @@ $plugin = array(
 
 $use_addthis = variable_get('springboard_social_use_addthis', FALSE);
 if ($use_addthis) {
-  $plugin['js'] = 'plugins/social_networks/email/email.share.js';
+  $plugin['js'] = 'plugins/social_networks/twitter/twitter.share.js';
 }
 else {
   $plugin['js'] = FALSE;


### PR DESCRIPTION
This updates the twitter plugin to load the correct plugin js file, instead of loading the email plugin's js. Looks like maybe a copy/paste error. Currently the share text message for twitter shares is incorrect if springboard social is using AddThis as a result.