### PR TITLE
7.x 4.x 1529 fundriaser recurring status

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
@@ -1137,12 +1137,7 @@ function fundraiser_sustainers_update_7019(&$sandbox) {
     $sandbox['current_did'] = 0;
   }
 
-  $statuses = array(
-    'Expired' => array('payment_received', 'offline_check'),
-    'Canceled' => array('canceled', 'omitted'),
-    'Auto-canceled' => array('auto_canceled'),
-    'Failed' => array('failed', 'unknown'),
-  );
+  $statuses = fundraiser_sustainers_series_entity_statuses();
 
   // Grab every series.
   $series = db_query('
@@ -1168,15 +1163,35 @@ function fundraiser_sustainers_update_7019(&$sandbox) {
         array(':master_did' => $donation->did)
       )->fetchObject();
 
-      $order_status = isset($last_donation->status) ? $last_donation->status : 'unknown';
-      foreach ($statuses as $key => $status_arr) {
-        if (in_array($order_status, $status_arr)) {
-          $status = $key;
+      // Check if the series hasn't been created yet.
+      $update = TRUE;
+      if (variable_get('fundraiser_sustainers_create_series_cron', FALSE)) {
+        $full_donation = fundraiser_donation_get_donation($donation->did);
+        // If the series creation is pending don't update.
+        if (
+          !empty($full_donation->data['fundraiser_sustainers_series_status'])
+          && $full_donation->data['fundraiser_sustainers_series_status'] == FUNDRAISER_SUSTAINERS_SERIES_STATUS_PENDING
+        ) {
+          $update = FALSE;
         }
       }
-      $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $donation->did);
-      $fundraiser_sustainers_series->status = $status;
-      $fundraiser_sustainers_series->save();
+
+      if ($update) {
+        // Match the donation status to the array of the series entity statuses.
+        $order_status = isset($last_donation->status) ? $last_donation->status : 'unknown';
+        foreach ($statuses as $key => $status_arr) {
+          if (in_array($order_status, $status_arr)) {
+            $status = $key;
+          }
+        }
+
+        if (!empty($status)) {
+          db_update('fundraiser_sustainers_series')
+            ->fields(array('status' => $status))
+            ->condition('did', $donation->did)
+            ->execute();
+        }
+      }
     }
     $sandbox['progress']++;
     $sandbox['current_did'] = $donation->did;
@@ -1185,6 +1200,12 @@ function fundraiser_sustainers_update_7019(&$sandbox) {
   $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
 
   if ($sandbox['#finished'] >= 1) {
-    return t('Expired fundraiser sustainers series have been updated with the status of their last donation.');
+    // Set all remaining series to active.
+    db_update('fundraiser_sustainers_series')
+      ->fields(array('status' => 'active'))
+      ->isNull('status')
+      ->execute();
+
+    return t('Fundraiser sustainers series status columns have been updated.');
   }
 }

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
@@ -353,6 +353,12 @@ function fundraiser_sustainers_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'status' => array(
+        'description' => 'Gateway Status.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
       'created' => array(
         'description' => 'The timestamp when this donation series was created.',
         'type' => 'int',
@@ -1106,3 +1112,17 @@ function fundraiser_sustainers_update_7018(&$sandbox) {
   }
 }
 */
+
+/**
+ * Add the status field to the sustainers series entity.
+ */
+function fundraiser_sustainers_update_7018(&$sandbox) {
+  // Add the new column.
+  $status = array(
+    'description' => 'Gateway Status.',
+    'type' => 'varchar',
+    'length' => '255',
+    'not null' => FALSE,
+  );
+  db_add_field('fundraiser_sustainers_series', 'status', $status);
+}

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.install
@@ -1126,3 +1126,65 @@ function fundraiser_sustainers_update_7018(&$sandbox) {
   );
   db_add_field('fundraiser_sustainers_series', 'status', $status);
 }
+
+/**
+ * Update recurring status on finished series.
+ */
+function fundraiser_sustainers_update_7019(&$sandbox) {
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['max'] = db_query('SELECT COUNT(did) FROM {fundraiser_sustainers_series}')->fetchField();
+    $sandbox['current_did'] = 0;
+  }
+
+  $statuses = array(
+    'Expired' => array('payment_received', 'offline_check'),
+    'Canceled' => array('canceled', 'omitted'),
+    'Auto-canceled' => array('auto_canceled'),
+    'Failed' => array('failed', 'unknown'),
+  );
+
+  // Grab every series.
+  $series = db_query('
+    SELECT * FROM {fundraiser_sustainers_series}
+    WHERE did > :current
+    ORDER BY did ASC
+    LIMIT 25',
+    array(':current' => $sandbox['current_did'])
+  );
+
+  foreach ($series as $donation) {
+    // Check if the series is active.
+    $recur_remain = _fundraiser_sustainers_get_donations_recurr_remaining($donation->did);
+    // If not active, proceed with an update.
+    if (empty($recur_remain)) {
+
+      $last_donation = db_query(
+        'SELECT f.did, o.status FROM {fundraiser_sustainers} f
+        join commerce_order o on o.order_id = f.did
+        WHERE master_did = :master_did
+        ORDER BY next_charge
+        DESC LIMIT 0, 1',
+        array(':master_did' => $donation->did)
+      )->fetchObject();
+
+      $order_status = isset($last_donation->status) ? $last_donation->status : 'unknown';
+      foreach ($statuses as $key => $status_arr) {
+        if (in_array($order_status, $status_arr)) {
+          $status = $key;
+        }
+      }
+      $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $donation->did);
+      $fundraiser_sustainers_series->status = $status;
+      $fundraiser_sustainers_series->save();
+    }
+    $sandbox['progress']++;
+    $sandbox['current_did'] = $donation->did;
+  }
+
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+
+  if ($sandbox['#finished'] >= 1) {
+    return t('Expired fundraiser sustainers series have been updated with the status of their last donation.');
+  }
+}

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3909,6 +3909,15 @@ function fundraiser_sustainers_update_recurring_series_entity($master_did) {
       }
     }
 
+    // If the status is canceled, check if its auto_canceled.
+    if (
+      !empty($status)
+      && $status == 'canceled'
+      && $last_donation->recurring->gateway_resp == 'auto_canceled'
+    ) {
+      $status = 'auto_canceled';
+    }
+
     if (!empty($status)) {
       $fundraiser_sustainers_series->status = $status;
       $fundraiser_sustainers_series->save();

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3296,6 +3296,7 @@ function fundraiser_sustainers_fundraiser_donation_success($donation) {
           'did' => $donation->did,
           'uid' => $donation->uid,
           'amount' => $donation->donation['amount'],
+          'status' => 'active',
           'installments' => _fundraiser_sustainers_calculate_installments($donation),
         );
 
@@ -3862,12 +3863,61 @@ function _fundraiser_sustainers_update_recurring($donation) {
     _fundraiser_sustainers_create_recurring($donation);
   }
   else {
+
     // Merge data together so we get everything in the record.
     $record = array_merge((array) $original, $donation);
     drupal_write_record('fundraiser_sustainers', $record, 'did');
-
     $log = fundraiser_sustainers_log();
     $log->log($donation, $original);
+
+
+    // Update the fundraiser_sustainer_series status.
+    if (!empty($record['master_did'])) {
+      $status = NULL;
+
+      // Save the master did to a static var in case we're cycling through
+      // a set of donations (normal processing and cancellation of series),
+      // so that we don't repeatedly re-save the sustainers_series object.
+      static $mdid;
+
+      // Check if there are remaining recurring donations. If there are,
+      // we only want to update once, even if we're cycling through a cancelled
+      // series (if cancelled, we'll pick it up again later).
+      $recur_remain = _fundraiser_sustainers_get_donations_recurr_remaining($record['master_did']);
+      if (!empty($recur_remain)) {
+        if ($record['master_did'] != $mdid) {
+          $status = 'active';
+          $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $record['master_did']);
+          $fundraiser_sustainers_series->status = $status;
+          $fundraiser_sustainers_series->save();
+          $mdid = $record['master_did'];
+        }
+      }
+      else {
+        // We only get here if this is the last donation in a series.
+        $statuses = array(
+          // Series has no pending charges, status of final charge is "Payment Received".
+          'Expired' => array('payment_received', 'offline_check'),
+          // Series has no pending charges, status of final charge is "Canceled".
+          'Canceled' => array('canceled', 'omitted'),
+          // Series has no pending charges, status of final charge is "Auto-canceled".
+          'Auto-canceled' => array('auto_canceled'),
+          // Series has no pending charges, status of final charge is "Payment Failed".
+          'Failed' => array('failed', 'unknown'),
+        );
+
+        // Load the full donation object to get the status.
+        $full_donation = fundraiser_donation_get_donation($donation['did']);
+        foreach ($statuses as $key => $status_arr) {
+          if (in_array($full_donation->status, $status_arr)) {
+            $status = $key;
+          }
+        }
+        $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $record['master_did']);
+        $fundraiser_sustainers_series->status = $status;
+        $fundraiser_sustainers_series->save();
+      }
+    }
   }
 
   // Fire a hook so that other modules can respond to the update.

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3886,11 +3886,13 @@ function _fundraiser_sustainers_update_recurring($donation) {
       $recur_remain = _fundraiser_sustainers_get_donations_recurr_remaining($record['master_did']);
       if (!empty($recur_remain)) {
         if ($record['master_did'] != $mdid) {
-          $status = 'active';
           $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $record['master_did']);
-          $fundraiser_sustainers_series->status = $status;
-          $fundraiser_sustainers_series->save();
-          $mdid = $record['master_did'];
+          // Do we need to do this at all?
+          if ($fundraiser_sustainers_series->status != 'active') {
+            $fundraiser_sustainers_series->status = 'active';
+            $fundraiser_sustainers_series->save();
+            $mdid = $record['master_did'];
+          }
         }
       }
       else {

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3899,7 +3899,8 @@ function fundraiser_sustainers_update_recurring_series_entity($master_did) {
     $statuses = fundraiser_sustainers_series_entity_statuses();
 
     // Load the last donation object to get the final order status.
-    $last_charge = array_pop(_fundraiser_sustainers_get_donations_recurr_by_masterdid($master_did));
+    $all_recuring = _fundraiser_sustainers_get_donations_recurr_by_masterdid($master_did);
+    $last_charge = array_pop($all_recuring);
     $last_donation = fundraiser_donation_get_donation($last_charge->did, TRUE);
     foreach ($statuses as $key => $status_arr) {
       // Match the order status to the array of series entity statuse.

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3884,7 +3884,7 @@ function _fundraiser_sustainers_update_recurring($donation) {
       // we only want to update once, even if we're cycling through a cancelled
       // series (if cancelled, we'll pick it up again later).
       $recur_remain = _fundraiser_sustainers_get_donations_recurr_remaining($record['master_did']);
-      if (!empty($recur_remain)) {
+      if (!empty($recur_remain) && empty($record['cancellation_reason'])) {
         if ($record['master_did'] != $mdid) {
           $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $record['master_did']);
           // Do we need to do this at all?

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3853,6 +3853,7 @@ function _fundraiser_sustainers_get_recurring_by_did($did) {
 function _fundraiser_sustainers_update_recurring($donation) {
   // Cast donation just in case.
   $donation = (array) $donation;
+
   // Check old data.
   $original = FALSE;
   if (isset($donation['did'])) {
@@ -3869,61 +3870,74 @@ function _fundraiser_sustainers_update_recurring($donation) {
     drupal_write_record('fundraiser_sustainers', $record, 'did');
     $log = fundraiser_sustainers_log();
     $log->log($donation, $original);
+  }
 
-
-    // Update the fundraiser_sustainer_series status.
-    if (!empty($record['master_did'])) {
-      $status = NULL;
-
-      // Save the master did to a static var in case we're cycling through
-      // a set of donations (normal processing and cancellation of series),
-      // so that we don't repeatedly re-save the sustainers_series object.
-      static $mdid;
-
-      // Check if there are remaining recurring donations. If there are,
-      // we only want to update once, even if we're cycling through a cancelled
-      // series (if cancelled, we'll pick it up again later).
-      $recur_remain = _fundraiser_sustainers_get_donations_recurr_remaining($record['master_did']);
-      if (!empty($recur_remain)) {
-        if ($record['master_did'] != $mdid && empty($record['cancellation_reason'])) {
-          $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $record['master_did']);
-          // Do we need to do this at all?
-          if ($fundraiser_sustainers_series->status != 'active') {
-            $fundraiser_sustainers_series->status = 'active';
-            $fundraiser_sustainers_series->save();
-            $mdid = $record['master_did'];
-          }
-        }
-      }
-      else {
-        // We only get here if this is the last donation in a series.
-        $statuses = array(
-          // Series has no pending charges, status of final charge is "Payment Received".
-          'Expired' => array('payment_received', 'offline_check'),
-          // Series has no pending charges, status of final charge is "Canceled".
-          'Canceled' => array('canceled', 'omitted'),
-          // Series has no pending charges, status of final charge is "Auto-canceled".
-          'Auto-canceled' => array('auto_canceled'),
-          // Series has no pending charges, status of final charge is "Payment Failed".
-          'Failed' => array('failed', 'unknown'),
-        );
-
-        // Load the full donation object to get the status.
-        $full_donation = fundraiser_donation_get_donation($donation['did']);
-        foreach ($statuses as $key => $status_arr) {
-          if (in_array($full_donation->status, $status_arr)) {
-            $status = $key;
-          }
-        }
-        $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $record['master_did']);
-        $fundraiser_sustainers_series->status = $status;
-        $fundraiser_sustainers_series->save();
-      }
-    }
+  // Update the series entity.
+  if (!empty($record['master_did'])) {
+    fundraiser_sustainers_update_recurring_series_entity($record['master_did']);
   }
 
   // Fire a hook so that other modules can respond to the update.
   module_invoke_all('fundraiser_sustainers_update_recurring', $donation);
+}
+
+/**
+ * Update the status of the sustainer series entity.
+ *
+ * @param int $master_did
+ *   The id of the entity series to update.
+ */
+function fundraiser_sustainers_update_recurring_series_entity($master_did) {
+  // Check if there are remaining recurring donations.
+  $recur_remain = _fundraiser_sustainers_get_donations_recurr_remaining($master_did);
+  $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $master_did);
+
+  // Change the status if no remaining charges and the status is set to active.
+  if (
+    empty($recur_remain)
+    && $fundraiser_sustainers_series->status == 'active'
+  ) {
+    $statuses = fundraiser_sustainers_series_entity_statuses();
+
+    // Load the last donation object to get the final order status.
+    $last_charge = array_pop(_fundraiser_sustainers_get_donations_recurr_by_masterdid($master_did));
+    $last_donation = fundraiser_donation_get_donation($last_charge->did, TRUE);
+    foreach ($statuses as $key => $status_arr) {
+      // Match the order status to the array of series entity statuse.
+      if (in_array($last_donation->status, $status_arr)) {
+        $status = $key;
+      }
+    }
+
+    if (!empty($status)) {
+      $fundraiser_sustainers_series->status = $status;
+      $fundraiser_sustainers_series->save();
+    }
+  }
+}
+
+/**
+ * Returns an array of statuses for the sustainer series entity.
+ *
+ * The array is keyed by series status values and contains matching commerce
+ * order statuses.
+ *
+ * @return array
+ *   Array of status values.
+ */
+function fundraiser_sustainers_series_entity_statuses() {
+  return array(
+    // Active series with remaining sustainers.
+    'active' => array('pending_future_payment'),
+    // Series has no pending charges, status of final charge is "Payment Received".
+    'expired' => array('payment_received', 'offline_check'),
+    // Series has no pending charges, status of final charge is "Canceled".
+    'canceled' => array('canceled', 'omitted'),
+    // Series has no pending charges, status of final charge is "Auto-canceled".
+    'auto_canceled' => array('auto_canceled'),
+    // Series has no pending charges, status of final charge is "Payment Failed".
+    'failed' => array('failed', 'unknown'),
+  );
 }
 
 /**

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3853,7 +3853,6 @@ function _fundraiser_sustainers_get_recurring_by_did($did) {
 function _fundraiser_sustainers_update_recurring($donation) {
   // Cast donation just in case.
   $donation = (array) $donation;
-
   // Check old data.
   $original = FALSE;
   if (isset($donation['did'])) {

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3884,8 +3884,8 @@ function _fundraiser_sustainers_update_recurring($donation) {
       // we only want to update once, even if we're cycling through a cancelled
       // series (if cancelled, we'll pick it up again later).
       $recur_remain = _fundraiser_sustainers_get_donations_recurr_remaining($record['master_did']);
-      if (!empty($recur_remain) && empty($record['cancellation_reason'])) {
-        if ($record['master_did'] != $mdid) {
+      if (!empty($recur_remain)) {
+        if ($record['master_did'] != $mdid && empty($record['cancellation_reason'])) {
           $fundraiser_sustainers_series = entity_load_single('fundraiser_sustainers_series', $record['master_did']);
           // Do we need to do this at all?
           if ($fundraiser_sustainers_series->status != 'active') {

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -3404,6 +3404,9 @@ function fundraiser_sustainers_donation_retry($donation) {
  *   Standard fundraiser donation data structure.
  */
 function fundraiser_sustainers_donation_fail($donation) {
+  // Let others know the donation has failed.
+  fundraiser_donation_decline($donation);
+
   // Set the sustainer record up in a failed state.
   $recurring = array(
     'did' => $donation->did,
@@ -3415,9 +3418,6 @@ function fundraiser_sustainers_donation_fail($donation) {
   watchdog('fundraiser_sustainers', 'Payment for recurring donation @id has
     failed @count times. The donation will not be submitted for payment again. Gateway message: @message',
     array('@id' => $donation->did, '@count' => variable_get('fundraiser_sustainers_max_processing_attempts', 3), '@message' => $donation->result['message']), WATCHDOG_DEBUG);
-
-  // Let others know the donation has failed.
-  fundraiser_donation_decline($donation);
 
   // Fire a hook so that other modules can respond to the failure.
   module_invoke_all('fundraiser_sustainers_donation_fail', $donation);

--- a/fundraiser/modules/fundraiser_upsell/fundraiser_upsell.module
+++ b/fundraiser/modules/fundraiser_upsell/fundraiser_upsell.module
@@ -800,6 +800,7 @@ function fundraiser_upsell_create_recurring_series($donation) {
               'did' => $donation->did,
               'uid' => $donation->uid,
               'amount' => $donation->donation['amount'],
+              'status' => 'active',
               'installments' => _fundraiser_sustainers_calculate_installments($donation),
             );
 


### PR DESCRIPTION
Adds a "Status" field to the fundraiser recurring series entity which can be mapped and synced to custom field in .

New series get a status of 'active'. When the final active donation in a series is updated, the series status is updated to reflect the appropriate status based on the $donation->status value of the last recurring donation.