### PR TITLE
7.x 4.x 1713 unlock sustainers payment received

### DIFF
--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -4424,6 +4424,15 @@ function fundraiser_sustainers_action_info() {
       'triggers' => array('any'),
       'permissions' => array('administrate recurring donations'),
     ),
+    'fundraiser_sustainers_payment_received_action' => array(
+      'type' => 'fundraiser_sustainer_record',
+      'label' => t('Unlock sustainer and set status to payment received'),
+      'behavior' => array('changes_property'),
+      'configurable' => FALSE,
+      'vbo_configurable' => FALSE,
+      'triggers' => array('any'),
+      'permissions' => array('administrate recurring donations'),
+    ),
   );
 }
 
@@ -4518,6 +4527,53 @@ function fundraiser_sustainers_omit_sustainer_action(&$sustainer_record, $contex
       $sustainer_record->gateway_resp = FUNDRAISER_SUSTAINERS_OMITTED_STATUS;
       $log->logOmittedDonation($sustainer_record->did, $sustainer_record->gateway_resp);
       drupal_set_message(t('Omitted sustainer %did and left its status at %status', $replacements));
+      break;
+
+    case FUNDRAISER_SUSTAINERS_SUCCESS_STATUS:
+      // Fall through.
+    case FUNDRAISER_SUSTAINERS_FAILED_STATUS:
+      // Fall through.
+    case FUNDRAISER_SUSTAINERS_SKIPPED_STATUS:
+      // Fall through.
+    case FUNDRAISER_SUSTAINERS_CANCELED_STATUS:
+      // Fall through.
+    default:
+      drupal_set_message(t('Cannot unlock the sustainer %did because its status is %status', $replacements));
+      break;
+  }
+}
+
+/**
+ * The unlock sustainer action.
+ *
+ * Note that I'm including all gateway_resp cases in case this action gets used
+ * in other situations besides the stuck sustainer VBO.
+ *
+ * Also note that drupal saves the sustainer record entity on its own so that's
+ * why it's not happening here.
+ *
+ * @param Entity $sustainer_record
+ *   The fundraiser_sustainer_record entity.
+ */
+function fundraiser_sustainers_payment_received_action(&$sustainer_record, $context) {
+  $replacements = array(
+    '%did' => $sustainer_record->did,
+    '%status' => $sustainer_record->gateway_resp,
+  );
+
+  $log = fundraiser_sustainers_log();
+
+  switch ($sustainer_record->gateway_resp) {
+    case FUNDRAISER_SUSTAINERS_PROCESSING_STATUS:
+    case FUNDRAISER_SUSTAINERS_LOCKED_STATUS:
+    case FUNDRAISER_SUSTAINERS_RETRY_STATUS:
+    case FUNDRAISER_SUSTAINERS_SCHEDULED_STATUS:
+      $sustainer_record->lock_id = 0;
+      $sustainer_record->gateway_resp = FUNDRAISER_SUSTAINERS_SUCCESS_STATUS;
+      $donation = fundraiser_donation_get_donation($sustainer_record->did);
+      fundraiser_donation_success($donation);
+      $log->logUnlockedDonation($sustainer_record->did, $sustainer_record->gateway_resp);
+      drupal_set_message(t('Unlocked sustainer %did and changed its status from %status to Success.', $replacements));
       break;
 
     case FUNDRAISER_SUSTAINERS_SUCCESS_STATUS:

--- a/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
+++ b/fundraiser/modules/fundraiser_sustainers/fundraiser_sustainers.module
@@ -4571,6 +4571,7 @@ function fundraiser_sustainers_payment_received_action(&$sustainer_record, $cont
       $sustainer_record->lock_id = 0;
       $sustainer_record->gateway_resp = FUNDRAISER_SUSTAINERS_SUCCESS_STATUS;
       $donation = fundraiser_donation_get_donation($sustainer_record->did);
+      $donation->batch_operation = 'fundraiser_sustainers_payment_received_action';
       fundraiser_donation_success($donation);
       $log->logUnlockedDonation($sustainer_record->did, $sustainer_record->gateway_resp);
       drupal_set_message(t('Unlocked sustainer %did and changed its status from %status to Success.', $replacements));

--- a/fundraiser/modules/fundraiser_sustainers/includes/fundraiser_sustainers.views_default.inc
+++ b/fundraiser/modules/fundraiser_sustainers/includes/fundraiser_sustainers.views_default.inc
@@ -391,7 +391,7 @@ function fundraiser_sustainers_views_default_views() {
 
   /* Display: Master */
   $handler = $view->new_display('default', 'Master', 'default');
-  $handler->display->display_options['title'] = 'Locked but not processed sustainers';
+  $handler->display->display_options['title'] = 'Locked sustainers';
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'perm';
   $handler->display->display_options['access']['perm'] = 'administrate recurring donations';
@@ -495,9 +495,17 @@ function fundraiser_sustainers_views_default_views() {
   $handler->display->display_options['fields']['views_bulk_operations']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['display_type'] = '0';
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['enable_select_all_pages'] = 1;
+  $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['row_clickable'] = 1;
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['force_single'] = 0;
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['entity_load_capacity'] = '10';
   $handler->display->display_options['fields']['views_bulk_operations']['vbo_operations'] = array(
+    'action::fundraiser_sustainers_omit_sustainer_action' => array(
+      'selected' => 1,
+      'postpone_processing' => 0,
+      'skip_confirmation' => 0,
+      'override_label' => 0,
+      'label' => '',
+    ),
     'action::fundraiser_sustainers_unlock_sustainer_action' => array(
       'selected' => 1,
       'postpone_processing' => 0,
@@ -505,7 +513,7 @@ function fundraiser_sustainers_views_default_views() {
       'override_label' => 0,
       'label' => '',
     ),
-    'action::fundraiser_sustainers_omit_sustainer_action' => array(
+    'action::fundraiser_sustainers_payment_received_action' => array(
       'selected' => 1,
       'postpone_processing' => 0,
       'skip_confirmation' => 0,


### PR DESCRIPTION
Adds a batch operation to set a donation to payment received.
Adds a batch_operation flag on the donation object prior to calling fundraiser_donation_success() when the batch operation is used.