### PR TITLE
make marketing and integration menu access alterable

### DIFF
--- a/springboard/modules/springboard_admin/springboard_admin.module
+++ b/springboard/modules/springboard_admin/springboard_admin.module
@@ -559,6 +559,12 @@ function springboard_admin_access_marketing_overview() {
   ) {
     return TRUE;
   }
+
+  $access = module_invoke_all('springboard_admin_access_marketing_overview');
+  if (!empty(array_filter($access))) {
+    return TRUE;
+  }
+
   return FALSE;
 }
 
@@ -578,6 +584,12 @@ function springboard_admin_access_integration_overview() {
   ) {
     return TRUE;
   }
+
+  $access = module_invoke_all('springboard_admin_access_integration_overview');
+  if (!empty(array_filter($access))) {
+    return TRUE;
+  }
+
   return FALSE;
 }
 


### PR DESCRIPTION
This adds the ability for other modules to alter the access to the marketing and reports menu items.

I didn't think  we need this need this for the ACLU groups integration, but you never know what others might want.