### PR TITLE
1866 dw skipped records

### DIFF
--- a/springboard_dw/modules/springboard_dw_queue_legacy/springboard_dw_queue_legacy.drush.inc
+++ b/springboard_dw/modules/springboard_dw_queue_legacy/springboard_dw_queue_legacy.drush.inc
@@ -626,7 +626,7 @@ function springboard_dw_queue_legacy_get_records($type, $limit = FALSE, $highwat
       $query = db_select('users', 'u', array('target' => 'slave'));
       $query->addField('u', 'uid', 'id');
       $query->addField('u', 'created', 'created');
-      $query->orderBy('created', 'ASC');
+      $query->orderBy('uid', 'ASC');
       $query->condition('uid', 0, '<>');
       if ($idlist) {
         $query->condition('uid', $idlist, 'IN');
@@ -641,7 +641,7 @@ function springboard_dw_queue_legacy_get_records($type, $limit = FALSE, $highwat
       $query->addField('f', 'did', 'id');
       $query->addField('f', 'nid');
       $query->addField('f', 'created');
-      $query->orderBy('created', 'ASC');
+      $query->orderBy('did', 'ASC');
       if ($idlist) {
         $query->condition('did', $idlist, 'IN');
       }
@@ -660,7 +660,7 @@ function springboard_dw_queue_legacy_get_records($type, $limit = FALSE, $highwat
       $query->addField('n', 'type');
       $query->join('node', 'n', 's.nid = n.nid');
       $query->condition('n.type', array('sba_message_action', 'sba_social_action', 'springboard_petition'), 'IN');
-      $query->orderBy('submitted', 'ASC');
+      $query->orderBy('sid', 'ASC');
       if ($idlist) {
         $query->condition('sid', $idlist, 'IN');
       }
@@ -681,7 +681,7 @@ function springboard_dw_queue_legacy_get_records($type, $limit = FALSE, $highwat
       $query->addField('s', 'submitted', 'created');
       $query->join('node', 'n', 's.nid = n.nid');
       $query->condition('n.type', 'springboard_petition', '=');
-      $query->orderBy('submitted', 'ASC');
+      $query->orderBy('sid', 'ASC');
       if ($idlist) {
         $query->condition('sid', $idlist, 'IN');
       }
@@ -694,7 +694,7 @@ function springboard_dw_queue_legacy_get_records($type, $limit = FALSE, $highwat
       $query = db_select('node', 'n', array('target' => 'slave'));
       $query->addField('n', 'nid', 'id');
       $query->addField('n', 'created');
-      $query->orderBy('created', 'ASC');
+      $query->orderBy('n.nid', 'ASC');
       $query->join('webform', 'w', 'n.nid = w.nid');
       if ($idlist) {
         $query->condition('n.nid', $idlist, 'IN');
@@ -717,7 +717,7 @@ function springboard_dw_queue_legacy_get_records($type, $limit = FALSE, $highwat
       $query->addField('s', 'submitted', 'created');
       $query->join('node', 'n', 's.nid = n.nid');
       $query->condition('n.type', $excluded_types, 'NOT IN');
-      $query->orderBy('submitted', 'ASC');
+      $query->orderBy('sid', 'ASC');
       if ($idlist) {
         $query->condition('sid', $idlist, 'IN');
       }
@@ -741,7 +741,7 @@ function springboard_dw_queue_legacy_get_records($type, $limit = FALSE, $highwat
       $query->addField('c', 'remote_status');
       $query->addField('c', 'created');
       $query->addField('c', 'changed');
-      $query->orderBy('created', 'ASC');
+      $query->orderBy('transaction_id', 'ASC');
       if ($idlist) {
         $query->condition('transaction_id', $idlist, 'IN');
       }

--- a/springboard_dw/modules/springboard_dw_queue_legacy/springboard_dw_queue_legacy.install
+++ b/springboard_dw/modules/springboard_dw_queue_legacy/springboard_dw_queue_legacy.install
@@ -42,7 +42,7 @@ function springboard_dw_queue_legacy_uninstall() {
  */
 function springboard_dw_queue_legacy_schema() {
   $schema['springboard_data_warehouse_queue_legacy'] = array(
-    'description' => 'Record highwater timestamps so each queueing command can pick up where they left off',
+    'description' => 'Record the last processed record so each queueing command can pick up where they left off',
     'fields' => array(
       'id' => array(
         'description' => 'Primary key',
@@ -58,7 +58,7 @@ function springboard_dw_queue_legacy_schema() {
         'default' => '',
       ),
       'highwater' => array(
-        'description' => 'Timestamp of last queued item',
+        'description' => 'Id of last queued item',
         'type' => 'int',
         'not null' => TRUE,
       ),

--- a/springboard_dw/modules/springboard_dw_queue_legacy/springboard_dw_queue_legacy.module
+++ b/springboard_dw/modules/springboard_dw_queue_legacy/springboard_dw_queue_legacy.module
@@ -213,21 +213,20 @@ function springboard_dw_queue_legacy_get_highwater_mark($type) {
  *
  * @param string $type
  *   Type of queue record to create. eg contact, petition, message action, etc.
- * @param int $timestamp
- *   of seconds since the Unix Epoch.
- *   Number of seconds since the Unix Epoch.
- *  @param  mixed $idlist
+ * @param int $highwater_id
+ *   The id of the most recently processed record.
+ * @param mixed $idlist
  *   False or array if IDs that are being specifically queued.
  *
  * @return mixed
  *   FALSE on error. Otherwise, SAVED_NEW or SAVED_UPDATED.
  */
-function springboard_dw_queue_legacy_set_highwater_mark($type, $timestamp, $idlist = FALSE) {
+function springboard_dw_queue_legacy_set_highwater_mark($type, $highwater_id, $idlist = FALSE) {
   // If we are working with a specific set of IDs, don't move highwater mark.
   if ($idlist) {
     return;
   }
-  $record = array('type' => $type, 'highwater' => $timestamp);
+  $record = array('type' => $type, 'highwater' => $highwater_id);
   return drupal_write_record('springboard_data_warehouse_queue_legacy', $record, 'type');
 }
 


### PR DESCRIPTION
Some records don't have created timestamps, so sorting queries by that field is problematic. This can cause records to get skipped when queuing them up for the DW. 

Sort by  ID instead.